### PR TITLE
Removed unused trademarks storage. #872

### DIFF
--- a/solr/openshift/solr-deploy.DEV.param
+++ b/solr/openshift/solr-deploy.DEV.param
@@ -11,6 +11,4 @@ APPLICATION_HOSTNAME=namex-solr-dev
 APPLICATION_DOMAIN=pathfinder.gov.bc.ca
 CORES_PV_SIZE=1Gi
 CORES_MOUNT_PATH=/opt/solr/server/solr/mycores
-TRADEMARKS_PV_SIZE=1Gi
-TRADEMARKS_MOUNT_PATH=/opt/solr/trademarks_data
 CORE_NAME=names,possible.conflicts,trademarks

--- a/solr/openshift/solr-deploy.PROD.param
+++ b/solr/openshift/solr-deploy.PROD.param
@@ -11,6 +11,4 @@ APPLICATION_HOSTNAME=namex-solr
 APPLICATION_DOMAIN=pathfinder.gov.bc.ca
 CORES_PV_SIZE=1Gi
 CORES_MOUNT_PATH=/opt/solr/server/solr/mycores
-TRADEMARKS_PV_SIZE=1Gi
-TRADEMARKS_MOUNT_PATH=/opt/solr/trademarks_data
 CORE_NAME=names,possible.conflicts,trademarks

--- a/solr/openshift/solr-deploy.TEST.param
+++ b/solr/openshift/solr-deploy.TEST.param
@@ -11,6 +11,4 @@ APPLICATION_HOSTNAME=namex-solr-test
 APPLICATION_DOMAIN=pathfinder.gov.bc.ca
 CORES_PV_SIZE=1Gi
 CORES_MOUNT_PATH=/opt/solr/server/solr/mycores
-TRADEMARKS_PV_SIZE=1Gi
-TRADEMARKS_MOUNT_PATH=/opt/solr/trademarks_data
 CORE_NAME=names,possible.conflicts,trademarks

--- a/solr/openshift/templates/solr-deploy-local.json
+++ b/solr/openshift/templates/solr-deploy-local.json
@@ -97,32 +97,6 @@
       }
     },
     {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata":
-      {
-        "name": "${NAME}-trademarks",
-        "labels":
-        {
-          "app": "${NAME}",
-          "template": "${NAME}-deployment-template"
-        }
-      },
-      "spec":
-      {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources":
-        {
-          "requests":
-          {
-            "storage": "${TRADEMARKS_PV_SIZE}"
-          }
-        }
-      }
-    },
-    {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata":
@@ -197,13 +171,6 @@
                 }
               },
               {
-                "name": "${NAME}-trademarks",
-                "persistentVolumeClaim":
-                {
-                  "claimName": "${NAME}-trademarks"
-                }
-              },
-              {
                 "name": "solr-datasources",
                 "configMap": {
                   "name": "solr-datasources",
@@ -229,10 +196,6 @@
                   {
                     "name": "${NAME}-cores",
                     "mountPath": "${CORES_MOUNT_PATH}"
-                  },
-                  {
-                    "name": "${NAME}-trademarks",
-                    "mountPath": "${TRADEMARKS_MOUNT_PATH}"
                   },
                   {
                     "name": "solr-datasources",
@@ -370,25 +333,11 @@
       "value": "1Gi"
     },
     {
-      "name": "TRADEMARKS_PV_SIZE",
-      "displayName": "Trademarks Persistent Volume Size",
-      "description": "The size of the persistent volume housing the trademarks files , e.g. 512Mi, 1Gi, 2Gi.",
-      "required": true,
-      "value": "1Gi"
-    },
-    {
       "name": "CORES_MOUNT_PATH",
       "displayName": "Cores Mount Path",
       "description": "The path to mount the cores persistent volume.",
       "required": true,
       "value": "/opt/solr/server/solr/mycores"
-    },
-    {
-      "name": "TRADEMARKS_MOUNT_PATH",
-      "displayName": "Trademarks Mount Path",
-      "description": "The path to mount the trademarks persistent volume.",
-      "required": true,
-      "value": "/opt/solr/trademarks_data"
     },
     {
       "name": "CORE_NAME",

--- a/solr/openshift/templates/solr-deploy.json
+++ b/solr/openshift/templates/solr-deploy.json
@@ -98,32 +98,6 @@
       }
     },
     {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata":
-      {
-        "name": "${NAME}-trademarks",
-        "labels":
-        {
-          "app": "${NAME}",
-          "template": "${NAME}-deployment-template"
-        }
-      },
-      "spec":
-      {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources":
-        {
-          "requests":
-          {
-            "storage": "${TRADEMARKS_PV_SIZE}"
-          }
-        }
-      }
-    },
-    {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata":
@@ -198,13 +172,6 @@
                 }
               },
               {
-                "name": "${NAME}-trademarks",
-                "persistentVolumeClaim":
-                {
-                  "claimName": "${NAME}-trademarks"
-                }
-              },
-              {
                 "name": "solr-datasources",
                 "configMap": {
                   "name": "solr-datasources",
@@ -230,10 +197,6 @@
                   {
                     "name": "${NAME}-cores",
                     "mountPath": "${CORES_MOUNT_PATH}"
-                  },
-                  {
-                    "name": "${NAME}-trademarks",
-                    "mountPath": "${TRADEMARKS_MOUNT_PATH}"
                   },
                   {
                     "name": "solr-datasources",
@@ -371,25 +334,11 @@
       "value": "1Gi"
     },
     {
-      "name": "TRADEMARKS_PV_SIZE",
-      "displayName": "Trademarks Persistent Volume Size",
-      "description": "The size of the persistent volume housing the trademarks files , e.g. 512Mi, 1Gi, 2Gi.",
-      "required": true,
-      "value": "1Gi"
-    },
-    {
       "name": "CORES_MOUNT_PATH",
       "displayName": "Cores Mount Path",
       "description": "The path to mount the cores persistent volume.",
       "required": true,
       "value": "/opt/solr/server/solr/mycores"
-    },
-    {
-      "name": "TRADEMARKS_MOUNT_PATH",
-      "displayName": "Trademarks Mount Path",
-      "description": "The path to mount the trademarks persistent volume.",
-      "required": true,
-      "value": "/opt/solr/trademarks_data"
     },
     {
       "name": "CORE_NAME",


### PR DESCRIPTION
*Issue #, if available:* 872

*Description of changes:* Removed the trademarks storage from the deploy scripts and environment-specific parameters files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
