### PR TITLE
created a schema just to be used by request search

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -67,8 +67,6 @@ class Request(db.Model):
     ##### end of table definitions
     REQUEST_FURNISHED = 'Y'
 
-
-
     def __init__(self, *args, **kwargs):
         pass
 

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -224,19 +224,6 @@ class Requests(Resource):
         q = q.offset(start)
         q = q.limit(rows)
 
-        results = q.all()
-
-        for r in results:
-            print(r.__dict__, file=sys.stderr)
-
-        # result_set = Requests.search_request_schemas.dump(results)
-        result_set = request_search_schemas.dump(results)
-        current_app.logger.debug(result_set)
-        if not result_set:
-            resp = None
-        else:
-            resp= result_set.data
-
         # create the response
         rep = {'response':{'start':start,
                            'rows': rows,
@@ -246,25 +233,25 @@ class Requests(Resource):
                            'queue': queue,
                            'order': order_list
                            },
-               'nameRequests': resp
+               'nameRequests': request_search_schemas.dump(q.all())
                }
 
         ## counts for updatedToday and priorities
-        data = rep['nameRequests']
-        for row in data:
-            try:
-                if row['priorityCd'] == 'Y':
-                    rep['response']['numPriorities'] += 1
-            except KeyError or AttributeError:
-                pass
-
-        today = str(datetime.datetime.now)[0:10]
-        for row in data:
-            try:
-                if row['lastUpdate'][0:10] == today:
-                    rep['response']['numUpdatedToday'] += 1
-            except KeyError or AttributeError:
-                pass
+        # data = rep['nameRequests']
+        # for row in data:
+        #     try:
+        #         if row['priorityCd'] == 'Y':
+        #             rep['response']['numPriorities'] += 1
+        #     except KeyError or AttributeError:
+        #         pass
+        #
+        # today = str(datetime.datetime.now)[0:10]
+        # for row in data:
+        #     try:
+        #         if row['lastUpdate'][0:10] == today:
+        #             rep['response']['numUpdatedToday'] += 1
+        #     except KeyError or AttributeError:
+        #         pass
 
         return jsonify(rep), 200
 


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#741
request search erroring in dev, but not locally or in test

*Description of changes:*
Created new schema just to be used by search.
There were some lookup segments that were erroring out as they had no schema. Not sure why this wouldn't error out in all environments, but this fix should cover all deployments.

Also removed comments from the return set, as they can get large.
Also remove the running completed and priority totals (commented out) as they logically do not work. Do we really need them here? If so then they should be done as DB queries, not sums across the return sets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
