### PR TITLE
Allow embedded spaces in Solr synonyms. #774

### DIFF
--- a/solr-admin-app/docs/readme.md
+++ b/solr-admin-app/docs/readme.md
@@ -38,6 +38,10 @@ redirect URI "http://localhost:8080/oidc_callback" for desktop development.
 * Export of synonym_audit loses date and time information
 * Move the solr core names to somewhere easily configurable
 * Add error reporting for Solr core reloading
+* Don't reload solr cores if only the category or comment change
+* Edit page should use a text area for large varchar strings
+* If you're on page 2 when less than 100 items, switch to 1000 per page fails
+* SynonymView has commented out code for embedded spaces - remove if not needed
 
 #### DONE:
 * Better duplicate error message

--- a/solr-admin-app/model/user.py
+++ b/solr-admin-app/model/user.py
@@ -1,5 +1,0 @@
-from flask_login import UserMixin
-
-
-class User(UserMixin):
-    pass

--- a/solr-admin-app/solr_admin/views/synonym_view.py
+++ b/solr-admin-app/solr_admin/views/synonym_view.py
@@ -94,16 +94,16 @@ class SynonymView(ModelView):
         # Strip leading and trailing spaces.
         values = list(map(str.strip, values))
 
-        # Embedded spaces are not allowed.
-        embedded_spaces = []
-        for value in values:
-            if " " in value:
-                embedded_spaces.append(value)
-
-        if len(embedded_spaces) != 0:
-            raise ValidationError("Synonyms Text does not allow embedded spaces ({})"
-                                  .format(", ".join(embedded_spaces)))
-
+#        # Embedded spaces are not allowed.
+#        embedded_spaces = []
+#        for value in values:
+#            if " " in value:
+#                embedded_spaces.append(value)
+#
+#        if len(embedded_spaces) != 0:
+#            raise ValidationError("Synonyms Text does not allow embedded spaces ({})"
+#                                  .format(", ".join(embedded_spaces)))
+#
         # Duplicate values are not allowed.
         duplicate_values = []
         previous_value = ""


### PR DESCRIPTION
*Issue #, if available:* 774

*Description of changes:* removed the validation that disallowed embedded spaces in synonyms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
