### PR TITLE
Use jwt library from PyPi

### DIFF
--- a/api/requirements/prod.NoVer.txt
+++ b/api/requirements/prod.NoVer.txt
@@ -7,7 +7,7 @@ Flask-Moment
 Flask-SQLAlchemy
 Flask-RESTplus
 Flask-Marshmallow
-git+https://github.com/thorwolpert/flask-jwt-oidc.git
+flask-jwt-oidc
 
 python-dotenv
 psycopg2-binary

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -7,7 +7,8 @@ Flask-Moment
 Flask-SQLAlchemy
 Flask-RESTplus
 Flask-Marshmallow
-git+https://github.com/thorwolpert/flask-jwt-oidc.git
+#git+https://github.com/thorwolpert/flask-jwt-oidc.git
+flask-jwt-oidc
 
 python-dotenv
 psycopg2-binary


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Moved namex to use the JWT library from PyPi


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
