### PR TITLE
Update Solr API to handle apostrophes in search terms #628

### DIFF
--- a/api/app/resources/document_analysis.py
+++ b/api/app/resources/document_analysis.py
@@ -1,4 +1,4 @@
-from flask import request, jsonify, current_app, escape
+from flask import request, jsonify, current_app
 from flask_restplus import Namespace, Resource, cors, fields as rp_fields
 from marshmallow import Schema, validates, ValidationError, fields as ma_fields
 from app import oidc
@@ -79,7 +79,7 @@ class DocumentAnalysis(Resource):
         if err:
             return jsonify(err), 400
 
-        content = escape(json_input['content'])
+        content = json_input['content']
 
         if analysis in RestrictedWords.RESTRICTED_WORDS:
             results, msg, code = RestrictedWords.get_restricted_words_conditions(content)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/name-examination/issues/628

*Description of changes:* Removed the escaping of the query string on input, as it was being escaped twice. This was causing words containing apostrophes to basically be excluded as search terms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
