### PR TITLE
Force NR names to be uppercase.

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -57,6 +57,9 @@ class Name(db.Model):
         return cls.query.filter_by(name=name).first()
 
     def save_to_db(self):
+        # force uppercase names
+        self.name = self.name.upper()
+
         db.session.add(self)
         db.session.commit()
 

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -617,10 +617,11 @@ class Request(Resource):
                         new_name_choice = Name()
                         new_name_choice.nrId = nrd.id
 
-                        # convert data to ascii, removing data that won't save to Oracle
-                        new_name_choice.name = convert_to_ascii(new_name_choice.name)
-
                         names_schema.load(in_name, instance=new_name_choice, partial=False)
+
+                        # convert data to ascii, removing data that won't save to Oracle
+                        # - also force uppercase
+                        new_name_choice.name = convert_to_ascii(new_name_choice.name.upper())
 
                         nrd.names.append(new_name_choice)
 
@@ -651,7 +652,9 @@ class Request(Resource):
                             nrd_name.comment = None
 
                         # convert data to ascii, removing data that won't save to Oracle
+                        # - also force uppercase
                         nrd_name.name = convert_to_ascii(nrd_name.name)
+                        if (nrd_name.name is not None): nrd_name.name = nrd_name.name.upper()
 
 
                         # check if any of the Oracle db fields have changed, so we can send them back


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#983

*Description of changes:*
Force NR names to be uppercase. Done in Request PUT (where the name edits are handled) as well in the name save_to_db() function, even though that function is not used for name edits at this time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
