### PR TITLE
fixed what was passed to the tokenizer, as it is set for all lower case

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -245,14 +245,16 @@ class SolrQueries:
     # Look up each token in name, and if it is in the synonyms then we need to search for it separately.
     @classmethod
     def _get_synonyms_clause(cls, name):
+
+        current_app.logger.debug('getting synonyms for: {}'.format(name))
         clause = ''
         synonyms = []
 
-        tokens = cls._tokenize(name, [string.digits,
-                                      string.whitespace,
-                                      RESERVED_CHARACTERS,
-                                      string.punctuation,
-                                      string.ascii_lowercase])
+        tokens = cls._tokenize(name.lower(), [string.digits,
+                                              string.whitespace,
+                                              RESERVED_CHARACTERS,
+                                              string.punctuation,
+                                              string.ascii_lowercase])
         candidates = cls._parse_for_synonym_candidates(tokens)
         for token in candidates:
             if cls._synonyms_exist(token):

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -70,6 +70,7 @@ name_tokenize_data = [
     ('waffle mania', ['waffle', ' ', 'mania']),
     (' waffle mania', [' ', 'waffle', ' ', 'mania']),
     ('waffle mania ', ['waffle', ' ', 'mania', ' ']),
+    ("dave's auto services ltd.", ['dave', "'", 's', ' ', 'auto', ' ', 'services', ' ', 'ltd', '.']),
 ]
 
 

--- a/api/tests/python/solr/test_solr.py
+++ b/api/tests/python/solr/test_solr.py
@@ -65,3 +65,22 @@ def test_get_results_query_to_solr(mocker, monkeypatch, name, compresed_name, es
     mocker.patch('urllib.request.urlopen')
     response = SolrQueries.get_results(SolrQueries.CONFLICTS, name)
     urllib.request.urlopen.assert_called_once_with(query)
+
+
+solr_get_synonym_test_data = [
+    ("DAVE'S AUTO SERVICES LTD.", 'dave%20%27%20s%20auto%20services%20ltd%20.'),
+]
+
+
+@pytest.mark.parametrize("name, expected", solr_get_synonym_test_data)
+def test_solr__get_synonyms_clause(monkeypatch, name, expected):
+
+    def mock_solr__synonyms_exist(token):
+        return True
+    monkeypatch.setattr(SolrQueries, '_synonyms_exist', mock_solr__synonyms_exist)
+
+    syn = SolrQueries._get_synonyms_clause(name)
+
+    print (syn)
+
+    assert SYNONYMS_PREFIX+'(' + expected + ')' == syn


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* bcgov/namex#398

*Description of changes:*
The tokenizer scans for lower case, but it was being passed UPPER CASE ascii which it turned into a long list of singular tokens

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
