### PR TITLE
Changed automatic time entries from UTCNOW to simply NOW for PST/PDT.

### DIFF
--- a/api/namex/models/comment.py
+++ b/api/namex/models/comment.py
@@ -9,7 +9,7 @@ class Comment(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     comment = db.Column(db.String(4096))
-    timestamp = db.Column('timestamp', db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column('timestamp', db.DateTime, default=datetime.now)
 
     # parent keys
     nrId = db.Column('nr_id', db.Integer, db.ForeignKey('requests.id'))

--- a/api/namex/models/event.py
+++ b/api/namex/models/event.py
@@ -14,7 +14,7 @@ class Event(db.Model):
     __tablename__ = 'events'
 
     id = db.Column(db.Integer, primary_key=True)
-    eventDate = db.Column('event_dt', db.DateTime, default=datetime.utcnow)
+    eventDate = db.Column('event_dt', db.DateTime, default=datetime.now)
     action = db.Column(db.String(1000))
     jsonZip = db.Column('json_zip', db.LargeBinary)
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -25,8 +25,8 @@ class Request(db.Model):
 
     # core fields
     id = db.Column(db.Integer, primary_key=True)
-    submittedDate = db.Column('submitted_date', db.DateTime, default=datetime.utcnow)
-    lastUpdate = db.Column('last_update', db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    submittedDate = db.Column('submitted_date', db.DateTime, default=datetime.now)
+    lastUpdate = db.Column('last_update', db.DateTime, default=datetime.now, onupdate=datetime.now)
 
     nrNum = db.Column('nr_num', db.String(10), unique=True)
     requestTypeCd = db.Column('request_type_cd', db.String(10))

--- a/api/namex/models/user.py
+++ b/api/namex/models/user.py
@@ -12,7 +12,7 @@ class User(db.Model):
     lastname = db.Column(db.String(1000))
     sub = db.Column(db.String(36), unique=True)
     iss = db.Column(db.String(1024))
-    creationDate = db.Column(db.DateTime, default=datetime.utcnow)
+    creationDate = db.Column(db.DateTime, default=datetime.now)
 
     APPROVER='names_approver'
     EDITOR='names_editor'


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Changed automatic time entries from UTCNOW to NOW - for PST/PDT instead of GMT.

This solves a few problems we have re. times being 8 hours ahead of actual local time, ie: we are storing UTC time (aka GMT, aka London time 8 hours ahead) in a timezone-less datetime field. 

Additionally this becomes a problem with the NRO Sync script, which looks for records recently updated (within the past 10 minutes). However any new updates in the database are 8 hours in the future, so it will take 8 hours (plus 10 minutes) before they can be picked up by the script. This change fixes that issue as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
