### PR TITLE
Convert data in edit NR and decision to ascii, removing data not

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -21,7 +21,7 @@ from namex.models import DecisionReason
 
 from namex.services import ServicesError, MessageServices, EventRecorder
 
-from namex.services.name_request import check_ownership, get_or_create_user_by_jwt, valid_state_transition
+from namex.services.name_request import check_ownership, get_or_create_user_by_jwt, valid_state_transition, convert_to_ascii
 from namex.utils.util import cors_preflight
 from namex.analytics import SolrQueries, RestrictedWords, VALID_ANALYSIS as ANALYTICS_VALID_ANALYSIS
 from namex.services.nro import NROServicesError
@@ -387,7 +387,7 @@ class Request(Resource):
                         is_new_comment = True
                     if is_new_comment and in_comment['comment'] is not None:
                         new_comment = Comment()
-                        new_comment.comment = in_comment['comment']
+                        new_comment.comment = convert_to_ascii(in_comment['comment'])
                         new_comment.examiner = user
                         new_comment.nrId = nrd.id
 
@@ -496,9 +496,9 @@ class Request(Resource):
                 reset = True
 
             request_header_schema.load(json_input, instance=nrd, partial=True)
-            nrd.additionalInfo = json_input.get('additionalInfo', None)
+            nrd.additionalInfo = convert_to_ascii(json_input.get('additionalInfo', None))
             nrd.furnished = json_input.get('furnished', 'N')
-            nrd.natureBusinessInfo = json_input.get('natureBusinessInfo', None)
+            nrd.natureBusinessInfo = convert_to_ascii(json_input.get('natureBusinessInfo', None))
             nrd.stateCd = state
             nrd.userId = user.id
 
@@ -539,6 +539,24 @@ class Request(Resource):
 
                     applicant_schema.load(appl, instance=applicants_d, partial=True)
 
+                    # convert data to ascii, removing data that won't save to Oracle
+                    applicants_d.lastName = convert_to_ascii(applicants_d.lastName)
+                    applicants_d.firstName = convert_to_ascii(applicants_d.firstName)
+                    applicants_d.middleName = convert_to_ascii(applicants_d.middleName)
+                    applicants_d.phoneNumber = convert_to_ascii(applicants_d.phoneNumber)
+                    applicants_d.faxNumber = convert_to_ascii(applicants_d.faxNumber)
+                    applicants_d.emailAddress = convert_to_ascii(applicants_d.emailAddress)
+                    applicants_d.contact = convert_to_ascii(applicants_d.contact)
+                    applicants_d.clientFirstName = convert_to_ascii(applicants_d.clientFirstName)
+                    applicants_d.clientLastName = convert_to_ascii(applicants_d.clientLastName)
+                    applicants_d.addrLine1 = convert_to_ascii(applicants_d.addrLine1)
+                    applicants_d.addrLine2 = convert_to_ascii(applicants_d.addrLine2)
+                    applicants_d.addrLine3 = convert_to_ascii(applicants_d.addrLine3)
+                    applicants_d.city = convert_to_ascii(applicants_d.city)
+                    applicants_d.postalCd = convert_to_ascii(applicants_d.postalCd)
+                    applicants_d.stateProvinceCd = convert_to_ascii(applicants_d.stateProvinceCd)
+                    applicants_d.countryTypeCd = convert_to_ascii(applicants_d.countryTypeCd)
+
                     # check if any of the Oracle db fields have changed, so we can send them back
                     if applicants_d.lastName != orig_applicant['lastName']: is_changed__applicant = True
                     if applicants_d.firstName != orig_applicant['firstName']: is_changed__applicant = True
@@ -577,6 +595,10 @@ class Request(Resource):
             if len(nrd.names.all()) == 0:
                 new_name_choice = Name()
                 new_name_choice.nrId = nrd.id
+
+                # convert data to ascii, removing data that won't save to Oracle
+                new_name_choice.name = convert_to_ascii(new_name_choice.name)
+
                 nrd.names.append(new_name_choice)
 
             for nrd_name in nrd.names.all():
@@ -594,6 +616,10 @@ class Request(Resource):
 
                         new_name_choice = Name()
                         new_name_choice.nrId = nrd.id
+
+                        # convert data to ascii, removing data that won't save to Oracle
+                        new_name_choice.name = convert_to_ascii(new_name_choice.name)
+
                         names_schema.load(in_name, instance=new_name_choice, partial=False)
 
                         nrd.names.append(new_name_choice)
@@ -624,6 +650,10 @@ class Request(Resource):
                         else:
                             nrd_name.comment = None
 
