### PR TITLE
bcgov/name-examination#739

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -361,7 +361,7 @@ class Request(Resource):
             return jsonify(message='Internal server error'), 500
 
         if 'warnings' in locals() and warnings:
-            return jsonify(message='Request:{} - patched'.format(nr), warnings=warnings), 200
+            return jsonify(message='Request:{} - patched'.format(nr), warnings=warnings), 206
         return jsonify(message='Request:{} - patched'.format(nr)), 200
 
     @staticmethod
@@ -575,10 +575,11 @@ class Request(Resource):
             current_app.logger.error("Error when replacing NR:{0} Err:{1}".format(nr, err))
             return jsonify(message='NR had an internal error'), 500
 
+        # if we're here, messaging only contains warnings
         warning_and_errors = MessageServices.get_all_messages()
         if warning_and_errors:
             current_app.logger.debug(nrd.json(), warning_and_errors)
-            return jsonify(nameRequest=nrd.json(), warnings=warning_and_errors), 200
+            return jsonify(nameRequest=nrd.json(), warnings=warning_and_errors), 206
 
         current_app.logger.debug(nrd.json())
         return jsonify(nrd.json()), 200


### PR DESCRIPTION
In the distributed system there are times that some of the remote services will fail, but the business flow can continue. In those cases we still return or process the object, but provide the back-office users warning messages. To make it easier for the clients to process, we will change that return from a 200 to a 206 to indicate that there are warnings that may require alternate business processes.

Change return of Requests-PUT/PATCH when a warning exists to a 206

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
