### PR TITLE
1075 solr synonyms

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -159,57 +159,9 @@ class SolrQueries:
             tokens.append(line[start_token:])
         return tokens
 
-    # Split a string into a list of tokens, where tokens are delimited by whitespace, but quotation marks escape
-    # whitespace, and quotation marks may be preceded by control characters such as +.
-    @classmethod
-    def _tokenize_name(cls, name):
-        tokens = []
-
-        # strip quotes hyphens in quotes
-        name = re.sub(r'(?!(([^"]*"){2})*[^"]*$)-', ' ', name)
-        # push @ across "
-        name = re.sub(r"([ \-+@])(.)(?<=\")(.*)(?=\")", lambda m: '{1}{0}'.format((' '+m.group(1)).join(m.group(3).split()),m.group(1)), name)
-        # strip punctuation
-        name = re.sub('[^a-z +-@]', ' ', name)
-
-        word = ''
-        ignore_indicator_on = False
-        quotes_on = False
-        for letter in name:
-            if letter == NO_SYNONYMS_INDICATOR or letter == '-':
-                # Only allow the indicator outside of quotes.
-                if not quotes_on:
-                    ignore_indicator_on = True
-
-                continue
-
-            if letter == '"':
-                quotes_on = not quotes_on
-
-                if not ignore_indicator_on:
-                    continue
-
-            if letter in ', ' and not quotes_on:
-                if not ignore_indicator_on:
-                    if word != '':
-                        tokens.append(word)
-                        word = ''
-
-                ignore_indicator_on = False
-
-                continue
-
-            if not ignore_indicator_on:
-                word += letter
-
-        # Handle when the last word was prefixed with the indicator.
-        if not ignore_indicator_on and word != '':
-            tokens.append(word)
-
-        return tokens
 
     @classmethod
-    def _parse_for_synonym_candidates(cls, tokens):
+    def _parse_for_synonym_candidates(cls, tokens: List[str]) -> List[str]:
         """
         A list of tokens is passed in.
         We parse with the following rules:
@@ -217,7 +169,7 @@ class SolrQueries:
         token after a '-' token is ignored unless it is between quotes, then it is ignored
         '@' mean ignore next token, if next token is ", ignore everything until the balancing " or until end of list
         :param tokens:
-        :return:
+        :return: List[str] of tokens that are candidates as synonym tokens
         """
 
         candidates: List[str] = []
@@ -296,7 +248,6 @@ class SolrQueries:
         clause = ''
         synonyms = []
 
