### PR TITLE
1159 - we now handle more complex cases

### DIFF
--- a/api/namex/resources/exact_match.py
+++ b/api/namex/resources/exact_match.py
@@ -1,9 +1,9 @@
 from flask import jsonify, request
 from flask_restplus import Resource, Namespace, cors
 from namex.utils.util import cors_preflight
-import requests
 import json
 from namex import jwt
+import urllib
 
 api = Namespace('exactMatchMeta', description='Exact Match System - Metadata')
 import os
@@ -24,10 +24,10 @@ class ExactMatch(Resource):
               'sow=false' + \
               '&df=name_exact_match' + \
               '&wt=json' + \
-              '&q=' + query
-        results = requests.get(url)
-        text = results.text
-        answer = json.loads(text)
+              '&q=' + urllib.parse.quote(query)
+        print(url)
+        connection = urllib.request.urlopen(url)
+        answer = json.loads(connection.read())
         docs = answer['response']['docs']
         names =[{ 'name':doc['name'], 'id':doc['id'], 'source':doc['source'] } for doc in docs ]
 

--- a/api/namex/resources/exact_match.py
+++ b/api/namex/resources/exact_match.py
@@ -4,6 +4,7 @@ from namex.utils.util import cors_preflight
 import json
 from namex import jwt
 import urllib
+from flask import current_app
 
 api = Namespace('exactMatchMeta', description='Exact Match System - Metadata')
 import os
@@ -25,7 +26,7 @@ class ExactMatch(Resource):
               '&df=name_exact_match' + \
               '&wt=json' + \
               '&q=' + urllib.parse.quote(query)
-        print(url)
+        current_app.logger.debug('Exact-match query: ' + url)
         connection = urllib.request.urlopen(url)
         answer = json.loads(connection.read())
         docs = answer['response']['docs']

--- a/api/requirements/dev.txt
+++ b/api/requirements/dev.txt
@@ -13,3 +13,4 @@ flake8-docstrings
 flake8-isort
 flake8-quotes
 pep8-naming
+requests

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -12,4 +12,3 @@ psycopg2-binary
 marshmallow
 marshmallow-sqlalchemy
 cx_Oracle
-requests

--- a/api/tests/python/end_points/test_exact_match.py
+++ b/api/tests/python/end_points/test_exact_match.py
@@ -3,6 +3,8 @@ import os
 import requests
 import json
 import pytest
