### PR TITLE
set request state in NameX whin loading COMPLETED requests from NRO

### DIFF
--- a/nro-extractor/api/endpoints/requests.py
+++ b/nro-extractor/api/endpoints/requests.py
@@ -272,6 +272,13 @@ def add_names(nr, nr_names, update=False):
         name.name = n['name']
         name.designation = n['designation']
 
+        if nr.stateCd in ['COMPLETED', State.REJECTED] and name.state == Name.APPROVED:
+            nr.stateCd = State.APPROVED
+        elif nr.stateCd in ['COMPLETED', State.REJECTED, State.APPROVED] and name.state == Name.CONDITION:
+            nr.stateCd = State.CONDITIONAL
+        elif nr.stateCd == 'COMPLETED' and name.state == Name.REJECTED:
+            nr.stateCd = State.REJECTED
+
         nr.names.append(name)
 
 
@@ -480,4 +487,5 @@ def get_names(session, request_id):
     if len(names) < 1:
         return None
     return names
+
 

--- a/nro-extractor/tests/unit/test_requests.py
+++ b/nro-extractor/tests/unit/test_requests.py
@@ -1,6 +1,14 @@
 from datetime import datetime
+<<<<<<< Updated upstream
 import pytest
 
+=======
+
+import pytest
+
+from namex.models import Request, Name, State, User
+
+>>>>>>> Stashed changes
 
 priority_flag_testdata = [
     ('PQ', 'Y'),
@@ -14,7 +22,10 @@ priority_flag_testdata = [
 def test_add_nr_header_with_priority(priority_cd, expected):
 
     from api.endpoints.requests import add_nr_header
+<<<<<<< Updated upstream
     from namex.models import Request, User
+=======
+>>>>>>> Stashed changes
 
     nr = Request()
     user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
@@ -39,3 +50,137 @@ def test_add_nr_header_with_priority(priority_cd, expected):
     add_nr_header(nr, nr_header, nr_submitter, user, update=False)
 
     assert nr.priorityCd == expected
+<<<<<<< Updated upstream
+=======
+
+
+nr_state_testdata = [
+    ('HISTORICAL',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'}],
+     'HISTORICAL'
+     ),
+    ('H',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'}],
+     'HOLD'
+     ),
+    ('D',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'}],
+     'DRAFT'
+     ),
+    ('C',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'}],
+     'CANCELLED'
+     ),
+    ('E',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'}],
+     'EXPIRED'
+     ),
+    ('COMPLETED',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'}],
+     State.APPROVED
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'},
+     ],
+     State.APPROVED
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'},
+     ],
+     State.APPROVED
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'},
+     ],
+     State.APPROVED
+     ),
+    ('COMPLETED',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'}],
+     State.REJECTED
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'},
+     ],
+     State.REJECTED
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'NE'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'},
+     ],
+     State.REJECTED
+     ),
+    ('COMPLETED',
+     [{'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'C'}],
+     State.CONDITIONAL
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'NE'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'C'},
+     ],
+     State.CONDITIONAL
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'C'},
+     ],
+     State.CONDITIONAL
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'R'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'C'},
+     ],
+     State.CONDITIONAL
+     ),
+    ('COMPLETED',
+     [
+         {'choice_number': 1, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'C'},
+         {'choice_number': 2, 'name': 'PROCINE ENTERPRISES LTD', 'designation': None, 'name_state_type_cd': 'A'},
+     ],
+     State.CONDITIONAL
+     ),
+]
+
+
+@pytest.mark.parametrize("state_type_cd,nr_names,expected", nr_state_testdata)
+def test_add_nr_header_set_state(state_type_cd, nr_names, expected):
+    from api.endpoints.requests import add_nr_header, add_names
+
+    # the correct state for a Request that is completed in NRO is determined by the Name states
+
+    nr = Request()
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+    nr_submitter = None
+
+    nr_header = {
+        'priority_cd': 'N',
+        'state_type_cd': state_type_cd,
+        'nr_num': 'NR 0000001',
+        'request_id': 1,
+        'previous_request_id': None,
+        'submit_count': 0,
+        'request_type_cd': 'REQ',
+        'expiration_date': None,
+        'additional_info': None,
+        'nature_business_info': 'N/A',
+        'xpro_jurisdiction': None,
+        'submitted_date': datetime.utcfromtimestamp(0),
+        'last_update': datetime.utcfromtimestamp(0)
+    }
+
+    add_nr_header(nr, nr_header, nr_submitter, user, update=False)
+    add_names(nr, nr_names, update=False)
+
+    assert nr.stateCd == expected
+>>>>>>> Stashed changes


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#921

*Description of changes:*
If the Name Request in NRO is in a COMPLETED state, we need to set the Request state in NameX based on what the name_state is. All the other request states should behave the same.
There is a series of tests to exercise the various permutations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
