### PR TITLE
887 set username in NRO correctly

### DIFF
--- a/api/namex/services/nro/oracle_services.py
+++ b/api/namex/services/nro/oracle_services.py
@@ -9,6 +9,7 @@ from namex.models import State
 from namex.services.nro import NROServicesError
 
 from .exceptions import NROServicesError
+from .utils import nro_examiner_name
 
 
 class NROServices(object):
@@ -167,7 +168,7 @@ class NROServices(object):
                             'H',               # p_status
                             '',               # p_expiry_date - mandatory, but ignored by the proc
                             '',               # p_consent_flag- mandatory, but ignored by the proc
-                            examiner_username[:7], # p_examiner_id
+                            nro_examiner_name(examiner_username), # p_examiner_id
                             ]
 
                 # Call the name_examination procedure to save complete decision data for a single NR

--- a/api/namex/services/nro/utils.py
+++ b/api/namex/services/nro/utils.py
@@ -1,0 +1,13 @@
+
+
+def nro_examiner_name(examiner_name): #-> (str)
+    """returns an examiner name, formated and tuncated to fit in NRO
+    :examiner_name (str): an examiner name, as found in NameX
+    :returns (str): an examiner name that is 7 or less chars in length
+    """
+    #namex examiner_names are {domain}{/}{username}
+    start = examiner_name.find('/')+1
+    return examiner_name[start:start+7]
+
+
+

--- a/api/tests/python/nro_services/test_nro_utils.py
+++ b/api/tests/python/nro_services/test_nro_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from namex.services.nro import utils
+
+
+# testdata pattern is ({username}, {expected return value})
+testdata = [
+    ('idir/examiner', 'examine'),
+    ('idir/', ''),
+    ('github/examiner', 'examine'),
+    ('/examiner', 'examine'),
+    ('examiner', 'examine'),
+    ('goofygoober', 'goofygo'),
+    ('', '')
+]
+
+
+@pytest.mark.parametrize("username,expected", testdata)
+def test_nro_examiner_name(username, expected):
+    en = utils.nro_examiner_name(username)
+    assert expected == en


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#887

*Description of changes:*
887 removing the SSI portion of the username and trunc to 7 chars for NRO


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
