### PR TITLE
925 adding in missing end_event_ids to several views used by the extr…

### DIFF
--- a/nro-legacy/sql/object/names/namex/view/corp_nob_vw.sql
+++ b/nro-legacy/sql/object/names/namex/view/corp_nob_vw.sql
@@ -6,6 +6,7 @@ CREATE OR REPLACE FORCE VIEW namex.corp_nob_vw (nature_business_info, nr_num)
 AS
     SELECT ri.nature_business_info, r.nr_num
       FROM request_instance ri INNER JOIN request r ON r.request_id = ri.request_id
+     WHERE ri.end_event_id IS NULL
            ;
 
 

--- a/nro-legacy/sql/object/names/namex/view/req_instance_max_event.sql
+++ b/nro-legacy/sql/object/names/namex/view/req_instance_max_event.sql
@@ -37,7 +37,8 @@ AS
                      ens.event_timestamp AS event_timestamp
                 FROM NAME n LEFT OUTER JOIN name_state ns ON ns.name_id = n.name_id
                      LEFT OUTER JOIN event ens ON ens.event_id = ns.start_event_id
-               WHERE ns.end_event_id IS NULL)
+               WHERE ns.end_event_id IS NULL
+        )
     GROUP BY request_id;
 
 

--- a/nro-legacy/sql/object/names/namex/view/request_party_vw.sql
+++ b/nro-legacy/sql/object/names/namex/view/request_party_vw.sql
@@ -29,7 +29,8 @@ AS
       FROM request_party rp LEFT OUTER JOIN address@global_readonly addr
            ON addr.addr_id = rp.address_id
            LEFT OUTER JOIN request r ON r.request_id = rp.request_id
-     WHERE rp.party_type_cd = 'APP';
+     WHERE rp.party_type_cd = 'APP'
+       AND rp.end_event_id IS NULL;
 
 
 DROP PUBLIC SYNONYM REQUEST_PARTY_VW;

--- a/nro-legacy/sql/object/names/namex/view/request_vw.sql
+++ b/nro-legacy/sql/object/names/namex/view/request_vw.sql
@@ -18,6 +18,7 @@ AS
            ri.request_type_cd, ri.expiration_date, ri.additional_info, ri.nature_business_info,
            ri.xpro_jurisdiction
       FROM request r LEFT OUTER JOIN request_instance ri ON ri.request_id = r.request_id
+      WHERE ri.end_event_id IS NULL
            ;
 
 


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#925

*Description of changes:*
 adding in missing end_event_ids to several views used by the extractor and colin api


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
