### PR TITLE
Bug fixes - NRO Updater and NRO Services in API

### DIFF
--- a/api/namex/services/nro/oracle_services.py
+++ b/api/namex/services/nro/oracle_services.py
@@ -167,7 +167,7 @@ class NROServices(object):
                             'H',               # p_status
                             '',               # p_expiry_date - mandatory, but ignored by the proc
                             '',               # p_consent_flag- mandatory, but ignored by the proc
-                            examiner_username, # p_examiner_id
+                            examiner_username[:7], # p_examiner_id
                             ]
 
                 # Call the name_examination procedure to save complete decision data for a single NR

--- a/nro-update/nro/nro_datapump.py
+++ b/nro-update/nro/nro_datapump.py
@@ -23,8 +23,8 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
             names[choice]['state'] = 'NE'
 
         decision_text = ''
-        if name.state in [Name.APPROVED, name.CONDITION]:
-            names[choice]['decision'] = '{}****{}'.format(name.state, name.decision_text[:1000])
+        if name.state in [Name.APPROVED, Name.CONDITION, Name.REJECTED]:
+            names[choice]['decision'] = '{}****{}'.format(names[choice]['state'], name.decision_text[:1000])
 
         if name.conflict1:
             names[choice]['conflict1'] = '{}****{}'.format(name.conflict1_num[:10], name.conflict1[:150])

--- a/nro-update/nro_update.py
+++ b/nro-update/nro_update.py
@@ -70,8 +70,8 @@ try:
     ora_cursor = ora_con.cursor()
 
     reqs = db.session.query(Request).\
-                filter(Request.stateCd.in_([State.APPROVED, State.REJECTED])).\
-                filter(Request.furnished is not 'Y'). \
+                filter(Request.stateCd.in_([State.APPROVED, State.REJECTED, State.CONDITIONAL])).\
+                filter(Request.furnished != 'Y'). \
         filter(Request.lastUpdate < datetime.utcnow()-timedelta(seconds=delay)). \
         order_by(Request.lastUpdate.asc()). \
         limit(max_rows). \


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Bug fixes:
- NRO Updater:
-- set decision text for rejected names (was missing check for rejected)
-- pick up CONDITIONAL request types in NRO Update (was missing check
for conditional)
-- condition on Furnished flag correctly (python style "is not "Y" not
working in SQL statement)
- NRO Services in API:
-- substring username to 7 chars to match TRANSACTION.BCOL_RACF_ID table
used by name_examination() proc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
