### PR TITLE
Change Solr API to allow not synonymizing #728

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -3,13 +3,20 @@ from urllib import request, parse
 import json
 
 
+# Use this character in the search strings to indicate that the word should not by synonymized.
+NO_SYNONYMS_INDICATOR = '@'
+
+# Prefix used to indicate that words are not to have synonyms.
+NO_SYNONYMS_PREFIX = '&fq=name_copy:'
+
+
 class SolrQueries:
 
-    CONFLICTS='conflicts'
-    HISTORY='histories'
-    TRADEMARKS='trademarks'
-    RESTRICTED_WORDS='restricted_words'
-    VALID_QUERIES=[CONFLICTS, HISTORY, TRADEMARKS]
+    CONFLICTS = 'conflicts'
+    HISTORY = 'histories'
+    TRADEMARKS = 'trademarks'
+    RESTRICTED_WORDS = 'restricted_words'
+    VALID_QUERIES = [CONFLICTS, HISTORY, TRADEMARKS]
 
     #
     # Prototype:
@@ -18,13 +25,13 @@ class SolrQueries:
     queries = {
         CONFLICTS: '/solr/possible.conflicts/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&'
                    'hl.simple.pre=%3Cb%3E&hl=on&indent=on&mm=75%25&q={name}&qf=name&wt=json&start={start}&'
-                   'rows={rows}&fl=source,id,name,score',
+                   'rows={rows}&fl=source,id,name,score{name_copy_clause}',
         HISTORY: '/solr/names/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&hl=on&'
                  'indent=on&mm=75%25&q={name}&qf=name&wt=json&start={start}&rows={rows}&'
-                 'fl=nr_num,name,score,submit_count,name_state_type_cd',
+                 'fl=nr_num,name,score,submit_count,name_state_type_cd{name_copy_clause}',
         TRADEMARKS: '/solr/trademarks/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&'
                     'hl=on&indent=on&mm=75%25&q={name}&qf=name&wt=json&start={start}&rows={rows}&'
-                    'fl=application_number,name,status,description,score&bq=status:REGISTERED^5.0'
+                    'fl=application_number,name,status,description,score&bq=status:REGISTERED^5.0{name_copy_clause}'
     }
 
     @classmethod
@@ -38,27 +45,94 @@ class SolrQueries:
         if query_type not in SolrQueries.VALID_QUERIES:
             return None, 'Not a valid analysis type', 400
 
-        current_app.logger.debug('Solr Query - type:{qtype} - name:{name}'.format(qtype=query_type, name=parse.quote(name)))
+        current_app.logger.debug('Solr Query - type:{qtype} - name:{name}'
+                                 .format(qtype=query_type, name=parse.quote(name)))
         query = solr_base_url + SolrQueries.queries[query_type].format(
             start=start,
             rows=rows,
-            name=parse.quote(name)
+            name=parse.quote(name.replace(NO_SYNONYMS_INDICATOR, '')),
+            name_copy_clause=cls._get_name_copy_clause(name)
         )
+        current_app.logger.debug('Query: ' + query)
         try:
             connection = request.urlopen(query)
         except Exception as err:
             current_app.logger.error(err, query)
             return None, 'Internal server error', 500
 
-        solr=json.load(connection)
+        solr = json.load(connection)
         results = {"response": {"numFound": solr['response']['numFound'],
-                                  "start": solr['response']['start'],
-                                  "rows": solr['responseHeader']['params']['rows'],
-                                  "maxScore": solr['response']['maxScore'],
-                                  "name": solr['responseHeader']['params']['q'][5:]
-                                  },
-                     'names': solr['response']['docs'],
-                     'highlighting': solr['highlighting']}
+                                "start": solr['response']['start'],
+                                "rows": solr['responseHeader']['params']['rows'],
+                                "maxScore": solr['response']['maxScore'],
+                                "name": solr['responseHeader']['params']['q']
+                                },
+                   'names': solr['response']['docs'],
+                   'highlighting': solr['highlighting']}
 
         return results, '', None
 
