### PR TITLE
/exact_match now returns id, source, name for each entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,9 @@ solr/cores/.DS_Store
 */.pytest_cache
 .coverage
 .hypothesis
+
+# Solr core data
+#######################
+**/cores/**/data/index
+**/cores/**/data/tlog
+**/cores/**/core.properties

--- a/api/namex/resources/__init__.py
+++ b/api/namex/resources/__init__.py
@@ -4,6 +4,7 @@ from .requests import api as nr_api
 from .ops import api as nr_ops
 from .document_analysis import api as analysis_api
 from .meta import api as meta_api
+from .exact_match import api as exact_match_api
 
 
 # This will add the Authorize button to the swagger docs
@@ -28,3 +29,4 @@ api.add_namespace(nr_api, path='/requests')
 api.add_namespace(nr_ops, path='/nr-ops')
 api.add_namespace(analysis_api, path='/documents')
 api.add_namespace(meta_api, path='/meta')
+api.add_namespace(exact_match_api, path='/exact-match')

--- a/api/namex/resources/exact_match.py
+++ b/api/namex/resources/exact_match.py
@@ -1,0 +1,34 @@
+from flask import jsonify, request
+from flask_restplus import Resource, Namespace, cors
+from namex.utils.util import cors_preflight
+import requests
+import json
+from namex import jwt
+
+api = Namespace('exactMatchMeta', description='Exact Match System - Metadata')
+import os
+SOLR_URL = os.getenv('SOLR_BASE_URL')
+
+
+@cors_preflight("GET")
+@api.route("", methods=['GET', 'OPTIONS'])
+class ExactMatch(Resource):
+
+    @staticmethod
+    @cors.crossdomain(origin='*')
+    @jwt.requires_auth
+    def get():
+        query = request.args.get('query')
+        url = SOLR_URL + '/solr/possible.conflicts' + \
+              '/select?' + \
+              'sow=false' + \
+              '&df=name_exact_match' + \
+              '&wt=json' + \
+              '&q=' + query
+        results = requests.get(url)
+        text = results.text
+        answer = json.loads(text)
+        docs = answer['response']['docs']
+        names =[{ 'name':doc['name'], 'id':doc['id'], 'source':doc['source'] } for doc in docs ]
+
+        return jsonify({ 'names':names })

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -12,3 +12,4 @@ psycopg2-binary
 marshmallow
 marshmallow-sqlalchemy
 cx_Oracle
+requests

