### PR TITLE
changed MIN_DELAY_SECONDS parameter default to 120 from 600

### DIFF
--- a/nro-update/openshift/templates/cron-nro-update.yml
+++ b/nro-update/openshift/templates/cron-nro-update.yml
@@ -100,7 +100,7 @@ parameters: [
           "displayName": "MIN_DELAY_SECONDS",
           "description": "The minimum amount of time between when the job started and the approve/rejected timestamp of the Name Request",
           "required": true,
-          "value": "600"
+          "value": "120"
         },{
           "name": "EXPIRES_DAYS",
           "displayName": "EXPIRES_DAYS",


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* bcgov/name-examination#1119

*Description of changes:*
changed MIN_DELAY_SECONDS parameter default to 120 from 600

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
