### PR TITLE
adding EventRecorder service back into the API

### DIFF
--- a/api/namex/models/event.py
+++ b/api/namex/models/event.py
@@ -26,9 +26,16 @@ class Event(db.Model):
     userId = db.Column('user_id', db.Integer, db.ForeignKey('users.id'))
     user = db.relationship('User', backref=backref('user_events', uselist=False), foreign_keys=[userId])
 
-    def __init__(self, action, jsonData):
-        self.action = action
-        self.jsonZip = bz2.compress(jsonData)
+    GET = 'get'
+    PUT='put'
+    PATCH='patch'
+    POST='post'
+    DELETE='DELETE'
+
+    VALID_ACTIONS=[GET, PUT, PATCH, POST, DELETE]
+
+    def __init__(self):
+        pass # use the fields listed to set the values
 
     def json(self):
         return {"eventDate": self.eventDate, "action": self.action, "jsonData": bz2.decompress(self.jsonZip),

--- a/api/namex/services/__init__.py
+++ b/api/namex/services/__init__.py
@@ -1,2 +1,3 @@
 from .exceptions import ServicesError
 from .messages import MessageServices
+from .audit_trail import EventRecorder

--- a/api/namex/services/audit_trail/__init__.py
+++ b/api/namex/services/audit_trail/__init__.py
@@ -1,0 +1,1 @@
+from .event_recorder import EventRecorder

--- a/api/namex/services/audit_trail/event_recorder.py
+++ b/api/namex/services/audit_trail/event_recorder.py
@@ -1,0 +1,25 @@
+from flask import current_app
+from namex import models
+import datetime
+import bz2
+
+
+class EventRecorder(object):
+
+    @staticmethod
+    def record(user, action, nr, json):
+
+        event = models.Event(
+            eventDate = datetime.utcnow,
+            action = action,
+            jsonZip = bz2.compress(json),
+            nrId = nr.id,
+            stateCd = nr.stateCd,
+            userId = user.id
+        )
+        try:
+            event.save_to_db()
+        except Exception as err:
+            current_app.logger.error('AUDIT BROKEN: change was - NRNUM: {}, ACTION: {}, USER {}, JSON{}'
+                                     .format(nr.nr_num, action, user.username, json)
+                                    )


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#751

*Description of changes:*
adding EventRecorder service back into the API to record what was changed and by whom.

The service will add an Event to the system, so easier to track fields of Datetime, User, Request, State and the json input that modified the record.

Not sure if the NRO Extractor should use this, but it might be a good idea to do so, as that would sort of give us a reverse delta history if you wanted to run/view changes to see what the Request looked like at a point in time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
