### PR TITLE
setting the default expiry date for consuming an NR to 56

### DIFF
--- a/nro-update/openshift/templates/cron-nro-update.yml
+++ b/nro-update/openshift/templates/cron-nro-update.yml
@@ -106,6 +106,6 @@ parameters: [
           "displayName": "EXPIRES_DAYS",
           "description": "The number of days, from today, that an APPROVED Name Request is valid for.",
           "required": true,
-          "value": "60"
+          "value": "56"
         },
 ]


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#884

*Description of changes:*
setting the default expiry date for consuming an NR to 56

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