-        # tokens = cls._tokenize_name(name)
         tokens = cls._tokenize(name, [string.digits,
                                       string.whitespace,
                                       RESERVED_CHARACTERS,

--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -1,12 +1,20 @@
+import json
+import re
+import string
+from typing import List
+
 from flask import current_app
 from urllib import request, parse
 from urllib.error import HTTPError
-import json
-import re
 
 
 # Use this character in the search strings to indicate that the word should not by synonymized.
 NO_SYNONYMS_INDICATOR = '@'
+
+# Constant names for useful chars used by the functions below
+RESERVED_CHARACTERS = '-+@"'
+DOUBLE_QUOTE = '"'
+HYPHEN = '-'
 
 # Prefix used to indicate that words are not to have synonyms.
 NO_SYNONYMS_PREFIX = '&fq=name_copy:'
@@ -73,17 +81,20 @@ class SolrQueries:
             current_app.logger.error(err, query)
             return None, 'Internal server error', 500
 
-        solr = json.load(connection)
-        results = {"response": {"numFound": solr['response']['numFound'],
-                                "start": solr['response']['start'],
-                                "rows": solr['responseHeader']['params']['rows'],
-                                "maxScore": solr['response']['maxScore'],
-                                "name": solr['responseHeader']['params']['q']
-                                },
-                   'names': solr['response']['docs'],
-                   'highlighting': solr['highlighting']}
-
-        return results, '', None
+        try:
+            solr = json.load(connection)
+            results = {"response": {"numFound": solr['response']['numFound'],
+                                    "start": solr['response']['start'],
+                                    "rows": solr['responseHeader']['params']['rows'],
+                                    "maxScore": solr['response']['maxScore'],
+                                    "name": solr['responseHeader']['params']['q']
+                                    },
+                       'names': solr['response']['docs'],
+                       'highlighting': solr['highlighting']}
+            return results, '', None
+        except Exception as err:
+            current_app.logger.error(err, query)
+            return None, 'Internal server error', 500
 
     # Compress the name by removing designations and then striping all non-alpha characters. Solr eventually converts to
     # lowercase so we'll choose that over doing everything in uppercase.
@@ -104,11 +115,62 @@ class SolrQueries:
 
         return re.sub('[^a-z]', '', name)
 
+    @classmethod
+    def _tokenize(cls, line: str, categories: List[str] = []) -> List[str]:
+        """
+        Builds a list of tokens based upon the categories defined
+        The tokens are in the same order as the original input
+
+        Categories are scanned left->right,
+           so if you do repeat the contents in categories, the one to the left wins
+
+        example in Doctest format <- because like, why not?!
+
+        >>> _tokenize('a set of tokens', [' ', string.ascii_lowercase])
+        ['a', ' ', 'set', ' ', 'of', ' ', 'tokens']
+        >>> _tokenize('a "set of" tokens', [' ', string.ascii_lowercase])
+        ['a', ' ', '"', 'set', ' ', 'of', '"', ' ', 'tokens']
+        >>> _tokenize('a +"set of" tokens', [' ', '+"', ' "' string.ascii_lowercase])
+        ['a', ' ', '+"', 'set', ' ', 'of', '"', ' ', 'tokens']
+
+        :param line: str: the string to tokenize
+        :param categories: List[str]: a list of strings used as categories to classify the tokens
+        :return: List[str]: a list of string tokens that can be parsed left-> as order is preserved
+        """
+        tokens = [] # yep, lazy format
+        start_token: int = 0
+        idx: int
+        category: List[str] = None
+        for idx, char in enumerate(line):
+
+            if category and char not in category:
+                tokens.append(line[start_token:idx])
+                category = None
+
+            if not category:
+                category = '\u0000'
+                for cat in categories:
+                    if char in cat:
+                        category = cat
+                        break
+                start_token = idx
+
+        if start_token <= idx:
+            tokens.append(line[start_token:])
+        return tokens
+
     # Split a string into a list of tokens, where tokens are delimited by whitespace, but quotation marks escape
     # whitespace, and quotation marks may be preceded by control characters such as +.
     @classmethod
     def _tokenize_name(cls, name):
         tokens = []
+
+        # strip quotes hyphens in quotes
+        name = re.sub(r'(?!(([^"]*"){2})*[^"]*$)-', ' ', name)
+        # push @ across "
+        name = re.sub(r"([ \-+@])(.)(?<=\")(.*)(?=\")", lambda m: '{1}{0}'.format((' '+m.group(1)).join(m.group(3).split()),m.group(1)), name)
+        # strip punctuation
+        name = re.sub('[^a-z +-@]', ' ', name)
 
         word = ''
         ignore_indicator_on = False
@@ -127,7 +189,7 @@ class SolrQueries:
                 if not ignore_indicator_on:
                     continue
 
-            if letter == ' ' and not quotes_on:
+            if letter in ', ' and not quotes_on:
                 if not ignore_indicator_on:
                     if word != '':
                         tokens.append(word)
@@ -145,6 +207,66 @@ class SolrQueries:
             tokens.append(word)
 
         return tokens
+
+    @classmethod
+    def _parse_for_synonym_candidates(cls, tokens):
+        """
+        A list of tokens is passed in.
+        We parse with the following rules:
+        prefix " str str str .. str " -  prefix is applied to all terms inside of the "  " tokens
+        token after a '-' token is ignored unless it is between quotes, then it is ignored
+        '@' mean ignore next token, if next token is ", ignore everything until the balancing " or until end of list
+        :param tokens:
+        :return:
+        """
+
+        candidates: List[str] = []
+        previous_token: str = None
+        double_quote_flag: bool = False
+        skip_token_flag: bool = False
+
+        for token in tokens:
+            if token in string.whitespace:
+                previous_token = token
+                if not double_quote_flag:
+                    skip_token_flag = False
+                continue
+
+            elif token is DOUBLE_QUOTE:
+                if double_quote_flag:
+                    skip_token_flag = False
+                double_quote_flag = not double_quote_flag
+                previous_token = token
+                continue
+
+            elif token is HYPHEN:
+                if double_quote_flag:
+                    previous_token = token
+                    continue
+
+                if previous_token in string.whitespace:
+                    skip_token_flag = True
+                    previous_token = token
+                    continue
+
+            elif token is NO_SYNONYMS_INDICATOR:
+                skip_token_flag = True
+                previous_token = token
+                continue
+
+            else:
+                if skip_token_flag:
+                    if not double_quote_flag:
+                        skip_token_flag = False
+
+                    previous_token = token
+                    continue
+
+                candidates.append(token)
+
+            previous_token = token
+
+        return candidates
 
     # Call the synonyms API for the given token.
     @classmethod
@@ -174,11 +296,14 @@ class SolrQueries:
         clause = ''
         synonyms = []
 
-        tokens = cls._tokenize_name(name)
-        for token in tokens:
-            # We will ignore some special characters. This list is not exhaustive and will likely need rework.
-            token = re.sub('\+', '', token)
-
+        # tokens = cls._tokenize_name(name)
+        tokens = cls._tokenize(name, [string.digits,
+                                      string.whitespace,
+                                      RESERVED_CHARACTERS,
+                                      string.punctuation,
+                                      string.ascii_lowercase])
+        candidates = cls._parse_for_synonym_candidates(tokens)
+        for token in candidates:
             if cls._synonyms_exist(token):
                 synonyms.append(token)
 

--- a/api/tests/python/__init__.py
+++ b/api/tests/python/__init__.py
@@ -13,4 +13,5 @@ from .util import \
     integration_oracle_namesdb,\
     integration_fdw_namex,\
     integration_solr,\
+    integration_synonym_api, \
     integration_nro_extractor

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -31,38 +31,6 @@ def test_compress_name(name, expected):
 
     assert expected == response
 
-
-tokenize_name_test_data = [
-    ('waffle', ['waffle']),
-    (' waffle', ['waffle']),
-    ('waffle ', ['waffle']),
-    ('waffle mania', ['waffle', 'mania']),
-    (' waffle mania', ['waffle', 'mania']),
-    ('waffle mania ', ['waffle', 'mania']),
-    ('   waffle   mania   ', ['waffle', 'mania']),
-    ('-waffle mania', ['mania']),
-    ('waffle -mania', ['waffle']),
-    ('waffle "mania inc"', ['waffle', 'mania', 'inc']),
-    ('waffle -"mania inc"', ['waffle']),
-    ('   waffle     -"   mania    inc   "    ', ['waffle']),
-    ('belgian @waffles,', ['belgian']),                        # testing ignore @ == no-synonyms
-    ('belgian, waffles,', ['belgian', 'waffles']),             # testing trailing comma
-    ('belgian waffle-cream,', ['belgian', 'waffle']),          # testing trailing comma
-    ('belgian "waffle-cream",', ['belgian', 'waffle', 'cream']),          # testing trailing comma with -hyphen not minus
-    ('belgian waffle,cream,', ['belgian', 'waffle', 'cream']), # testing trailing comma
-    ('belgian @"waffle-cream",', ['belgian']),          # testing trailing comma with -hyphen not minus
-    ('"waffles and strawberries", @waffle, "whipped cream,"', ['waffles', 'and', 'strawberries', 'whipped', 'cream']), # testing trailing comma
-    ('"waffles and strawberries", @waffle, @"whipped cream,"', ['waffles', 'and', 'strawberries']), # testing trailing comma
-]
-
-
-@pytest.mark.parametrize("search_string,expected", tokenize_name_test_data)
-def test_tokenize_name(search_string, expected):
-    response = SolrQueries._tokenize_name(search_string)
-
-    assert expected == response
-
-
 name_copy_test_data = [
     ('waffle corp', ''),
     ('waffle ' + NO_SYNONYMS_INDICATOR + ' corp', ''),

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -1,10 +1,12 @@
 #
 # Pytests for checking the code that produces the more intricate components of the Solr query string.
 #
+import string
+from typing import List
 
 import pytest
 
-from namex.analytics.solr import NO_SYNONYMS_INDICATOR, NO_SYNONYMS_PREFIX, SolrQueries
+from namex.analytics.solr import NO_SYNONYMS_INDICATOR, NO_SYNONYMS_PREFIX, RESERVED_CHARACTERS, SolrQueries
 
 
 compress_name_test_data = [
@@ -22,6 +24,14 @@ compress_name_test_data = [
     ('waffle mania inc. / le wafflemania inc.', 'wafflemanialewafflemania'),
 ]
 
+
+@pytest.mark.parametrize("name,expected", compress_name_test_data)
+def test_compress_name(name, expected):
+    response = SolrQueries._compress_name(name)
+
+    assert expected == response
+
+
 tokenize_name_test_data = [
     ('waffle', ['waffle']),
     (' waffle', ['waffle']),
@@ -32,10 +42,26 @@ tokenize_name_test_data = [
     ('   waffle   mania   ', ['waffle', 'mania']),
     ('-waffle mania', ['mania']),
     ('waffle -mania', ['waffle']),
-    ('waffle "mania inc"', ['waffle', 'mania inc']),
+    ('waffle "mania inc"', ['waffle', 'mania', 'inc']),
     ('waffle -"mania inc"', ['waffle']),
     ('   waffle     -"   mania    inc   "    ', ['waffle']),
+    ('belgian @waffles,', ['belgian']),                        # testing ignore @ == no-synonyms
+    ('belgian, waffles,', ['belgian', 'waffles']),             # testing trailing comma
+    ('belgian waffle-cream,', ['belgian', 'waffle']),          # testing trailing comma
+    ('belgian "waffle-cream",', ['belgian', 'waffle', 'cream']),          # testing trailing comma with -hyphen not minus
+    ('belgian waffle,cream,', ['belgian', 'waffle', 'cream']), # testing trailing comma
+    ('belgian @"waffle-cream",', ['belgian']),          # testing trailing comma with -hyphen not minus
+    ('"waffles and strawberries", @waffle, "whipped cream,"', ['waffles', 'and', 'strawberries', 'whipped', 'cream']), # testing trailing comma
+    ('"waffles and strawberries", @waffle, @"whipped cream,"', ['waffles', 'and', 'strawberries']), # testing trailing comma
 ]
+
+
+@pytest.mark.parametrize("search_string,expected", tokenize_name_test_data)
+def test_tokenize_name(search_string, expected):
+    response = SolrQueries._tokenize_name(search_string)
+
+    assert expected == response
+
 
 name_copy_test_data = [
     ('waffle corp', ''),
@@ -57,22 +83,62 @@ name_copy_test_data = [
 ]
 
 
-@pytest.mark.parametrize("name,expected", compress_name_test_data)
-def test_compress_name(name, expected):
-    response = SolrQueries()._compress_name(name)
-
-    assert expected == response
-
-
-@pytest.mark.parametrize("search_string,expected", tokenize_name_test_data)
-def test_tokenize_name(search_string, expected):
-    response = SolrQueries()._tokenize_name(search_string)
-
-    assert expected == response
-
-
 @pytest.mark.parametrize("search_string,expected", name_copy_test_data)
 def test_get_name_copy_clause(search_string, expected):
-    response = SolrQueries()._get_name_copy_clause(search_string)
+    response = SolrQueries._get_name_copy_clause(search_string)
 
     assert expected == response
+
+
+name_tokenize_data = [
+    ('three tokens', ['three', ' ', 'tokens']),
+    ('skinny garçon "puppy-records" ®',
+     ['skinny', ' ', 'gar', 'ç', 'on', ' ', '"', 'puppy', '-', 'records', '"', ' ', '®']),
+    ('skinny "puppy-records" ®',
+     ['skinny', ' ', '"', 'puppy', '-', 'records', '"', ' ', '®']),
+    ('waffle', ['waffle']),
+    (' waffle', [' ', 'waffle']),
+    ('waffle ', ['waffle', ' ']),
+    ('waffle mania', ['waffle', ' ', 'mania']),
+    (' waffle mania', [' ', 'waffle', ' ', 'mania']),
+    ('waffle mania ', ['waffle', ' ', 'mania', ' ']),
+]
+
+
+@pytest.mark.parametrize("name_string, expected", name_tokenize_data)
+def test_tokenz(name_string, expected):
+
+    response = SolrQueries._tokenize(name_string,
+                                     [string.digits,
+                                      string.whitespace,
+                                      RESERVED_CHARACTERS,
+                                      string.punctuation,
+                                      string.ascii_lowercase])
+
+    assert expected == response
+
+
+name_parse_data = [
+    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', '-', '"', 'records', '"'], ['skinny']),
+    (['skinny', ' ', '"', 'puppy', ' ', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', 'puppy', '-', 'records'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', 'puppy', ' ', '-', 'records'], ['skinny', 'puppy']),
+    (['skinny', ' ', '@', 'puppy'], ['skinny']),
+    (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"'], ['skinny']),
+    (['skinny', ' ', '@', '"', 'puppy', '-', 'records', '"'], ['skinny']),
+    (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"', 'chain'], ['skinny', 'chain']),
+    (['skinny', ' ', '@', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+]
+
+
+@pytest.mark.parametrize("tokens, expected", name_parse_data)
+def test_parse_for_synonym_candidates(tokens, expected):
+
+    synonym_candidates = SolrQueries._parse_for_synonym_candidates(tokens)
+
+    print (synonym_candidates)
+
+    assert expected == synonym_candidates
+

--- a/api/tests/python/solr/test_solr.py
+++ b/api/tests/python/solr/test_solr.py
@@ -1,0 +1,67 @@
+import urllib
+
+import pytest
+
+from namex.analytics.solr import SolrQueries, SYNONYMS_PREFIX, current_app
+from tests.python import integration_synonym_api
+
+
+solr_name_test_data = [
+    ('some name', 'somename', 'some%20name', 'some%20name'),
+    ('a longer name jesus and the mary chain'
+     ,'alongernamejesusandthemarychain'
+     ,'a%20longer%20name%20jesus%20and%20the%20mary%20chain'
+     ,'a%20longer%20name%20jesus%20and%20the%20mary%20chain'),
+]
+
+
+# setting this up as a parameterized test, maybe not needed to check permutations
+# if we do / need to do a more interesting thing for the synonyms call, the parameters will be handy
+@pytest.mark.parametrize("name, compresed_name, escaped_name, synonym_tokens", solr_name_test_data)
+def test_get_results_query_to_solr(mocker, monkeypatch, name, compresed_name, escaped_name, synonym_tokens):
+    """
+    This tests the creation of the query string sent to SOLR
+    as such, anything outside of that is not tested and ignored within this test
+    (eg. environment variable and getting synonym from other services are mocked out)
+    """
+    #
+    # SETUP for the test
+    #
+
+    #  patch out the calls made to get the SOLR environment variables
+    def mock_env(env_name, default):
+        if env_name == 'SOLR_BASE_URL':
+            return 'http://not_a_real_server_just_mock'
+
+        elif env_name == 'SOLR_SYNONYMS_API_URL':
+            return 'http://not_a_real_server_just_mock'
+
+        return default
+    monkeypatch.setattr(current_app.config, 'get', mock_env)
+
+    # patch out the call to the solr synonyms API
+    def mock_synonym(name_token):
+        return True
+    monkeypatch.setattr(SolrQueries, '_synonyms_exist', mock_synonym)
+
+    # The query string that should be created in the call to the Solr API
+    query = 'http://not_a_real_server_just_mock/solr/possible.conflicts/select?defType=edismax&hl.fl=name' \
+            '&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&hl=on&indent=on&q=' \
+            + compresed_name \
+            + '%20OR%20' \
+            + escaped_name \
+            + '&qf=name_compressed^6%20name_with_synonyms&wt=json' \
+              '&start=0&rows=10&fl=source,id,name,score&sort=score%20desc' \
+              '&fq=name_with_synonyms:(' \
+            + synonym_tokens \
+            + ')'
+
+    #
+    # ACTUAL TEST
+    #
+
+    # mock the urlopen call so that we can catch what is passed to it
+    # in the SolrQueries get_results method
+    mocker.patch('urllib.request.urlopen')
+    response = SolrQueries.get_results(SolrQueries.CONFLICTS, name)
+    urllib.request.urlopen.assert_called_once_with(query)

--- a/api/tests/python/util.py
+++ b/api/tests/python/util.py
@@ -16,5 +16,8 @@ integration_fdw_namex = pytest.mark.skipif((os.getenv('FDW_NAMEX_TESTS', False) 
 integration_solr = pytest.mark.skipif((os.getenv('SOLR_TESTS', False) is False),
                                       reason="requires access to Solr")
 
+integration_synonym_api = pytest.mark.skipif((os.getenv('SOLR_SYNONYM_TESTS', False) is False),
+                                      reason="requires access to Solr Synonym API")
+
 integration_nro_extractor = pytest.mark.skipif((os.getenv('NRO_EXTRACTOR_TESTS', False) is False),
                                                reason="requires access to nor-extractor via HTTPS POST/PUT")


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* bcgov/name-examination#1075

*Description of changes:*
Added a tokenizer that doesn't create as many temporary objects by using slices.
Broke it into a tokenizer and then a parser for synonyms. The tokenizer could be used for the other parsers as well.
Added tests for the 2 new methods
Added a test to confirm the query string that is sent to Solr is as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