+    # The NO_SYNONYMS_INDICATOR is used to prefix a word or phrase that is not to be to synonymized. The decision was
+    # made that the indicator would not be used within double quotes, and that mixing it with search meta-characters is
+    # not a defined operation.
+    #
+    # - 'NO INDICATOR' > ''
+    # - '@ONE INDICATOR' > 'ONE'
+    # - '@MAYBE @TWO INDICATORS' > 'MAYBE TWO'
+    # - '@"SOME PHRASE" ALLOWED' > '"SOME PHRASE"'
+    #
+    # This is far from exhaustive and very GIGO.
+    @classmethod
+    def _get_name_copy_clause(cls, name):
+        clause = ''
+
+        # There's no easy way to split the name with whitespace as a delimiter, because quotes can be used to preserve
+        # terms with internal whitespace and additionally the quotes may also be prefixed with +, -, or *, or
+        # combinations of such.
+        unsynonymed_words = []
+
+        word = ''
+        indicator_on = False
+        quotes_on = False
+        for letter in name:
+            if letter == NO_SYNONYMS_INDICATOR:
+                # Only allow the indicator outside of quotes.
+                if not quotes_on:
+                    indicator_on = True
+    
+                continue
+
+            if letter == '"':
+                quotes_on = not quotes_on
+
+                if not indicator_on:
+                    continue
+
+            if letter == ' ' and not quotes_on:
+                if indicator_on:
+                    unsynonymed_words.append(word)
+                    word = ''
+                    indicator_on = False
+
+                continue
+
+            if indicator_on:
+                word += letter
+
+        # Handle when the last word was prefixed with the indicator.
+        if indicator_on:
+            unsynonymed_words.append(word)
+
+        if len(unsynonymed_words) != 0:
+            clause = NO_SYNONYMS_PREFIX + ' '.join(unsynonymed_words)
+
+        return clause
+
+
+'''
+https://namex-solr-test.pathfinder.gov.bc.ca/solr/names/select?defType=edismax&fq=name_copy:RED&indent=on&mm=75%&q=RED
+CLEANING SERVICES LTD.&qf=name&wt=json
+
+this is the one that will get passed from the front-end with the *RED CLEANING SERVICES LTD so that Red will not be
+substituted with the synonyms. the clause &fq=name_copy:RED is what says only give me back he ones with RED.
+'''

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -1,0 +1,70 @@
+#
+# I desperately needed tests but had no time to figure out pytest in Pycharm. It's hacked together for now, but the
+# tests at least are written.
+#
+
+from namex.analytics.solr import NO_SYNONYMS_INDICATOR, NO_SYNONYMS_PREFIX, SolrQueries
+
+
+def test_plain_search():
+    response = SolrQueries()._get_name_copy_clause('waffle corp')
+    print(response)
+    assert response == ''
+
+
+def test_one_term_first():
+    response = SolrQueries()._get_name_copy_clause(NO_SYNONYMS_INDICATOR + 'waffle corp')
+
+    assert response == NO_SYNONYMS_PREFIX + 'waffle'
+
+
+def test_one_term_middle():
+    response = SolrQueries()._get_name_copy_clause('big ' + NO_SYNONYMS_INDICATOR + 'waffle corp')
+
+    assert response == NO_SYNONYMS_PREFIX + 'waffle'
+
+
+def test_one_term_last():
+    response = SolrQueries()._get_name_copy_clause('big corp for ' + NO_SYNONYMS_INDICATOR + 'waffle')
+
+    assert response == NO_SYNONYMS_PREFIX + 'waffle'
+
+
+def test_quoted():
+    response = SolrQueries()._get_name_copy_clause('my "happy waffle"')
+
+    assert response == ''
+
+
+def test_quoted_ignore_embedded_indicator():
+    response = SolrQueries()._get_name_copy_clause('my "happy ' + NO_SYNONYMS_INDICATOR + 'waffle"')
+
+    assert response == ''
+
+
+def test_indicatored_quoted():
+    response = SolrQueries()._get_name_copy_clause('my ' + NO_SYNONYMS_INDICATOR + '"happy waffle"')
+
+    assert response == NO_SYNONYMS_PREFIX + '"happy waffle"'
+
+
+def test_quoted_ignore_embedded_indicator2():
+    response = SolrQueries()._get_name_copy_clause('my ' + NO_SYNONYMS_INDICATOR + '"happy ' + NO_SYNONYMS_INDICATOR +
+                                                   'waffle"')
+
+    assert response == NO_SYNONYMS_PREFIX + '"happy waffle"'
+
+
+# No idea how to get the tests running, so do it manually for now.
+try:
+    test_plain_search()
+    test_one_term_first()
+    test_one_term_middle()
+    test_one_term_last()
+    test_quoted()
+    test_quoted_ignore_embedded_indicator()
+    test_indicatored_quoted()
+    test_quoted_ignore_embedded_indicator2()
+except AssertionError as exception:
+    pass  # (for a breakpoint)
+    raise exception


### PR DESCRIPTION
*Issue #, if available:* 728

*Description of changes:* Added use of the @ character to indicate that the following word or quoted phrase is not to be run through the synonyms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
