### PR TITLE
better fix for issue #18

### DIFF
--- a/colin-api/app/resources/corporations.py
+++ b/colin-api/app/resources/corporations.py
@@ -146,7 +146,9 @@ class Methods(Resource):
     def build_addr_id_sql(corp_num_sql):
         return text("select delivery_addr_id "
                     "from bc_registries.office_vw "
-                    "where corp_num={} and end_event_id IS NULL;".format(corp_num_sql))
+                    "where corp_num={} "
+                    "and end_event_id IS NULL "
+                    "and delivery_addr_id IS NOT NULL;".format(corp_num_sql))
 
     @staticmethod
     def build_jurisdiction_sql(corp_num_sql):

--- a/colin-api/tests/unit/conftest.py
+++ b/colin-api/tests/unit/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-
+import os
 from app import create_app
 from config import TestConfig
-import sys, os
+from flask_sqlalchemy import SQLAlchemy
 
 
 @pytest.fixture(scope="session")
-def app(request):
+def app():
     """
     Returns session-wide application.
     """
@@ -33,8 +33,20 @@ def client_ctx(app):
 
 
 @pytest.fixture(scope="session")
-def db():
-    from flask_sqlalchemy import SQLAlchemy
+def fake_names_db(app):
+    user = os.getenv('FAKE_NAMES_DATABASE_USERNAME', '')
+    password = os.getenv('FAKE_NAMES_DATABASE_PASSWORD', '')
+    name = os.getenv('FAKE_NAMES_DATABASE_NAME', '')
+    host = os.getenv('FAKE_NAMES_DATABASE_HOST', '')
+    port = os.getenv('FAKE_NAMES_DATABASE_PORT', '5432')
+    SQLALCHEMY_DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
+        user=user,
+        password=password,
+        host=host,
+        port=port,
+        name=name,
+    )
     db = SQLAlchemy()
+    app.config['SQLALCHEMY_DATABASE_URI'] = SQLALCHEMY_DATABASE_URI
 
     return db

--- a/colin-api/tests/unit/conftest.py
+++ b/colin-api/tests/unit/conftest.py
@@ -30,3 +30,11 @@ def client_ctx(app):
     """
     with app.test_client() as c:
         yield c
+
+
+@pytest.fixture(scope="session")
+def db():
+    from flask_sqlalchemy import SQLAlchemy
+    db = SQLAlchemy()
+
+    return db

--- a/colin-api/tests/unit/test_addr_id_sql.py
+++ b/colin-api/tests/unit/test_addr_id_sql.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 
 
 @pytest.fixture(autouse=True)
-def given(db):
+def given(fake_names_db):
     background = [
         'drop schema if exists bc_registries cascade;',
         'create schema bc_registries;',
@@ -17,7 +17,7 @@ def given(db):
         """
     ]
     for sql in background:
-        db.engine.execute(sql)
+        fake_names_db.engine.execute(sql)
 
 
 def insert(addr_id, end_event_id, corp_num):
@@ -29,24 +29,24 @@ def insert(addr_id, end_event_id, corp_num):
         corp_num
     ))
 
-def test_ignores_past_addresses(app, db):
-    db.engine.execute(insert(addr_id='1', end_event_id='1', corp_num='12345'))
+def test_ignores_past_addresses(app, fake_names_db):
+    fake_names_db.engine.execute(insert(addr_id='1', end_event_id='1', corp_num='12345'))
     sql = Methods.build_addr_id_sql('\'12345\'')
-    result = db.engine.execute(sql).fetchall()
+    result = fake_names_db.engine.execute(sql).fetchall()
 
     assert [] == result
 
-def test_return_current_addresses(app, db):
-    db.engine.execute(insert(addr_id='1', end_event_id=None, corp_num='12345'))
-    db.engine.execute(insert('2', None, '12345'))
+def test_return_current_addresses(app, fake_names_db):
+    fake_names_db.engine.execute(insert(addr_id='1', end_event_id=None, corp_num='12345'))
+    fake_names_db.engine.execute(insert('2', None, '12345'))
     sql = Methods.build_addr_id_sql('\'12345\'')
-    result = db.engine.execute(sql).fetchall()
+    result = fake_names_db.engine.execute(sql).fetchall()
 
     assert 2 == len(result)
 
-def test_ignores_empty_address(app, db):
-    db.engine.execute(insert(addr_id=None, end_event_id=None, corp_num='12345'))
+def test_ignores_empty_address(app, fake_names_db):
+    fake_names_db.engine.execute(insert(addr_id=None, end_event_id=None, corp_num='12345'))
     sql = Methods.build_addr_id_sql('\'12345\'')
-    result = db.engine.execute(sql).fetchall()
+    result = fake_names_db.engine.execute(sql).fetchall()
 
     assert [] == result

