### PR TITLE
Solr: fixed NR expiry date logic. #1147

### DIFF
--- a/nro-legacy/sql/object/names/namex/view/solr_dataimport_conflicts_vw.sql
+++ b/nro-legacy/sql/object/names/namex/view/solr_dataimport_conflicts_vw.sql
@@ -17,7 +17,7 @@ AS
        AND rs.state_type_cd = 'COMPLETED'
        AND ns.name_state_type_cd IN ('A', 'C')
        AND ni.consumption_date IS NULL
-       AND TRUNC (ri.expiration_date) > TRUNC (SYSDATE)
+       AND TRUNC (ri.expiration_date) >= TRUNC (SYSDATE)
        AND ri.request_type_cd NOT IN
                ('CEM', 'CFR', 'CLL', 'CLP', 'FR', 'LIB', 'LL', 'LP', 'NON', 'PAR', 'RLY', 'TMY',
                 'XCLL', 'XCLP', 'XLL', 'XLP');

--- a/nro-legacy/sql/release/201810XX_solr_bugs/names/namex/create.sql
+++ b/nro-legacy/sql/release/201810XX_solr_bugs/names/namex/create.sql
@@ -1,0 +1,4 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+-- Fix the expiry date (#1147).
+@ ../../../../object/names/namex/view/solr_dataimport_conflicts_vw.sql


### PR DESCRIPTION
*Issue #, if available:* 1147

*Description of changes:* fixed the names view for conflicts, as it was excluding NRs that expire at the end of the current day.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
