### PR TITLE
Solr API bugfix for @ in unexpected locations. #960

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -110,8 +110,10 @@ class SolrQueries:
 
             if letter == ' ' and not quotes_on:
                 if indicator_on:
-                    unsynonymed_words.append(word)
-                    word = ''
+                    if word != '':
+                        unsynonymed_words.append(word)
+                        word = ''
+
                     indicator_on = False
 
                 continue
@@ -120,7 +122,7 @@ class SolrQueries:
                 word += letter
 
         # Handle when the last word was prefixed with the indicator.
-        if indicator_on:
+        if indicator_on and word != '':
             unsynonymed_words.append(word)
 
         if len(unsynonymed_words) != 0:

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -12,6 +12,30 @@ def test_plain_search():
     assert response == ''
 
 
+def test_empty_term():
+    response = SolrQueries()._get_name_copy_clause('waffle ' + NO_SYNONYMS_INDICATOR + ' corp')
+    print(response)
+    assert response == ''
+
+
+def test_empty_term_end():
+    response = SolrQueries()._get_name_copy_clause('waffle corp ' + NO_SYNONYMS_INDICATOR)
+    print(response)
+    assert response == ''
+
+
+def test_trailing_indicator():
+    response = SolrQueries()._get_name_copy_clause('waffle' + NO_SYNONYMS_INDICATOR + ' corp')
+    print(response)
+    assert response == ''
+
+
+def test_trailing_indicator_end():
+    response = SolrQueries()._get_name_copy_clause('waffle corp' + NO_SYNONYMS_INDICATOR)
+    print(response)
+    assert response == ''
+
+
 def test_one_term_first():
     response = SolrQueries()._get_name_copy_clause(NO_SYNONYMS_INDICATOR + 'waffle corp')
 
@@ -58,6 +82,10 @@ def test_quoted_ignore_embedded_indicator2():
 # No idea how to get the tests running, so do it manually for now.
 try:
     test_plain_search()
+    test_empty_term()
+    test_empty_term_end()
+    test_trailing_indicator()
+    test_trailing_indicator_end()
     test_one_term_first()
     test_one_term_middle()
     test_one_term_last()


### PR DESCRIPTION
*Issue #, if available:* 960

*Description of changes:* Fixed the @ handling code to behave correctly when there is no term following the @ sign.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
