### PR TITLE
Added registration_number to Trademarks managed-schema

### DIFF
--- a/solr/cores/trademarks/conf/managed-schema
+++ b/solr/cores/trademarks/conf/managed-schema
@@ -123,6 +123,7 @@
     <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
 	
     <field name="application_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
+	<field name="registration_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
     <field name="category" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="status" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="name" type="text_en_splitting" multiValued="false" indexed="true" required="false" stored="true"

--- a/solr/cores/trademarks/conf/managed-schema
+++ b/solr/cores/trademarks/conf/managed-schema
@@ -123,7 +123,7 @@
     <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
 	
     <field name="application_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
-    <field name="registration_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
+    <field name="registration_number" type="string" multiValued="false" indexed="false" required="true" stored="true"/>
     <field name="category" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="status" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="name" type="text_en_splitting" multiValued="false" indexed="true" required="false" stored="true"

--- a/solr/cores/trademarks/conf/managed-schema
+++ b/solr/cores/trademarks/conf/managed-schema
@@ -123,7 +123,7 @@
     <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
 	
     <field name="application_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
-	<field name="registration_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
+    <field name="registration_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
     <field name="category" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="status" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="name" type="text_en_splitting" multiValued="false" indexed="true" required="false" stored="true"


### PR DESCRIPTION
*Issue #, if available:*1109

*Description of changes:*
registration_number was added to the Trademarks core so that it can be displayed to examiners in search results. It is not the uniqueKey, but it is required.

Next steps: modify the parser to pull this field from the XML into the JSON file used for loading the index.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
