### PR TITLE
Solr: handle the RESET transaction. #934

### DIFF
--- a/nro-legacy/sql/object/names/namex/package/solr_pkb.sql
+++ b/nro-legacy/sql/object/names/namex/package/solr_pkb.sql
@@ -242,7 +242,7 @@ CREATE OR REPLACE PACKAGE BODY solr AS
                                 ACTION_UPDATE);
                         status := STATUS_COMPLETE;
                     END IF;
-                ELSIF row_transaction_type_cd IN ('CONSUME', 'EXPIR', 'HISTORICAL') THEN
+                ELSIF row_transaction_type_cd IN ('CONSUME', 'EXPIR', 'HISTORICAL', 'RESET') THEN
                     INSERT INTO solr_feeder (id, transaction_id, nr_num, solr_core, action) VALUES
                             (solr_feeder_id_seq.NEXTVAL, row_transaction_id, row_nr_num, SOLR_CORE_CONFLICTS,
                             ACTION_DELETE);

--- a/nro-legacy/sql/release/20180925_solr_package/names/namex/create.sql
+++ b/nro-legacy/sql/release/20180925_solr_package/names/namex/create.sql
@@ -1,0 +1,5 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+-- RESET was missing from the list of transactions that delete from the names core.
+
+@ ../../../../object/names/namex/package/solr_pkb.sql


### PR DESCRIPTION
*Issue #, if available:* 934

*Description of changes:* Added RESET to the set of transactions that cause names to be removed from the names core in Solr.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
