### PR TITLE
Restrict characters allowed in synonyms. #775

### DIFF
--- a/solr-admin-app/docs/readme.md
+++ b/solr-admin-app/docs/readme.md
@@ -40,33 +40,5 @@ redirect URI "http://localhost:8080/oidc_callback" for desktop development.
 * Add error reporting for Solr core reloading
 * Don't reload solr cores if only the category or comment change
 * Edit page should use a text area for large varchar strings
-* If you're on page 2 when less than 100 items, switch to 1000 per page fails
+* If you're on page 2 when less than 1000 items, switching to 1000 per page fails
 * SynonymView has commented out code for embedded spaces - remove if not needed
-
-#### DONE:
-* Better duplicate error message
-* DB Configuration
-* Singularize table name
-* Sorting warning on create box
-* Notice of version for template files plus documentation
-* Put into NAMEX
-* Redeploy Solr with new config files ("enabled")
-* What container? Python
-* Config for different environments
-* Dev DB reconfiguration and reload
-* Documentation on data loading, project, DB schemas
-* Where to deploy? Test and push to dev/prod
-* SSO authentication
-* Dev DB reconfiguration and reload
-* Documentation on data loading, project, DB schemas
-* Where to deploy? Test and push to dev/prod
-* SSO authentication
-* Monkeypatch the Verisign G2 root certificate
-* Add "category" column to the database, plus searching or filtering
-* Auditing
-* Insert commas after spaces in the view (data too wide for page)
-* Figure out why OIDC redirect is not working for HTTPS
-* Reload cores automatically
-* Ensure that singleton values in synonyms are disallowed
-* Ensure that synonyms do not have embedded spaces
-* Ensure that duplicate values in synonyms are disallowed

--- a/solr-admin-app/solr_admin/views/synonym_view.py
+++ b/solr-admin-app/solr_admin/views/synonym_view.py
@@ -2,6 +2,7 @@
 from flask import request
 from flask_admin.contrib.sqla import ModelView
 from wtforms.validators import ValidationError
+import re
 
 from solr_admin.models import db
 from solr_admin.keycloak import Keycloak
@@ -104,6 +105,16 @@ class SynonymView(ModelView):
 #            raise ValidationError("Synonyms Text does not allow embedded spaces ({})"
 #                                  .format(", ".join(embedded_spaces)))
 #
+        # Only a-z, 0-9, and space are allowed in the synonyms.
+        disallowed_values = []
+        for value in values:
+            if re.search("[^a-z0-9 ]", value):
+                disallowed_values.append(value)
+
+        if len(disallowed_values) != 0:
+            raise ValidationError("Synonyms Text only allows lower case letters, digits, and space characters ({})"
+                                  .format(", ".join(disallowed_values)))
+
         # Duplicate values are not allowed.
         duplicate_values = []
         previous_value = ""


### PR DESCRIPTION
*Issue #, if available:* 775

*Description of changes:* updated the validation to restrict synonym text to a-z, 0-9, and space.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
