### PR TITLE
Replace NR number conflicts with generic "NR 0000000"

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -60,6 +60,21 @@ class Name(db.Model):
         # force uppercase names
         self.name = self.name.upper()
 
+        # remove NR numbers from conflicts - replace with generic NR number
+        # - this is for regulatory/privacy reasons
+        try:
+            if self.conflict1_num[0:2] == 'NR': self.conflict1_num = "NR 0000000"
+        except (TypeError, IndexError) as e:
+            pass
+        try:
+            if self.conflict2_num[0:2] == 'NR': self.conflict2_num = "NR 0000000"
+        except (TypeError, IndexError) as e:
+            pass
+        try:
+            if self.conflict3_num[0:2] == 'NR': self.conflict3_num = "NR 0000000"
+        except (TypeError, IndexError) as e:
+            pass
+
         db.session.add(self)
         db.session.commit()
 

--- a/api/tests/python/models/test_names.py
+++ b/api/tests/python/models/test_names.py
@@ -75,3 +75,33 @@ def test_name_schema_db_query_update(session):
     assert name.id == name_id
     assert name.name == test_name
     assert name_json == name_schema.dump(name).data
+
+def test_name_update_via_save_to_db_method(session):
+    """Test save via save_to_db() method, which does data transformations."""
+
+    # setup
+    test_name = "my good company"
+    name_json = {"name": test_name, "state": "NE", "conflict1": "conflict1", "conflict2": "conflict2", "conflict3": "", "consumptionDate": None,  "designation": "LLC", "conflict1_num": "NR 0000001", "decision_text": "my descision", "conflict3_num": "", "conflict2_num": "A123456", "choice": 1}
+    name_schema = NameSchema()
+
+    # create a name
+    name = Name(name="temp")
+    session.add(name)
+    session.commit()
+    name_id = name.id
+
+    # update it from the json data vi the schema loader
+    name_schema.load(name_json, instance=name, partial=False)
+    name.save_to_db()
+
+
+    # get the name from the data base & assert it was updated with data changes
+    name = None
+    name = Name.query.filter_by(id=name_id).one_or_none()
+    assert name.id is not None
+    assert name.id == name_id
+    assert name.name == test_name.upper() # name should be uppercase
+    assert name.conflict1_num == "NR 0000000" # NR number conflicts should be replaced with NR 0000000
+    assert name.conflict2_num == "A123456" # corp number conflicts should be unchanged
+    assert name.conflict3_num in ("", None)
+


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#1108

*Description of changes:*
Replace NR number conflicts with generic "NR 0000000"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
