### PR TITLE
Handle incorrect name_copy terms in Solr. #960

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -126,6 +126,6 @@ class SolrQueries:
             unsynonymed_words.append(word)
 
         if len(unsynonymed_words) != 0:
-            clause = NO_SYNONYMS_PREFIX + parse.quote(' '.join(unsynonymed_words))
+            clause = NO_SYNONYMS_PREFIX + '(' + parse.quote(' '.join(unsynonymed_words)) + ')'
 
         return clause

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -2,95 +2,33 @@
 # Pytests for checking the code that produces the "name_copy" portion of the Solr query string.
 #
 
+import pytest
+
 from namex.analytics.solr import NO_SYNONYMS_INDICATOR, NO_SYNONYMS_PREFIX, SolrQueries
 
 
-def test_plain_search():
-    response = SolrQueries()._get_name_copy_clause('waffle corp')
-
-    assert response == ''
-
-
-def test_empty_term():
-    response = SolrQueries()._get_name_copy_clause('waffle ' + NO_SYNONYMS_INDICATOR + ' corp')
-
-    assert response == ''
-
-
-def test_empty_term_end():
-    response = SolrQueries()._get_name_copy_clause('waffle corp ' + NO_SYNONYMS_INDICATOR)
-
-    assert response == ''
-
-
-def test_trailing_indicator():
-    response = SolrQueries()._get_name_copy_clause('waffle' + NO_SYNONYMS_INDICATOR + ' corp')
-
-    assert response == ''
+name_copy_test_data = [
+    ('waffle corp', ''),
+    ('waffle ' + NO_SYNONYMS_INDICATOR + ' corp', ''),
+    ('waffle corp ' + NO_SYNONYMS_INDICATOR, ''),
+    ('waffle' + NO_SYNONYMS_INDICATOR + ' corp', ''),
+    ('waffle corp' + NO_SYNONYMS_INDICATOR, ''),
+    ('waffle' + NO_SYNONYMS_INDICATOR + 'corp', NO_SYNONYMS_PREFIX + '(corp)'),
+    ('the waffle' + NO_SYNONYMS_INDICATOR + 'corp', NO_SYNONYMS_PREFIX + '(corp)'),
+    (NO_SYNONYMS_INDICATOR + '^corp!', NO_SYNONYMS_PREFIX + '(%5Ecorp%21)'),
+    (NO_SYNONYMS_INDICATOR + 'waffle corp', NO_SYNONYMS_PREFIX + '(waffle)'),
+    ('big ' + NO_SYNONYMS_INDICATOR + 'waffle corp', NO_SYNONYMS_PREFIX + '(waffle)'),
+    ('big corp for ' + NO_SYNONYMS_INDICATOR + 'waffle', NO_SYNONYMS_PREFIX + '(waffle)'),
+    ('my "happy waffle"', ''),
+    ('my "happy ' + NO_SYNONYMS_INDICATOR + 'waffle"', ''),
+    ('my ' + NO_SYNONYMS_INDICATOR + '"happy waffle"', NO_SYNONYMS_PREFIX + '(%22happy%20waffle%22)'),
+    ('my ' + NO_SYNONYMS_INDICATOR + '"happy ' + NO_SYNONYMS_INDICATOR + 'waffle"', NO_SYNONYMS_PREFIX +
+        '(%22happy%20waffle%22)')
+]
 
 
-def test_trailing_indicator_end():
-    response = SolrQueries()._get_name_copy_clause('waffle corp' + NO_SYNONYMS_INDICATOR)
+@pytest.mark.parametrize("search_string,expected", name_copy_test_data)
+def test_get_name_copy_clause(search_string, expected):
+    response = SolrQueries()._get_name_copy_clause(search_string)
 