--- a/colin-api/tests/unit/test_addr_id_sql.py
+++ b/colin-api/tests/unit/test_addr_id_sql.py
@@ -1,0 +1,52 @@
+from app.resources.corporations import Methods
+import pytest
+from sqlalchemy import text
+
+
+@pytest.fixture(autouse=True)
+def given(db):
+    background = [
+        'drop schema if exists bc_registries cascade;',
+        'create schema bc_registries;',
+        """
+        create table bc_registries.office_vw(
+            delivery_addr_id    varchar(1),
+            end_event_id        varchar(1),
+            corp_num            varchar(10)
+        );
+        """
+    ]
+    for sql in background:
+        db.engine.execute(sql)
+
+
+def insert(addr_id, end_event_id, corp_num):
+    return text("insert into bc_registries.office_vw"
+                "(delivery_addr_id, end_event_id, corp_num)"
+                "values({}, {}, {})".format(
+        addr_id if addr_id!=None else 'NULL',
+        end_event_id if end_event_id!=None else 'NULL',
+        corp_num
+    ))
+
+def test_ignores_past_addresses(app, db):
+    db.engine.execute(insert(addr_id='1', end_event_id='1', corp_num='12345'))
+    sql = Methods.build_addr_id_sql('\'12345\'')
+    result = db.engine.execute(sql).fetchall()
+
+    assert [] == result
+
+def test_return_current_addresses(app, db):
+    db.engine.execute(insert(addr_id='1', end_event_id=None, corp_num='12345'))
+    db.engine.execute(insert('2', None, '12345'))
+    sql = Methods.build_addr_id_sql('\'12345\'')
+    result = db.engine.execute(sql).fetchall()
+
+    assert 2 == len(result)
+
+def test_ignores_empty_address(app, db):
+    db.engine.execute(insert(addr_id=None, end_event_id=None, corp_num='12345'))
+    sql = Methods.build_addr_id_sql('\'12345\'')
+    result = db.engine.execute(sql).fetchall()
+
+    assert [] == result

--- a/nro-legacy/sql/object/registry/namex/view/office_vw.sql
+++ b/nro-legacy/sql/object/registry/namex/view/office_vw.sql
@@ -15,9 +15,7 @@ AS
     SELECT corp_num, office_typ_cd, start_event_id,
             end_event_id, mailing_addr_id, delivery_addr_id,
            dd_corp_num, email_address
-      FROM office
-      WHERE delivery_addr_id is not null
-            and end_event_id is null;
+      FROM office;
 
 
 DROP PUBLIC SYNONYM OFFICE_VW;

--- a/nro-legacy/tests/postgres.py
+++ b/nro-legacy/tests/postgres.py
@@ -13,8 +13,8 @@ class Postgres(object):
             with connection.cursor() as cursor:
                 cursor.execute(sql, values)
 
-    def selectFirst(self, sql):
+    def select(self, sql):
         with psycopg2.connect(host='localhost',dbname=self.database, user=self.user, password=self.password) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(sql)
-                return cursor.fetchone()
+                return cursor.fetchall()

--- a/nro-legacy/tests/test_office_vw.py
+++ b/nro-legacy/tests/test_office_vw.py
@@ -34,7 +34,7 @@ def before_each():
     Postgres().execute(open('tests/sql/create.table.office.sql').read())
 
 
-def test_select_current_office():
+def test_select_current_addresses():
     Postgres().execute("""
         insert into office(
             corp_num, 
@@ -46,14 +46,8 @@ def test_select_current_office():
             dd_corp_num, 
             email_address
         )
-        values ('1', '1', '1', null, '1', '1', '1', '1')
+        values ('1', '1', '1', '1', '1', '1', '1', '1')
     """)
-    result = Postgres().selectFirst(extract_select())
-
-    assert_that(result[0], equal_to('1'))
-
-
-def test_ignores_null_delivery_address():
     Postgres().execute("""
             insert into office(
                 corp_num, 
@@ -65,27 +59,9 @@ def test_ignores_null_delivery_address():
                 dd_corp_num, 
                 email_address
             )
-            values ('1', '1', '1', '1', '1', null, '1', '1')
+            values ('2', '2', '2', '2', '2', '2', '2', '2')
         """)
-    result = Postgres().selectFirst(extract_select())
+    result = Postgres().select(extract_select())
 
-    assert_that(result, equal_to(None))
+    assert_that(len(result), equal_to(2))
 
-
-def test_ignores_historical_address():
-    Postgres().execute("""
-            insert into office(
-                corp_num, 
-                office_typ_cd, 
-                start_event_id, 
-                end_event_id, 
-                mailing_addr_id, 
-                delivery_addr_id,
-                dd_corp_num, 
-                email_address
-            )
-            values ('1', '1', '1', '1', '1', '1', '1', '1')
-        """)
-    result = Postgres().selectFirst(extract_select())
-
-    assert_that(result, equal_to(None))


### PR DESCRIPTION
*Description of changes:*
We now implement the [not null delivery_addr_id and null end_event_id] in the api instead of in the oracle view

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
