### PR TITLE
874 fix the exmainer name being sent to NRO, add tests to help with m…

### DIFF
--- a/nro-update/nro/nro_datapump.py
+++ b/nro-update/nro/nro_datapump.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 
 from namex.models import Name, State
 
+from .utils import nro_examiner_name
+
 
 def nro_data_pump_update(nr, ora_cursor, expires_days=60):
 
@@ -56,7 +58,7 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
                          'A' if (nr.stateCd in [State.APPROVED, State.CONDITIONAL]) else 'R',  # p_status
                          expiry_date.strftime('%Y%m%d'),  # p_expiry_date
                          'Y' if (nr.consentFlag in ['Y', State.CONDITIONAL]) else 'N',  # p_consent_flag
-                         nr.activeUser.username[:7],  # p_examiner_id
+                         nro_examiner_name(nr.activeUser.username),  # p_examiner_id
                          nro_names[0]['decision'],  # p_choice1
                          nro_names[1]['decision'],  # p_choice2
                          nro_names[2]['decision'],  # p_choice3

--- a/nro-update/nro/utils.py
+++ b/nro-update/nro/utils.py
@@ -1,0 +1,10 @@
+
+
+def nro_examiner_name(examiner_name): #-> (str)
+    """returns an examiner name, formated and tuncated to fit in NRO
+    :examiner_name (str): an examiner name, as found in NameX
+    :returns (str): an examiner name that is 7 or less chars in length
+    """
+    #namex examiner_names are {domain}{/}{username}
+    start = examiner_name.find('/')+1
+    return examiner_name[start:start+7]

--- a/nro-update/pytest.ini
+++ b/nro-update/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+minversion = 2.0
+norecursedirs = .git .tox venv* requirements* build
+python_files = test*.py

--- a/nro-update/requirements/dev.txt
+++ b/nro-update/requirements/dev.txt
@@ -3,6 +3,7 @@
 
 # Testing
 pytest
+pytest-mock
 
 # Lint and code style
 flake8

--- a/nro-update/tests/test_nro_datapump.py
+++ b/nro-update/tests/test_nro_datapump.py
@@ -1,0 +1,56 @@
+import pytest
+import pytest_mock
+from datetime import datetime
+from nro.nro_datapump import nro_data_pump_update
+from namex.models import Request, Name, State, User
+
+
+# TODO Add more tests for the various use-cases.
+def test_datapump(mocker):
+
+    # create minimal NR to send to NRO
+    nr = Request()
+    nr.nrNum = 'NR 0000001'
+    nr.stateCd = State.REJECTED
+    nr.consentFlag = 'N'
+    nr.lastUpdate = datetime.utcfromtimestamp(0)
+
+    # requires the username
+    user = User('idir/bob','bob','last','idir','localhost')
+    nr.activeUser = user
+
+    # add name(s) to the NR - max 3
+    for i in range(1,4):
+        name = Name()
+        name.state=Name.REJECTED
+        name.name = 'sample name {}'.format(i)
+        name.choice = i
+        name.decision_text = 'No Distinctive Term {}'.format(i)
+        nr.names.append(name)
+
+    # mock the oracle cursor
+    oc = mocker.MagicMock()
+    # make the real call
+    nro_data_pump_update(nr, ora_cursor=oc, expires_days=60)
+
+    oc.callproc.assert_called_with('NRO_DATAPUMP_PKG.name_examination', #package.proc_name
+                                   ['NR 0000001',                  # p_nr_number
+                                    'R',                           # p_status
+                                    '19700302',                    # p_expiry_date (length=8)
+                                    'N',                           # p_consent_flag
+                                    'bob',                         # p_examiner_id (anything length <=7)
+                                    'R****No Distinctive Term 1',  # p_choice1
+                                    'R****No Distinctive Term 2',  # p_choice2
+                                    'R****No Distinctive Term 3',  # p_choice3
+                                    None,                          # p_exam_comment
+                                    '',                            # p_add_info - not used in proc anymore
+                                    None,                          # p_confname1A
+                                    None,                          # p_confname1B
+                                    None,                          # p_confname1C
+                                    None,                          # p_confname2A
+                                    None,                          # p_confname2B
+                                    None,                          # p_confname2C
+                                    None,                          # p_confname3A
+                                    None,                          # p_confname3B
+                                    None])                         # p_confname3C
+

--- a/nro-update/tests/test_nro_utils.py
+++ b/nro-update/tests/test_nro_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from nro import utils
+
+
+# testdata pattern is ({username}, {expected return value})
+testdata = [
+    ('idir/examiner', 'examine'),
+    ('idir/', ''),
+    ('github/examiner', 'examine'),
+    ('/examiner', 'examine'),
+    ('examiner', 'examine'),
+    ('goofygoober', 'goofygo'),
+    ('', '')
+]
+
+
+@pytest.mark.parametrize("username,expected", testdata)
+def test_nro_examiner_name(username, expected):
+    en = utils.nro_examiner_name(username)
+    assert expected == en


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* bcgov/name-examination#874

*Description of changes:*
Fix the examiner name being sent to NRO, add tests to help with maintenance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