-    assert response == ''
-
-
-def test_embedded_indicator():
-    response = SolrQueries()._get_name_copy_clause('waffle' + NO_SYNONYMS_INDICATOR + 'corp')
-
-    assert response == NO_SYNONYMS_PREFIX + '(corp)'
-
-
-def test_embedded_indicator_end():
-    response = SolrQueries()._get_name_copy_clause('the waffle' + NO_SYNONYMS_INDICATOR + 'corp')
-
-    assert response == NO_SYNONYMS_PREFIX + '(corp)'
-
-
-def test_special_character():
-    response = SolrQueries()._get_name_copy_clause(NO_SYNONYMS_INDICATOR + '^corp!')
-
-    assert response == NO_SYNONYMS_PREFIX + '(%5Ecorp%21)'
-
-
-def test_one_term_first():
-    response = SolrQueries()._get_name_copy_clause(NO_SYNONYMS_INDICATOR + 'waffle corp')
-
-    assert response == NO_SYNONYMS_PREFIX + '(waffle)'
-
-
-def test_one_term_middle():
-    response = SolrQueries()._get_name_copy_clause('big ' + NO_SYNONYMS_INDICATOR + 'waffle corp')
-
-    assert response == NO_SYNONYMS_PREFIX + '(waffle)'
-
-
-def test_one_term_last():
-    response = SolrQueries()._get_name_copy_clause('big corp for ' + NO_SYNONYMS_INDICATOR + 'waffle')
-
-    assert response == NO_SYNONYMS_PREFIX + '(waffle)'
-
-
-def test_quoted():
-    response = SolrQueries()._get_name_copy_clause('my "happy waffle"')
-
-    assert response == ''
-
-
-def test_quoted_ignore_embedded_indicator():
-    response = SolrQueries()._get_name_copy_clause('my "happy ' + NO_SYNONYMS_INDICATOR + 'waffle"')
-
-    assert response == ''
-
-
-def test_indicatored_quoted():
-    response = SolrQueries()._get_name_copy_clause('my ' + NO_SYNONYMS_INDICATOR + '"happy waffle"')
-
-    assert response == NO_SYNONYMS_PREFIX + '(%22happy%20waffle%22)'
-
-
-def test_quoted_ignore_embedded_indicator2():
-    response = SolrQueries()._get_name_copy_clause('my ' + NO_SYNONYMS_INDICATOR + '"happy ' + NO_SYNONYMS_INDICATOR +
-                                                   'waffle"')
-
-    assert response == NO_SYNONYMS_PREFIX + '(%22happy%20waffle%22)'
+    assert response == expected

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -8,50 +8,68 @@ from namex.analytics.solr import NO_SYNONYMS_INDICATOR, NO_SYNONYMS_PREFIX, Solr
 
 def test_plain_search():
     response = SolrQueries()._get_name_copy_clause('waffle corp')
-    print(response)
+
     assert response == ''
 
 
 def test_empty_term():
     response = SolrQueries()._get_name_copy_clause('waffle ' + NO_SYNONYMS_INDICATOR + ' corp')
-    print(response)
+
     assert response == ''
 
 
 def test_empty_term_end():
     response = SolrQueries()._get_name_copy_clause('waffle corp ' + NO_SYNONYMS_INDICATOR)
-    print(response)
+
     assert response == ''
 
 
 def test_trailing_indicator():
     response = SolrQueries()._get_name_copy_clause('waffle' + NO_SYNONYMS_INDICATOR + ' corp')
-    print(response)
+
     assert response == ''
 
 
 def test_trailing_indicator_end():
     response = SolrQueries()._get_name_copy_clause('waffle corp' + NO_SYNONYMS_INDICATOR)
-    print(response)
+
     assert response == ''
+
+
+def test_embedded_indicator():
+    response = SolrQueries()._get_name_copy_clause('waffle' + NO_SYNONYMS_INDICATOR + 'corp')
+
+    assert response == NO_SYNONYMS_PREFIX + '(corp)'
+
+
+def test_embedded_indicator_end():
+    response = SolrQueries()._get_name_copy_clause('the waffle' + NO_SYNONYMS_INDICATOR + 'corp')
+
+    assert response == NO_SYNONYMS_PREFIX + '(corp)'
+
+
+def test_special_character():
+    response = SolrQueries()._get_name_copy_clause(NO_SYNONYMS_INDICATOR + '^corp!')
+
+    assert response == NO_SYNONYMS_PREFIX + '(%5Ecorp%21)'
 
 
 def test_one_term_first():
     response = SolrQueries()._get_name_copy_clause(NO_SYNONYMS_INDICATOR + 'waffle corp')
 
