### PR TITLE
r-words bug-fix

### DIFF
--- a/api/namex/analytics/restricted_words.py
+++ b/api/namex/analytics/restricted_words.py
@@ -60,7 +60,8 @@ class RestrictedWords(object):
             replace('@','').\
             replace('-','').\
             replace('?','').\
-            replace('*','') + ' '
+            replace('*',''). \
+            replace('.', '') + ' '
 
     @staticmethod
     def find_restricted_words(content):

--- a/api/tests/python/restricted_words/test_restricted_words.py
+++ b/api/tests/python/restricted_words/test_restricted_words.py
@@ -23,7 +23,7 @@ def test_get_restricted_short():
 
 def test_get_restricted_long(db):
     # test strip_content
-    content = RestrictedWords().strip_content('+DR -royal @"bc" *bc??royalre* nd')
+    content = RestrictedWords().strip_content('+DR. -royal @"bc" *bc??royalre* nd')
     assert '+' not in content
     assert '-' not in content
     assert '@' not in content


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #, if available:*

*Description of changes:*
- The API was not stripping out periods before (i.e. 'DR.' would not return as a restricted word)
- Added period in api and pytests to catch this 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
