### PR TITLE
bcgov/name-examination#560 Make Alembic ignore existing db tables when creating migrations

### DIFF
--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -65,6 +65,12 @@ def run_migrations_online():
                 directives[:] = []
                 logger.info('No changes in schema detected.')
 
+    def include_object(object, name, type_, reflected, compare_to):
+        if (type_ == "table" and reflected):
+            return False
+        else:
+            return True
+
     engine = engine_from_config(config.get_section(config.config_ini_section),
                                 prefix='sqlalchemy.',
                                 poolclass=pool.NullPool)
@@ -72,6 +78,7 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(connection=connection,
                       target_metadata=target_metadata,
+                      include_object=include_object,
                       process_revision_directives=process_revision_directives,
                       **current_app.extensions['migrate'].configure_args)
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,8 +1,11 @@
-<aside class="notice">
-Current settings in the api module are set to ignore tables that are not backed by a model.
-
-You have been warned.
-</aside>
+<table>
+    <tr>
+        <td bgcolor="#00FFFF">
+<p>Current settings in the api module are set to ignore tables that are not backed by a model.</p>
+<p>You have been warned.</p>
+		</td>
+    </tr>
+</table>
 
 ## Managing database fixtures
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,3 +1,9 @@
+<aside class="notice">
+Current settings in the api module are set to ignore tables that are not backed by a model.
+
+You have been warned.
+</aside>
+
 ## Managing database fixtures
 
 Alembic, via Flask-Migrate is used to manage our database. Changes to the models are put into a revision history.


### PR DESCRIPTION
*Issue #, if available:* #bcgov/name-examination560

*Description of changes:* Altered Alembic ENV to ignore tables not managed by the model. Updated the global DB docs with a note to reflect that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
