### PR TITLE
bug fix: Removed expirationDate from PUT

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -215,7 +215,6 @@ class RequestsHeaderSchema(ma.ModelSchema):
         # additional = ['stateCd']
         fields = ('requestTypeCd'
                  ,'priorityCd'
-                 ,'expirationDate'
                  ,'consentFlag'
                  ,'additionalInfo'
                  ,'natureBusinessInfo'


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Removed expirationDate from PUT, because a) we're not converting it from string to timestamp, so it's failing validation, and b) we don't actually let user edit it so it doesn't matter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
