### PR TITLE
Set the trademarks registration number to not be required. #1118

### DIFF
--- a/solr/cores/trademarks/conf/managed-schema
+++ b/solr/cores/trademarks/conf/managed-schema
@@ -123,7 +123,7 @@
     <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
 	
     <field name="application_number" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
-    <field name="registration_number" type="string" multiValued="false" indexed="false" required="true" stored="true"/>
+    <field name="registration_number" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="category" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="status" type="string" multiValued="false" indexed="false" required="false" stored="true"/>
     <field name="name" type="text_en_splitting" multiValued="false" indexed="true" required="false" stored="true"


### PR DESCRIPTION
*Issue #, if available:* 1118

*Description of changes:* Made the new field registration_number in the trademarks core to not be required. It only appears in around 75% of the records.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
