### PR TITLE
Added UTF8 encoding to the CPRD Solr package. #2

### DIFF
--- a/nro-legacy/sql/object/registry/namex/package/solr_pkb.sql
+++ b/nro-legacy/sql/object/registry/namex/package/solr_pkb.sql
@@ -1,6 +1,6 @@
 -- noinspection SqlNoDataSourceInspectionForFile
 
-CREATE OR REPLACE PACKAGE BODY NAMEX.solr AS
+CREATE OR REPLACE PACKAGE BODY solr AS
     -- Action Types
     ACTION_UPDATE CONSTANT VARCHAR2(1) := 'U';
     ACTION_DELETE CONSTANT VARCHAR2(1) := 'D';
@@ -72,6 +72,9 @@ CREATE OR REPLACE PACKAGE BODY NAMEX.solr AS
                 'destination_url';
 
         content := generate_json_conflicts(nr_number, action);
+
+        -- Convert the content to UTF-8, so that accented characters, etc, are handled.
+        content := CONVERT(content, 'UTF8');
 
         -- At some point it would make sense to move the ReST stuff out of here and into somewhere re-usable.
         utl_http.set_wallet(oracle_wallet);

--- a/nro-legacy/sql/release/201810XX_solr_bugs/registry/namex/create.sql
+++ b/nro-legacy/sql/release/201810XX_solr_bugs/registry/namex/create.sql
@@ -1,0 +1,4 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+-- Fix the accented character handling (#1138).
+@ ../../../../object/registry/namex/package/solr_pkb.sql


### PR DESCRIPTION
*Issue #, if available:* 2

*Description of changes:* UTF8 encoding was previously added to the solr package in NAMESP, but not CPRD. Adding it there, as names are stuck sending to Solr.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