+                        # convert data to ascii, removing data that won't save to Oracle
+                        nrd_name.name = convert_to_ascii(nrd_name.name)
+
+
                         # check if any of the Oracle db fields have changed, so we can send them back
                         # - this is only for editing a name from the Edit NR section, NOT making a decision
                         if nrd_name.name != orig_name['name']:
@@ -647,7 +677,7 @@ class Request(Resource):
                     is_new_comment = True
                 if is_new_comment and in_comment['comment'] is not None:
                     new_comment = Comment()
-                    new_comment.comment = in_comment['comment']
+                    new_comment.comment = convert_to_ascii(in_comment['comment'])
                     new_comment.examiner = user
                     new_comment.nrId = nrd.id
 
@@ -671,6 +701,11 @@ class Request(Resource):
                             # return jsonify(errors), 400
 
                         nwpta_schema.load(in_nwpta, instance=nrd_nwpta, partial=False)
+
+                        # convert data to ascii, removing data that won't save to Oracle
+                        nrd_nwpta.partnerName = convert_to_ascii(nrd_nwpta.partnerName)
+                        nrd_nwpta.partnerNameNumber = convert_to_ascii(nrd_nwpta.partnerNameNumber)
+
 
                         # check if any of the Oracle db fields have changed, so we can send them back
                         tmp_is_changed = False

--- a/api/namex/services/name_request/__init__.py
+++ b/api/namex/services/name_request/__init__.py
@@ -65,3 +65,10 @@ def valid_state_transition(user, nr, new_state):
         if nr.userId != user.id or nr.stateCd != State.INPROGRESS:
             return False
     return True
+
+
+def convert_to_ascii(value):
+    try:
+        return value.encode("ascii","ignore").decode('ascii')
+    except:
+        return value

--- a/nro-update/nro/nro_datapump.py
+++ b/nro-update/nro/nro_datapump.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from flask import current_app
 
 from namex.models import Name, State
 from namex.services.nro.utils import nro_examiner_name
@@ -20,6 +21,7 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
         {'state': None, 'decision': None, 'conflict1': None, 'conflict2': None, 'conflict3': None},
         {'state': None, 'decision': None, 'conflict1': None, 'conflict2': None, 'conflict3': None}
     ]
+    current_app.logger.debug('processing names for :{}'.format(nr.nrNum))
     for name in nr.names.all():
         choice = name.choice - 1
         if name.state in [Name.APPROVED, name.CONDITION]:
@@ -35,7 +37,7 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
         if name.state in [Name.APPROVED, Name.CONDITION, Name.REJECTED]:
             nro_names[choice]['decision'] = '{}****{}'.format(
                 nro_names[choice]['state']
-                , '  ' if (name.decision_text is None) else name.decision_text[:1000]
+                , '  ' if (name.decision_text in [None, '']) else name.decision_text[:1000].encode("ascii","ignore").decode('ascii')
             )
 
         if name.conflict1:
@@ -49,7 +51,17 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
             # use the last name comment as the examiner comment, whether that was a rejection or approval
             if name.choice > examiner_comment['choice']:
                 examiner_comment['choice'] = name.choice
-                examiner_comment['comment'] = name.comment.comment
+                examiner_comment['comment'] = name.comment.comment.encode("ascii","ignore").decode('ascii')
+
+    current_app.logger.debug('sending {} to NRO'.format(nr.nrNum))
+    current_app.logger.debug('nr:{}; stateCd:{}; status: {}; expiry_dt:{}; consent:{}; examiner:{}'
+                             .format(nr.nrNum,
+                                     nr.stateCd,
+                                     'A' if (nr.stateCd in [State.APPROVED, State.CONDITIONAL]) else 'R',
+                                     expiry_date.strftime('%Y%m%d'),
+                                     'Y' if (nr.consentFlag == 'Y' or nr.stateCd == State.CONDITIONAL) else 'N',
+                                     nro_examiner_name(nr.activeUser.username)
+                                     ))
 
     # # Call the name_examination procedure to save complete decision data for a single NR
     ora_cursor.callproc("NRO_DATAPUMP_PKG.name_examination",
@@ -74,6 +86,7 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
                          nro_names[2]['conflict3'],  # p_confname3C
                          ]
                         )
+    current_app.logger.debug('finished sending {} to NRO'.format(nr.nrNum))
     # mark that we've set the record in NRO - which assumes we have legally furnished this to the client.
     # and record the expiry date we sent to NRO
     nr.furnished = 'Y'


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#912

*Description of changes:*
Convert data in edit NR and decision to ascii, removing data not compatible with oracle.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