--- a/api/tests/python/end_points/test_exact_match.py
+++ b/api/tests/python/end_points/test_exact_match.py
@@ -1,0 +1,240 @@
+from namex.models import User
+import os
+import requests
+import json
+import pytest
+
+token_header = {
+                "alg": "RS256",
+                "typ": "JWT",
+                "kid": "flask-jwt-oidc-test-client"
+               }
+claims = {
+            "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/sbc",
+            "sub": "43e6a245-0bf7-4ccf-9bd0-e7fb85fd18cc",
+            "aud": "NameX-Dev",
+            "exp": 31531718745,
+            "iat": 1531718745,
+            "jti": "flask-jwt-oidc-test-support",
+            "typ": "Bearer",
+            "username": "test-user",
+            "realm_access": {
+                "roles": [
+                    "{}".format(User.EDITOR),
+                    "{}".format(User.APPROVER),
+                    "viewer",
+                    "user"
+                ]
+            }
+         }
+SOLR_URL = os.getenv('SOLR_TEST_URL')
+
+@pytest.fixture(scope="session", autouse=True)
+def reload_schema(request):
+    url = SOLR_URL + '/solr/admin/cores?action=RELOAD&core=possible.conflicts&wt=json'
+    r = requests.get(url)
+
+    assert r.status_code == 200
+
+def test_solr_available(app, client, jwt):
+    url = SOLR_URL + '/solr/possible.conflicts/admin/ping'
+    r = requests.get(url)
+
+    assert r.status_code == 200
+
+def clean_database(client, jwt):
+    url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
+    headers = {'content-type': 'text/xml'}
+    data = '<delete><query>id:*</query></delete>'
+    r = requests.post(url, headers=headers, data=data)
+
+    assert r.status_code == 200
+
+def seed_database_with(client, jwt, name, id='1', source='2'):
+    clean_database(client, jwt)
+    url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
+    headers = {'content-type': 'application/json'}
+    data = '[{"source":"' + source + '", "name":"' + name + '", "id":"'+ id +'"}]'
+    r = requests.post(url, headers=headers, data=data)
+
+    assert r.status_code == 200
+
+def verify(data, expected):
+    print(data['names'])
+
+    assert expected == data['names']
+
+def verify_exact_match_results(client, jwt, query, expected):
+    data = search_exact_match(client, jwt, query)
+    verify(data, expected)
+
+def verify_exact_match(client, jwt, query, expected):
+    data = search_exact_match(client, jwt, query)
+    expect = [
+        { 'name':expected, 'id':'1', 'source':'2' }
+    ]
+    if expected == None:
+        expect = []
+    verify(data, expect)
+
+def search_exact_match(client, jwt, query):
+    token = jwt.create_jwt(claims, token_header)
+    headers = {'Authorization': 'Bearer ' + token}
+    rv = client.get('/api/v1/exact-match?query='+query, headers=headers)
+
+    assert rv.status_code == 200
+    return json.loads(rv.data)
+
+def test_find_same_name(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+        query='JM Van Damme inc',
+        expected='JM Van Damme inc'
+    )
+
+def test_resists_different_type(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+        query='JM Van Damme ltd',
+        expected='JM Van Damme inc'
+    )
+
+def test_case_insensitive(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+        query='JM VAN DAMME INC',
+        expected='JM Van Damme inc'
+    )
+
+def test_no_match(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+        query='Hello BC inc',
+        expected=None
+    )
+
+def test_ignores_and(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+       query='J and M Van Damme inc',
+       expected='JM Van Damme inc'
+    )
+
+def test_ignores_dots(client, jwt, app):
+    seed_database_with(client, jwt, 'J.M. Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='J.M. Van Damme Inc'
+    )
+
+def test_ignores_ampersand(client, jwt, app):
+    seed_database_with(client, jwt, 'J&M & Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='J&M & Van Damme Inc'
+    )
+
+def test_ignores_comma(client, jwt, app):
+    seed_database_with(client, jwt, 'JM, Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='JM, Van Damme Inc'
+    )
+
+def test_ignores_exclamation_mark(client, jwt, app):
+    seed_database_with(client, jwt, 'JM! Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='JM! Van Damme Inc'
+    )
+
+def test_no_match_because_additional_initial(client, jwt, app):
+    seed_database_with(client, jwt, 'J.M.J. Van Damme Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='J.M. Van Damme Trucking Inc',
+       expected=None
+    )
+
+def test_no_match_because_additional_word(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Trucking International Inc',
+       expected=None
+    )
+
+def test_no_match_because_missing_one_word(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme Physio inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme inc',
+       expected=None
+    )
+
+def test_duplicated_letters(client, jwt, app):
+    seed_database_with(client, jwt, 'Damme Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='Dame Trucking Inc',
+       expected='Damme Trucking Inc'
+    )
+
+def test_entity_suffixes(client, jwt, app):
+    suffixes = [
+        'limited',
+        'ltd.',
+        'ltd',
+        'incorporated',
+        'inc',
+        'inc.',
+        'corporation',
+        'corp.',
+        'limitee',
+        'ltee',
+        'incorporee',
+        'llc',
+        'l.l.c.',
+        'limited liability company',
+        'limited liability co.',
+        'llp',
+        'limited liability partnership',
+        'societe a responsabilite limitee',
+        'societe en nom collectif a responsabilite limitee',
+        'srl',
+        'sencrl',
+        'ulc',
+        'unlimited liability company',
+        'association',
+        'assoc',
+        'assoc.',
+        'assn',
+        'co',
+        'co.',
+        'society',
+        'soc',
+        'soc.'
+    ]
+    for suffix in suffixes:
+        seed_database_with(client, jwt, 'Van Trucking ' + suffix)
+        verify_exact_match(client, jwt,
+           query='Van Trucking',
+           expected='Van Trucking ' + suffix
+        )
+
+def test_numbers_preserved(client, jwt, app):
+    seed_database_with(client, jwt, 'Van 4 Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='Van 4 Trucking ltd',
+       expected='Van 4 Trucking Inc'
+
+    )
+
+def test_returns_all_fields_that_we_need(client, jwt, app):
+    seed_database_with(client, jwt, 'Van Trucking Inc', 'any-id', 'any-source')
+    verify_exact_match_results(client, jwt,
+       query='Van Trucking ltd',
+       expected=[
+           {'name': 'Van Trucking Inc', 'id':'any-id', 'source':'any-source'}
+       ]
+    )
+
+
+
+

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -132,6 +132,7 @@
     <field name="name_with_synonyms" type="text_name_singular_synonyms" multiValued="false" indexed="true"
         stored="true"/>
     <field name="name_compressed" type="text_name_compressed" multiValued="false" indexed="true" stored="true"/>
+    <field name="name_exact_match" type="text_name_exact_match" multiValued="false" indexed="true" stored="true"/>
 
     <!-- Only enabled in the "schemaless" data-driven example (assuming the client
          does not know what fields may be searched) because it's very expensive to index everything twice. -->
@@ -707,6 +708,54 @@
       </analyzer>
     </fieldType>
 
+    <fieldType name="text_name_exact_match" class="solr.TextField" positionIncrementGap="100" multiValued="false">
+      <analyzer>
+          <tokenizer class="solr.KeywordTokenizerFactory" />
+
+          <filter class="solr.LowerCaseFilterFactory"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability company"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability co."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability partnership"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" societe a responsabilite limitee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" societe en nom collectif a responsabilite limitee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" incorporee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" unlimited liability company"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ltd."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ltd"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" incorporated"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" inc."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" inc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" corporation"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" corp."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limitee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ltee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" llc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" llp"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" l.l.c."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" srl"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" sencrl"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ulc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" association"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" assoc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" assoc."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" assn"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" co"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" co."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" society"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" soc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" soc."  replacement="" replace="all" />
+
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" and "  replacement="" replace="all" />
+
+          <filter class="solr.PatternReplaceFilterFactory" pattern="(\.)" replacement="" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="(,)" replacement="" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="(\!)" replacement="" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="(&amp;)" replacement="" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="([a-z]|\s)\1+" replacement="$1" replace="all"/>
+      </analyzer>
+    </fieldType>
+
     <!-- some examples for different languages (generally ordered by ISO code) -->
 
     <!-- Arabic -->
@@ -1136,4 +1185,5 @@
     <copyField source="name" dest="name_copy"/>
     <copyField source="name" dest="name_with_synonyms"/>
     <copyField source="name" dest="name_compressed"/>
+    <copyField source="name" dest="name_exact_match"/>
 </schema>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
a new end point to fetch the exact matches for a name.
Call is tlike /exact-match?query=incredible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
