### PR TITLE
855 nro

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -32,9 +32,9 @@ class Name(db.Model):
     comment = db.relationship("Comment", backref=backref("related_name", uselist=False), foreign_keys=[commentId])
 
     NOT_EXAMINED = 'NE'
-    APPROVED = 'A'
-    REJECTED = 'R'
-    CONDITION = 'C'
+    APPROVED = 'APPROVED'
+    REJECTED = 'REJECTED'
+    CONDITION = 'CONDITION'
 
     def as_dict(self):
         return {

--- a/nro-update/config.py
+++ b/nro-update/config.py
@@ -10,6 +10,7 @@ class Config(object):
 
     MAX_ROW_LIMIT = os.getenv('MAX_ROWS','100')
     MIN_DELAY_SECONDS = os.getenv('MIN_DELAY_SECONDS','600')
+    EXPIRES_DAYS = os.getenv('EXPIRES_DAYS','60')
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/nro-update/nro/nro_datapump.py
+++ b/nro-update/nro/nro_datapump.py
@@ -14,7 +14,7 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
     }
 
     # initialize array of derived values to use in the stored proc
-    names = [
+    nro_names = [
         {'state': None, 'decision': None, 'conflict1': None, 'conflict2': None, 'conflict3': None},
         {'state': None, 'decision': None, 'conflict1': None, 'conflict2': None, 'conflict3': None},
         {'state': None, 'decision': None, 'conflict1': None, 'conflict2': None, 'conflict3': None}
@@ -22,54 +22,58 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
     for name in nr.names.all():
         choice = name.choice - 1
         if name.state in [Name.APPROVED, name.CONDITION]:
-            names[choice]['state'] = 'A'
+            nro_names[choice]['state'] = 'A'
         elif name.state == Name.REJECTED:
-            names[choice]['state'] = 'R'
+            nro_names[choice]['state'] = 'R'
         else:
-            names[choice]['state'] = 'NE'
+            nro_names[choice]['state'] = 'NE'
 
         decision_text = ''
+        # some defensive coding here to handle approve/reject/condition where no decision text is available
+        # TODO determine if there a business rule requiring APPROVE|REJECTED|CONDITION to have a decision?
         if name.state in [Name.APPROVED, Name.CONDITION, Name.REJECTED]:
-            names[choice]['decision'] = '{}****{}'.format(names[choice]['state'], name.decision_text[:1000])
+            nro_names[choice]['decision'] = '{}****{}'.format(
+                nro_names[choice]['state']
+                , '  ' if (name.decision_text is None) else name.decision_text[:1000]
+            )
 
         if name.conflict1:
-            names[choice]['conflict1'] = '{}****{}'.format(name.conflict1_num[:10], name.conflict1[:150])
-
+            nro_names[choice]['conflict1'] = '{}****{}'.format(name.conflict1_num[:10], name.conflict1[:150])
         if name.conflict2:
-            names[choice]['conflict2'] = '{}****{}'.format(name.conflict2_num[:10], name.conflict2[:150])
-
+            nro_names[choice]['conflict2'] = '{}****{}'.format(name.conflict2_num[:10], name.conflict2[:150])
         if name.conflict3:
-            names[choice]['conflict3'] = '{}****{}'.format(name.conflict3_num[:10], name.conflict3[:150])
+            nro_names[choice]['conflict3'] = '{}****{}'.format(name.conflict3_num[:10], name.conflict3[:150])
 
         if name.comment:
-            # use the last name comment as the examiner comment, wether that was a rejection or approval
+            # use the last name comment as the examiner comment, whether that was a rejection or approval
             if name.choice > examiner_comment['choice']:
                 examiner_comment['choice'] = name.choice
                 examiner_comment['comment'] = name.comment.comment
 
-    ### Call the name_examination procedure to save complete decision data for a single NR
+    # # Call the name_examination procedure to save complete decision data for a single NR
     ora_cursor.callproc("NRO_DATAPUMP_PKG.name_examination",
                         [nr.nrNum,  # p_nr_number
                          'A' if (nr.stateCd in [State.APPROVED, State.CONDITIONAL]) else 'R',  # p_status
                          expiry_date.strftime('%Y%m%d'),  # p_expiry_date
                          'Y' if (nr.consentFlag in ['Y', State.CONDITIONAL]) else 'N',  # p_consent_flag
                          nr.activeUser.username[:7],  # p_examiner_id
-                         names[0]['decision'],  # p_choice1
-                         names[1]['decision'],  # p_choice2
-                         names[2]['decision'],  # p_choice3
+                         nro_names[0]['decision'],  # p_choice1
+                         nro_names[1]['decision'],  # p_choice2
+                         nro_names[2]['decision'],  # p_choice3
                          examiner_comment['comment'],  # p_exam_comment
                          '',  # p_add_info - not used in proc anymore
-                         names[0]['conflict1'],  # p_confname1A
-                         names[0]['conflict2'],  # p_confname1B
-                         names[0]['conflict3'],  # p_confname1C
-                         names[1]['conflict1'],  # p_confname2A
-                         names[1]['conflict2'],  # p_confname2B
-                         names[1]['conflict3'],  # p_confname2C
-                         names[2]['conflict1'],  # p_confname3A
-                         names[2]['conflict2'],  # p_confname3B
-                         names[2]['conflict3'],  # p_confname3C
+                         nro_names[0]['conflict1'],  # p_confname1A
+                         nro_names[0]['conflict2'],  # p_confname1B
+                         nro_names[0]['conflict3'],  # p_confname1C
+                         nro_names[1]['conflict1'],  # p_confname2A
+                         nro_names[1]['conflict2'],  # p_confname2B
+                         nro_names[1]['conflict3'],  # p_confname2C
+                         nro_names[2]['conflict1'],  # p_confname3A
+                         nro_names[2]['conflict2'],  # p_confname3B
+                         nro_names[2]['conflict3'],  # p_confname3C
                          ]
                         )
     # mark that we've set the record in NRO - which assumes we have legally furnished this to the client.
+    # and record the expiry date we sent to NRO
     nr.furnished = 'Y'
     nr.expirationDate = expiry_date

--- a/nro-update/nro_update.py
+++ b/nro-update/nro_update.py
@@ -71,7 +71,11 @@ try:
     ora_con.begin()
     ora_cursor = ora_con.cursor()
 
+    # A more generic way of setting time
+    # but it doens't print / log well from the Postgres Dialect
+    # so just leaving it here for future reference
     # q = q.filter(Request.lastUpdate < datetime.utcnow()-timedelta(seconds=delay)). \
+    #
     q = db.session.query(Request).\
                 filter(Request.stateCd.in_([State.APPROVED, State.REJECTED, State.CONDITIONAL])).\
                 filter(Request.furnished != 'Y').\

--- a/nro-update/openshift/templates/cron-nro-update.yml
+++ b/nro-update/openshift/templates/cron-nro-update.yml
@@ -12,8 +12,9 @@ objects:
   metadata:
     name: "nro-update"
   spec:
+    concurrencyPolicy: "Forbid"
     schedule: "*/10 7-19 * * *"
-    suspend: true
+    suspend: false
     jobTemplate:
       spec:
         template:
@@ -50,6 +51,8 @@ objects:
                     value: "${MAX_ROWS}"
                   - name: MIN_DELAY_SECONDS
                     value: "${MIN_DELAY_SECONDS}"
+                  - name: EXPIRES_DAYS
+                    value: "${EXPIRES_DAYS}"
                   - name: ORA_PORT
                     valueFrom:
                       secretKeyRef:
@@ -98,5 +101,11 @@ parameters: [
           "description": "The minimum amount of time between when the job started and the approve/rejected timestamp of the Name Request",
           "required": true,
           "value": "600"
+        },{
+          "name": "EXPIRES_DAYS",
+          "displayName": "EXPIRES_DAYS",
+          "description": "The number of days, from today, that an APPROVED Name Request is valid for.",
+          "required": true,
+          "value": "60"
         },
 ]


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#855

*Description of changes:*
Fix code related to setting names values when sending to NRO datapump package.
Lack of some business rules resulted in values being set inconsistently.
Updated the core model to use the same values as being set in the examiners tools.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