-    assert response == NO_SYNONYMS_PREFIX + 'waffle'
+    assert response == NO_SYNONYMS_PREFIX + '(waffle)'
 
 
 def test_one_term_middle():
     response = SolrQueries()._get_name_copy_clause('big ' + NO_SYNONYMS_INDICATOR + 'waffle corp')
 
-    assert response == NO_SYNONYMS_PREFIX + 'waffle'
+    assert response == NO_SYNONYMS_PREFIX + '(waffle)'
 
 
 def test_one_term_last():
     response = SolrQueries()._get_name_copy_clause('big corp for ' + NO_SYNONYMS_INDICATOR + 'waffle')
 
-    assert response == NO_SYNONYMS_PREFIX + 'waffle'
+    assert response == NO_SYNONYMS_PREFIX + '(waffle)'
 
 
 def test_quoted():
@@ -69,14 +87,14 @@ def test_quoted_ignore_embedded_indicator():
 def test_indicatored_quoted():
     response = SolrQueries()._get_name_copy_clause('my ' + NO_SYNONYMS_INDICATOR + '"happy waffle"')
 
-    assert response == NO_SYNONYMS_PREFIX + '%22happy%20waffle%22'
+    assert response == NO_SYNONYMS_PREFIX + '(%22happy%20waffle%22)'
 
 
 def test_quoted_ignore_embedded_indicator2():
     response = SolrQueries()._get_name_copy_clause('my ' + NO_SYNONYMS_INDICATOR + '"happy ' + NO_SYNONYMS_INDICATOR +
                                                    'waffle"')
 
-    assert response == NO_SYNONYMS_PREFIX + '%22happy%20waffle%22'
+    assert response == NO_SYNONYMS_PREFIX + '(%22happy%20waffle%22)'
 
 
 # No idea how to get the tests running, so do it manually for now.
@@ -86,6 +104,9 @@ try:
     test_empty_term_end()
     test_trailing_indicator()
     test_trailing_indicator_end()
+    test_embedded_indicator()
+    test_embedded_indicator_end()
+    test_special_character()
     test_one_term_first()
     test_one_term_middle()
     test_one_term_last()

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -1,6 +1,5 @@
 #
-# I desperately needed tests but had no time to figure out pytest in Pycharm. It's hacked together for now, but the
-# tests at least are written.
+# Pytests for checking the code that produces the "name_copy" portion of the Solr query string.
 #
 
 from namex.analytics.solr import NO_SYNONYMS_INDICATOR, NO_SYNONYMS_PREFIX, SolrQueries
@@ -95,25 +94,3 @@ def test_quoted_ignore_embedded_indicator2():
                                                    'waffle"')
 
     assert response == NO_SYNONYMS_PREFIX + '(%22happy%20waffle%22)'
-
-
-# No idea how to get the tests running, so do it manually for now.
-try:
-    test_plain_search()
-    test_empty_term()
-    test_empty_term_end()
-    test_trailing_indicator()
-    test_trailing_indicator_end()
-    test_embedded_indicator()
-    test_embedded_indicator_end()
-    test_special_character()
-    test_one_term_first()
-    test_one_term_middle()
-    test_one_term_last()
-    test_quoted()
-    test_quoted_ignore_embedded_indicator()
-    test_indicatored_quoted()
-    test_quoted_ignore_embedded_indicator2()
-except AssertionError as exception:
-    pass  # (for a breakpoint)
-    raise exception


### PR DESCRIPTION
*Issue #, if available:* 960

*Description of changes:* Fixed problems with name_copy when the @ character is appearing without a term, or at the end of a term (both nonsense positions, but they should not cause a 500). Also updated the pytests to be actual tests, and refactored to simplify.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
