### PR TITLE
changed analyser order for name_with_synonyms to prevent stemming pri…

### DIFF
--- a/solr/cores/names/conf/managed-schema
+++ b/solr/cores/names/conf/managed-schema
@@ -671,12 +671,12 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" words="lang/stopwords_en.txt" ignoreCase="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
+		<filter class="com.s24.search.solr.analysis.jdbc.JdbcSynonymFilterFactory" dataSource="jdbc/synonyms"
+            sql="select synonyms_text from synonym where enabled = true" ignoreMissingDatabase="true" ignoreCase="true"
+            expand="true"/>
         <filter class="solr.PorterStemFilterFactory"/>
         <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="0" splitOnCaseChange="0" generateWordParts="0" catenateAll="1" catenateWords="1"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="com.s24.search.solr.analysis.jdbc.JdbcSynonymFilterFactory" dataSource="jdbc/synonyms"
-            sql="select synonyms_text from synonym where enabled = true" ignoreMissingDatabase="true" ignoreCase="true"
-            expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
       </analyzer>
     </fieldType>

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -659,12 +659,12 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" words="lang/stopwords_en.txt" ignoreCase="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
+		<filter class="com.s24.search.solr.analysis.jdbc.JdbcSynonymFilterFactory" dataSource="jdbc/synonyms"
+            sql="select synonyms_text from synonym where enabled = true" ignoreMissingDatabase="true" ignoreCase="true"
+            expand="true"/>
         <filter class="solr.PorterStemFilterFactory"/>
         <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="0" splitOnCaseChange="0" generateWordParts="0" catenateAll="1" catenateWords="1"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="com.s24.search.solr.analysis.jdbc.JdbcSynonymFilterFactory" dataSource="jdbc/synonyms"
-            sql="select synonyms_text from synonym where enabled = true" ignoreMissingDatabase="true" ignoreCase="true"
-            expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
       </analyzer>
     </fieldType>

--- a/solr/cores/trademarks/conf/managed-schema
+++ b/solr/cores/trademarks/conf/managed-schema
@@ -659,13 +659,13 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" words="lang/stopwords_en.txt" ignoreCase="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="0" splitOnCaseChange="0" generateWordParts="0" catenateAll="1" catenateWords="1"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="com.s24.search.solr.analysis.jdbc.JdbcSynonymFilterFactory" dataSource="jdbc/synonyms"
+		<filter class="com.s24.search.solr.analysis.jdbc.JdbcSynonymFilterFactory" dataSource="jdbc/synonyms"
             sql="select synonyms_text from synonym where enabled = true" ignoreMissingDatabase="true" ignoreCase="true"
             expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="0" splitOnCaseChange="0" generateWordParts="0" catenateAll="1" catenateWords="1"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/tests/postman/Solr_Analysis_Endpoint.postman_collection.json
+++ b/solr/tests/postman/Solr_Analysis_Endpoint.postman_collection.json
@@ -1,0 +1,85 @@
+{
+	"info": {
+		"_postman_id": "0956d20d-e222-4fd1-8dbb-e289cab98988",
+		"name": "Solr Analysis Endpoint",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "analysis test localhost",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "fe69f40f-256f-4025-b455-7f8debce095b",
+						"exec": [
+							"pm.test(\"Check for synonym hit\", function () {",
+							"    pm.expect(pm.response.text()).to.include(\"SYNONYM\");",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "f6504969-155e-416f-8f08-9c3930210407",
+						"exec": [
+							"console.log(\"Synonym being checked: \" + data[\"synonym\"])"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8983/solr/possible.conflicts/analysis/field?_=1540931275899&analysis.fieldname=name_with_synonyms&analysis.query={{synonym}}&analysis.showmatch=true&verbose_output=1&wt=json",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8983",
+					"path": [
+						"solr",
+						"possible.conflicts",
+						"analysis",
+						"field"
+					],
+					"query": [
+						{
+							"key": "_",
+							"value": "1540931275899"
+						},
+						{
+							"key": "analysis.fieldname",
+							"value": "name_with_synonyms"
+						},
+						{
+							"key": "analysis.query",
+							"value": "{{synonym}}"
+						},
+						{
+							"key": "analysis.showmatch",
+							"value": "true"
+						},
+						{
+							"key": "verbose_output",
+							"value": "1"
+						},
+						{
+							"key": "wt",
+							"value": "json"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#1106

*Description of changes:*
Queries against the name_with_synonyms field were being stemmed prior to reaching the synonym filter. This resulted in many missed synonyms since the list maintained by staff today does not contain stems.

I changed managed_conf so that the synonyms happened before the stemmer.
I did this for the possible.conflicts core only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
