### PR TITLE
ensure Priority status is set

### DIFF
--- a/nro-extractor/api/endpoints/requests.py
+++ b/nro-extractor/api/endpoints/requests.py
@@ -184,6 +184,8 @@ def add_nr_header(nr, nr_header, nr_submitter, user, update=False):
 
     if nr_submitter:
         submitter = User.find_by_username(nr_submitter['submitter'])
+    else:
+        submitter = None
 
     nr.userId = user.id
     nr.stateCd = State.DRAFT if nr_header['state_type_cd'] is None else NR_STATE[nr_header['state_type_cd']]
@@ -196,12 +198,12 @@ def add_nr_header(nr, nr_header, nr_submitter, user, update=False):
     nr.additionalInfo = nr_header['additional_info']
     nr.natureBusinessInfo = nr_header['nature_business_info']
     nr.xproJurisdiction = nr_header['xpro_jurisdiction']
-    nr.submittedDate = nr_submitter['submitted_date']
-    nr.submitter_userid = None if (submitter is None) else submitter.id
+    nr.submittedDate = None if not nr_submitter else nr_submitter['submitted_date']
+    nr.submitter_userid = None if not submitter else submitter.id
     nr.nroLastUpdate = nr_header['last_update']
     nr.lastUpdate = nr.nroLastUpdate # this needs to be set to the same Point In Time as NRO until NameX owns it
 
-    if nr_header['priority_cd'] is 'PQ':
+    if nr_header['priority_cd'] == 'PQ':
         nr.priorityCd = 'Y'
     else:
         nr.priorityCd = 'N'

--- a/nro-extractor/tests/unit/test_requests.py
+++ b/nro-extractor/tests/unit/test_requests.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+import pytest
+
+
+priority_flag_testdata = [
+    ('PQ', 'Y'),
+    ('PJ', 'N'),
+    ('P', 'N'),
+    ('R', 'N')
+]
+
+
+@pytest.mark.parametrize("priority_cd,expected", priority_flag_testdata)
+def test_add_nr_header_with_priority(priority_cd, expected):
+
+    from api.endpoints.requests import add_nr_header
+    from namex.models import Request, User
+
+    nr = Request()
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+    nr_submitter = None
+
+    nr_header = {
+        'priority_cd': priority_cd,
+        'state_type_cd': 'H',
+        'nr_num': 'NR 0000001',
+        'request_id': 1,
+        'previous_request_id': None,
+        'submit_count': 0,
+        'request_type_cd': 'REQ',
+        'expiration_date': None,
+        'additional_info': None,
+        'nature_business_info': 'N/A',
+        'xpro_jurisdiction': None,
+        'submitted_date': datetime.utcfromtimestamp(0),
+        'last_update': datetime.utcfromtimestamp(0)
+    }
+
+    add_nr_header(nr, nr_header, nr_submitter, user, update=False)
+
+    assert nr.priorityCd == expected


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#902

*Description of changes:*
ensure priority flag is set when nro is set to PQ
add test to ensure all 4 known permutations in the priority setting are handled


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
