### PR TITLE
Roll back change to replace NR conflict with "NR 0000000"; clear data when pushing to Oracle only, replacing with "NR".

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -60,21 +60,6 @@ class Name(db.Model):
         # force uppercase names
         self.name = self.name.upper()
 
-        # remove NR numbers from conflicts - replace with generic NR number
-        # - this is for regulatory/privacy reasons
-        try:
-            if self.conflict1_num[0:2] == 'NR': self.conflict1_num = "NR 0000000"
-        except (TypeError, IndexError) as e:
-            pass
-        try:
-            if self.conflict2_num[0:2] == 'NR': self.conflict2_num = "NR 0000000"
-        except (TypeError, IndexError) as e:
-            pass
-        try:
-            if self.conflict3_num[0:2] == 'NR': self.conflict3_num = "NR 0000000"
-        except (TypeError, IndexError) as e:
-            pass
-
         db.session.add(self)
         db.session.commit()
 

--- a/api/tests/python/models/test_names.py
+++ b/api/tests/python/models/test_names.py
@@ -101,7 +101,7 @@ def test_name_update_via_save_to_db_method(session):
     assert name.id is not None
     assert name.id == name_id
     assert name.name == test_name.upper() # name should be uppercase
-    assert name.conflict1_num == "NR 0000000" # NR number conflicts should be replaced with NR 0000000
+    assert name.conflict1_num == "NR 0000001" # NR number conflicts should be unchanged
     assert name.conflict2_num == "A123456" # corp number conflicts should be unchanged
     assert name.conflict3_num in ("", None)
 

--- a/nro-update/nro/nro_datapump.py
+++ b/nro-update/nro/nro_datapump.py
@@ -41,11 +41,11 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
             )
 
         if name.conflict1:
-            nro_names[choice]['conflict1'] = '{}****{}'.format(name.conflict1_num[:10], name.conflict1[:150])
+            nro_names[choice]['conflict1'] = '{}****{}'.format(_clear_NR_num_from_conflict(name.conflict1_num[:10]), name.conflict1[:150])
         if name.conflict2:
-            nro_names[choice]['conflict2'] = '{}****{}'.format(name.conflict2_num[:10], name.conflict2[:150])
+            nro_names[choice]['conflict2'] = '{}****{}'.format(_clear_NR_num_from_conflict(name.conflict2_num[:10]), name.conflict2[:150])
         if name.conflict3:
-            nro_names[choice]['conflict3'] = '{}****{}'.format(name.conflict3_num[:10], name.conflict3[:150])
+            nro_names[choice]['conflict3'] = '{}****{}'.format(_clear_NR_num_from_conflict(name.conflict3_num[:10]), name.conflict3[:150])
 
         if name.comment:
             # use the last name comment as the examiner comment, whether that was a rejection or approval
@@ -91,3 +91,17 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=60):
     # and record the expiry date we sent to NRO
     nr.furnished = 'Y'
     nr.expirationDate = expiry_date
+
+def _clear_NR_num_from_conflict(conflict_num):
+    '''
+    Remove NR numbers from conflicts when pushing to Oracle - replace with "NR", this is for
+    regulatory/privacy reasons.
+    :param conflict_num:
+    :return: string - conflict_num
+    '''
+    try:
+        if conflict_num[:2] == 'NR': conflict_num = "NR"
+    except (TypeError, IndexError) as e:
+        pass
+
+    return conflict_num


### PR DESCRIPTION
*Issue #, if available:* bcgov/name-examination#1130

*Description of changes:*
Roll back change to replace NR conflict with "NR 0000000"; clear data when pushing to Oracle only, replacing with "NR".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
