### PR TITLE
Deleted empty synonynms.txt files. #811

### DIFF
--- a/solr/cores/names/conf/synonyms.txt
+++ b/solr/cores/names/conf/synonyms.txt
@@ -1,1 +1,0 @@
-# This file is no longer used. The synonyms are now in a postgres table. See managed-schema for details.

--- a/solr/cores/possible.conflicts/conf/synonyms.txt
+++ b/solr/cores/possible.conflicts/conf/synonyms.txt
@@ -1,1 +1,0 @@
-# This file is no longer used. The synonyms are now in a postgres table. See managed-schema for details.

--- a/solr/cores/trademarks/conf/synonyms.txt
+++ b/solr/cores/trademarks/conf/synonyms.txt
@@ -1,1 +1,0 @@
-# This file is no longer used. The synonyms are now in a postgres table. See managed-schema for details.


### PR DESCRIPTION
*Issue #, if available:* 811

*Description of changes:* dummy synonyms.txt files were previously added, as a temporary measure to get rid of the stuck synonyms..txt files that were not being deleted. Once again the synonyms.txt files have been deleted - it's assumed that they will again be stuck, but at least the content of the stuck files will be less confusing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
