### PR TITLE
Bug fix - only run nro.cancel_nr() in PATCH when user is trying to ca…

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -369,7 +369,8 @@ class Request(Resource):
             nrd.stateCd = state
             nrd.userId = user.id
 
-            nro.cancel_nr(nrd, user.username)
+            if state == State.CANCELLED:
+                nro.cancel_nr(nrd, user.username)
 
             ### COMMENTS ###
             # we only add new comments, we do not change existing comments


### PR DESCRIPTION
…ncel, not all PATCH statuses.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
