### PR TITLE
remove the cancelled status; and set the default page size to 50 to s…

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -1020,7 +1020,7 @@ class Stats(Resource):
 
         # validate row & start params
         start = request.args.get('currentpage', 1)
-        rows = request.args.get('perpage', 100)
+        rows = request.args.get('perpage', 50)
 
         try:
             rows = int(rows)
@@ -1030,7 +1030,7 @@ class Stats(Resource):
             return jsonify({'message': 'paging parameters were not integers'}), 406
 
         q = RequestDAO.query \
-            .filter(RequestDAO.stateCd.in_(State.COMPLETED_STATE + [State.CANCELLED]))\
+            .filter(RequestDAO.stateCd.in_(State.COMPLETED_STATE))\
             .filter(RequestDAO.lastUpdate >= text('NOW() - INTERVAL \'{delay} HOURS\''.format(delay=timespan))) \
             .order_by(RequestDAO.lastUpdate.desc())
 


### PR DESCRIPTION
…peed up loading for registry staff

*Issue #, if available: bcgov/name-examination#1081*

*Description of changes:*
 - Remove "cancelled" from query condition.
 - Set default page size to 50 to speed up load time

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