+from tests.python import integration_solr
+import urllib
 
 token_header = {
                 "alg": "RS256",
@@ -36,6 +38,7 @@ def reload_schema(request):
 
     assert r.status_code == 200
 
+@integration_solr
 def test_solr_available(app, client, jwt):
     url = SOLR_URL + '/solr/possible.conflicts/admin/ping'
     r = requests.get(url)
@@ -80,11 +83,14 @@ def verify_exact_match(client, jwt, query, expected):
 def search_exact_match(client, jwt, query):
     token = jwt.create_jwt(claims, token_header)
     headers = {'Authorization': 'Bearer ' + token}
-    rv = client.get('/api/v1/exact-match?query='+query, headers=headers)
+    url = '/api/v1/exact-match?query=' + urllib.parse.quote(query)
+    print(url)
+    rv = client.get(url, headers=headers)
 
     assert rv.status_code == 200
     return json.loads(rv.data)
 
+@integration_solr
 def test_find_same_name(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme inc')
     verify_exact_match(client, jwt,
@@ -92,6 +98,7 @@ def test_find_same_name(client, jwt, app):
         expected='JM Van Damme inc'
     )
 
+@integration_solr
 def test_resists_different_type(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme inc')
     verify_exact_match(client, jwt,
@@ -99,6 +106,7 @@ def test_resists_different_type(client, jwt, app):
         expected='JM Van Damme inc'
     )
 
+@integration_solr
 def test_case_insensitive(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme inc')
     verify_exact_match(client, jwt,
@@ -106,6 +114,7 @@ def test_case_insensitive(client, jwt, app):
         expected='JM Van Damme inc'
     )
 
+@integration_solr
 def test_no_match(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme inc')
     verify_exact_match(client, jwt,
@@ -113,6 +122,7 @@ def test_no_match(client, jwt, app):
         expected=None
     )
 
+@integration_solr
 def test_ignores_and(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme inc')
     verify_exact_match(client, jwt,
@@ -120,6 +130,7 @@ def test_ignores_and(client, jwt, app):
        expected='JM Van Damme inc'
     )
 
+@integration_solr
 def test_ignores_dots(client, jwt, app):
     seed_database_with(client, jwt, 'J.M. Van Damme Inc')
     verify_exact_match(client, jwt,
@@ -127,6 +138,7 @@ def test_ignores_dots(client, jwt, app):
        expected='J.M. Van Damme Inc'
     )
 
+@integration_solr
 def test_ignores_ampersand(client, jwt, app):
     seed_database_with(client, jwt, 'J&M & Van Damme Inc')
     verify_exact_match(client, jwt,
@@ -134,6 +146,7 @@ def test_ignores_ampersand(client, jwt, app):
        expected='J&M & Van Damme Inc'
     )
 
+@integration_solr
 def test_ignores_comma(client, jwt, app):
     seed_database_with(client, jwt, 'JM, Van Damme Inc')
     verify_exact_match(client, jwt,
@@ -141,6 +154,7 @@ def test_ignores_comma(client, jwt, app):
        expected='JM, Van Damme Inc'
     )
 
+@integration_solr
 def test_ignores_exclamation_mark(client, jwt, app):
     seed_database_with(client, jwt, 'JM! Van Damme Inc')
     verify_exact_match(client, jwt,
@@ -148,6 +162,7 @@ def test_ignores_exclamation_mark(client, jwt, app):
        expected='JM! Van Damme Inc'
     )
 
+@integration_solr
 def test_no_match_because_additional_initial(client, jwt, app):
     seed_database_with(client, jwt, 'J.M.J. Van Damme Trucking Inc')
     verify_exact_match(client, jwt,
@@ -155,6 +170,7 @@ def test_no_match_because_additional_initial(client, jwt, app):
        expected=None
     )
 
+@integration_solr
 def test_no_match_because_additional_word(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme Trucking Inc')
     verify_exact_match(client, jwt,
@@ -162,6 +178,7 @@ def test_no_match_because_additional_word(client, jwt, app):
        expected=None
     )
 
+@integration_solr
 def test_no_match_because_missing_one_word(client, jwt, app):
     seed_database_with(client, jwt, 'JM Van Damme Physio inc')
     verify_exact_match(client, jwt,
@@ -169,6 +186,7 @@ def test_no_match_because_missing_one_word(client, jwt, app):
        expected=None
     )
 
+@integration_solr
 def test_duplicated_letters(client, jwt, app):
     seed_database_with(client, jwt, 'Damme Trucking Inc')
     verify_exact_match(client, jwt,
@@ -176,6 +194,7 @@ def test_duplicated_letters(client, jwt, app):
        expected='Damme Trucking Inc'
     )
 
+@integration_solr
 def test_entity_suffixes(client, jwt, app):
     suffixes = [
         'limited',
@@ -218,6 +237,7 @@ def test_entity_suffixes(client, jwt, app):
            expected='Van Trucking ' + suffix
         )
 
+@integration_solr
 def test_numbers_preserved(client, jwt, app):
     seed_database_with(client, jwt, 'Van 4 Trucking Inc')
     verify_exact_match(client, jwt,
@@ -226,6 +246,7 @@ def test_numbers_preserved(client, jwt, app):
 
     )
 
+@integration_solr
 def test_returns_all_fields_that_we_need(client, jwt, app):
     seed_database_with(client, jwt, 'Van Trucking Inc', 'any-id', 'any-source')
     verify_exact_match_results(client, jwt,
@@ -233,6 +254,21 @@ def test_returns_all_fields_that_we_need(client, jwt, app):
        expected=[
            {'name': 'Van Trucking Inc', 'id':'any-id', 'source':'any-source'}
        ]
+    )
+
+@integration_solr
+@pytest.mark.parametrize("criteria, seed", [
+    ('J M HOLDINGS', 'J M HOLDINGS INC'),
+    ('JM Van Damme Inc', 'J&M & Van Damme Inc'),
+    ('J&M HOLDINGS', 'JM HOLDINGS INC'),
+    ('J. & M. HOLDINGS', 'JM HOLDINGS INC'),
+    ('J and M HOLDINGS', 'J. & M. HOLDINGS')
+])
+def test_explore_complex_cases(client, jwt, app, criteria, seed):
+    seed_database_with(client, jwt, seed)
+    verify_exact_match(client, jwt,
+       query=criteria,
+       expected=seed
     )
 
 

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -753,7 +753,8 @@
           <filter class="solr.PatternReplaceFilterFactory" pattern="(,)" replacement="" replace="all"/>
           <filter class="solr.PatternReplaceFilterFactory" pattern="(\!)" replacement="" replace="all"/>
           <filter class="solr.PatternReplaceFilterFactory" pattern="(&amp;)" replacement="" replace="all"/>
-          <filter class="solr.PatternReplaceFilterFactory" pattern="([a-z]|\s)\1+" replacement="$1" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="([a-z])\1+" replacement="$1" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="\s" replacement="" replace="all"/>
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use urllib in prod
explore writing tests the @pytest.mark.parametrize way
handle more exact-match cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
