### PR TITLE
User fix

### DIFF
--- a/api/namex/models/user.py
+++ b/api/namex/models/user.py
@@ -41,7 +41,8 @@ class User(db.Model):
             # s = KeycloakUserSchema()
             # u = s.load(data=token, partial=True)
             user = User(
-                username = token.get('username', None),
+                # username = token.get('username', None),
+                username = token.get('preferred_username', None),
                 firstname = token.get('given_name', None),
                 lastname = token.get('family_name', None),
                 iss = token['iss'],

--- a/api/namex/models/user.py
+++ b/api/namex/models/user.py
@@ -1,4 +1,5 @@
 from . import db, ma
+from flask import current_app
 from marshmallow import Schema, fields, post_load
 from datetime import datetime
 
@@ -46,6 +47,7 @@ class User(db.Model):
                 iss = token['iss'],
                 sub = token['sub']
             )
+            current_app.logger.debug('Creating user from JWT:{}; User:{}'.format(token, user))
             db.session.add(user)
             db.session.commit()
             return user

--- a/api/namex/services/name_request/__init__.py
+++ b/api/namex/services/name_request/__init__.py
@@ -44,7 +44,7 @@ def valid_state_transition(user, nr, new_state):
         return False
 
     # NR is in a final state, but maybe the user wants to pull it back for corrections
-    if nrd.stateCd in State.COMPLETED_STATE:
+    if nr.stateCd in State.COMPLETED_STATE:
         if not jwt.validate_roles([User.APPROVER]):
             return False
             # return jsonify({"message": "Only Names Examiners can alter completed Requests"}), 401

--- a/api/namex/services/name_request/__init__.py
+++ b/api/namex/services/name_request/__init__.py
@@ -16,7 +16,7 @@ def get_or_create_user_by_jwt(jwt_oidc_token):
         user = User.find_by_jwtToken(jwt_oidc_token)
         current_app.logger.debug('finding user: {}'.format(jwt_oidc_token))
         if not user:
-            current_app.logger.debug('didnt find user, attempting to create new user from the JWT info')
+            current_app.logger.debug('didnt find user, attempting to create new user from the JWT info:{}'.format(jwt_oidc_token))
             user = User.create_from_jwtToken(jwt_oidc_token)
 
         return user


### PR DESCRIPTION
*Issue #, if available:*  bcgov/name-examination#736 bcgov/name-examination#737

*Description of changes:*
work on bcgov/name-examination#736 bcgov/name-examination#737

There was a change in the keycloak map, username -> preferred_username.
Updating the User.create_from_jwtToken method to use the 'preferred_username'

update PUT to use the same calls for security and segments as Patch
not in this go-round, but the goal is that Put & Patch are almost identical, with marshmallow set to partial updates only in Patch, and maybe difference's in edit approval.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
