### PR TITLE
updates to document search

### DIFF
--- a/api/app/resources/document_analysis.py
+++ b/api/app/resources/document_analysis.py
@@ -73,6 +73,8 @@ class DocumentAnalysis(Resource):
                 ({"message": "{analysis} is not a valid analysis".format(analysis=analysis)}), 404
 
         json_input = request.get_json()
+        if not json_input:
+            return jsonify({'message': 'No JSON data provided'}), 400
 
         err = DocumentSchema().validate(json_input)
         if err:

--- a/api/tests/postman/namex-common.postman_collection.json
+++ b/api/tests/postman/namex-common.postman_collection.json
@@ -529,6 +529,270 @@
 			]
 		},
 		{
+			"name": "analysis document",
+			"description": "",
+			"item": [
+				{
+					"name": "conflicts",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "75b64372-8d70-4773-9e21-5d72f5cfba27",
+								"type": "text/javascript",
+								"exec": [
+									"eval(environment.auth_script);"
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "4b2f1d65-e3df-4748-bb48-fbccfdf31ebd",
+								"type": "text/javascript",
+								"exec": [
+									"eval(globals.postmanBDD);",
+									"",
+									"it('should be an success response', () => {",
+									"    response.ok.should.be.true;            // 2XX",
+									"    response.error.should.be.false;          // 4XX or 5XX",
+									"    response.clientError.should.be.false;    // 4XX",
+									"    response.serverError.should.be.false;   // 5XX",
+									"    response.should.have.status(200);",
+									"    response.statusType.should.equal(2);",
+									"});",
+									"",
+									"it('should return JSON', () => {",
+									"    response.should.be.json;",
+									"    response.should.have.header('Content-Type', 'application/json');",
+									"    response.type.should.equal('application/json');",
+									"});",
+									"",
+									"it('should contain the un-parsed JSON text', () => {",
+									"    response.text.should.be.a('string').with.length.above(10);",
+									"});",
+									"",
+									"it('should contain the parsed JSON keys', () => {",
+									"    response.body.should.be.an('object').with.keys(['highlighting', 'names', 'response']);",
+									"});",
+									"",
+									"it('should match against a JSON Schema', () => {",
+									"    // For more information about JSON Schema, see https://spacetelescope.github.io/understanding-json-schema/basics.html",
+									"    response.body.should.have.schema({",
+									"        type: 'object',",
+									"        required: ['names', 'highlighting', 'response']",
+									"    });",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": \"plain_text\",\n  \"content\": \"garden shop\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/documents:conflicts",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"documents:conflicts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "histories",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "75b64372-8d70-4773-9e21-5d72f5cfba27",
+								"type": "text/javascript",
+								"exec": [
+									"eval(environment.auth_script);"
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "1002b5c6-9f49-49e9-8884-0e72466e7481",
+								"type": "text/javascript",
+								"exec": [
+									"eval(globals.postmanBDD);",
+									"",
+									"it('should be an success response', () => {",
+									"    response.ok.should.be.true;            // 2XX",
+									"    response.error.should.be.false;          // 4XX or 5XX",
+									"    response.clientError.should.be.false;    // 4XX",
+									"    response.serverError.should.be.false;   // 5XX",
+									"    response.should.have.status(200);",
+									"    response.statusType.should.equal(2);",
+									"});",
+									"",
+									"it('should return JSON', () => {",
+									"    response.should.be.json;",
+									"    response.should.have.header('Content-Type', 'application/json');",
+									"    response.type.should.equal('application/json');",
+									"});",
+									"",
+									"it('should contain the un-parsed JSON text', () => {",
+									"    response.text.should.be.a('string').with.length.above(10);",
+									"});",
+									"",
+									"it('should contain the parsed JSON keys', () => {",
+									"    response.body.should.be.an('object').with.keys(['highlighting', 'names', 'response']);",
+									"});",
+									"",
+									"it('should match against a JSON Schema', () => {",
+									"    // For more information about JSON Schema, see https://spacetelescope.github.io/understanding-json-schema/basics.html",
+									"    response.body.should.have.schema({",
+									"        type: 'object',",
+									"        required: ['names', 'highlighting', 'response']",
+									"    });",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": \"plain_text\",\n  \"content\": \"garden shop\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/documents:histories",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"documents:histories"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "trademarks",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "75b64372-8d70-4773-9e21-5d72f5cfba27",
+								"type": "text/javascript",
+								"exec": [
+									"eval(environment.auth_script);"
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "cf6fa36e-812c-4b39-a907-0dd59d99d5cf",
+								"type": "text/javascript",
+								"exec": [
+									"eval(globals.postmanBDD);",
+									"",
+									"it('should be an success response', () => {",
+									"    response.ok.should.be.true;            // 2XX",
+									"    response.error.should.be.false;          // 4XX or 5XX",
+									"    response.clientError.should.be.false;    // 4XX",
+									"    response.serverError.should.be.false;   // 5XX",
+									"    response.should.have.status(200);",
+									"    response.statusType.should.equal(2);",
+									"});",
+									"",
+									"it('should return JSON', () => {",
+									"    response.should.be.json;",
+									"    response.should.have.header('Content-Type', 'application/json');",
+									"    response.type.should.equal('application/json');",
+									"});",
+									"",
+									"it('should contain the un-parsed JSON text', () => {",
+									"    response.text.should.be.a('string').with.length.above(10);",
+									"});",
+									"",
+									"it('should contain the parsed JSON keys', () => {",
+									"    response.body.should.be.an('object').with.keys(['highlighting', 'names', 'response']);",
+									"});",
+									"",
+									"it('should match against a JSON Schema', () => {",
+									"    // For more information about JSON Schema, see https://spacetelescope.github.io/understanding-json-schema/basics.html",
+									"    response.body.should.have.schema({",
+									"        type: 'object',",
+									"        required: ['names', 'highlighting', 'response']",
+									"    });",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": \"plain_text\",\n  \"content\": \"garden shop\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/documents:trademarks",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"documents:trademarks"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "authenticate",
 			"description": "",
 			"item": [


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#549

*Description of changes:*
Exposed the Solr queries under request analysis as generic text search.
The URL pattern is based on the Google Document Analysis API, which is similar to the Microsoft Azure Documents API. This should be familiar then to other developers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
