### PR TITLE
updates to support better debugging and ensure current image is used.

### DIFF
--- a/nro-update/openshift/templates/cron-nro-update.yml
+++ b/nro-update/openshift/templates/cron-nro-update.yml
@@ -13,6 +13,7 @@ objects:
     name: "nro-update"
   spec:
     schedule: "*/10 7-19 * * *"
+    suspend: true
     jobTemplate:
       spec:
         template:
@@ -20,6 +21,7 @@ objects:
             containers:
             - name: "nro-update"
               image: "docker-registry.default.svc:5000/servicebc-ne-tools/nro-update-runtime:${ENV_TAG}"
+              imagePullPolicy: Always
               args:
               - /bin/sh
               - -c


### PR DESCRIPTION
*Issue #, if available:* 424

*Description of changes:*
altering the sqlalchemy calls so that they can be printed fully in debug mode. altering the cronjob to force the image to come from the registry and not use the cached version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
