### PR TITLE
12 solr tuning manual search

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -66,6 +66,20 @@ class SolrQueries:
             return None, 'Internal server error', 500
 
         try:
+            # TODO: these should be loaded from somewhere.
+            designations = [
+                'corp.', 'corporation', 'inc.', 'incorporated', 'incorporee', 'l.l.c.', 'limited',
+                'limited liability co.', 'limited liability company', 'limited liability partnership', 'limitee', 'llc',
+                'llp', 'ltd.', 'ltee', 'sencrl', 'societe a responsabilite limitee',
+                'societe en nom collectif a responsabilite limitee', 'srl','ulc', 'unlimited liability company']
+
+            for designation in designations:
+                index = name.upper().find(' ' + designation.upper())
+                # checks if there is a designation AND if that designation is at the end of the string
+                if index != -1 and (index + len(designation)+1) is len(name):
+                    name = name[:index]
+                    break
+
             name = name.replace('&',' ').replace('+', '')
             list_name_split = name.split()
             combined_terms = ''

--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -39,7 +39,8 @@ class SolrQueries:
         SYN_CONFLICTS:
             '/solr/possible.conflicts/select?hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&'
             'hl=on&indent=on&q=txt_starts_with:{start_str}&wt=json&'
-            'start={start}&rows={rows}&fl=source,id,name,score&sort=score%20desc{synonyms_clause}{name_copy_clause}',
+            'start={start}&rows={rows}&fl=source,id,name,score&sort=score%20desc,txt_starts_with%20asc{synonyms_clause}'
+            '{name_copy_clause}',
         CONFLICTS:
             '/solr/possible.conflicts/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&'
             'hl=on&indent=on&q={compressed_name}%20OR%20{name}&qf=name_compressed^6%20name_with_synonyms&wt=json&'

--- a/api/namex/resources/exact_match.py
+++ b/api/namex/resources/exact_match.py
@@ -20,7 +20,7 @@ class ExactMatch(Resource):
     @jwt.requires_auth
     def get():
         query = request.args.get('query')
-        query = query.lower()
+        query = query.lower().replace('*','')
         url = SOLR_URL + '/solr/possible.conflicts' + \
               '/select?' + \
               'sow=false' + \

--- a/api/requirements/dev.txt
+++ b/api/requirements/dev.txt
@@ -4,6 +4,7 @@
 # Testing
 pytest
 pytest-mock
+requests
 
 # Lint and code style
 flake8

--- a/api/tests/python/end_points/test_exact_match.py
+++ b/api/tests/python/end_points/test_exact_match.py
@@ -195,6 +195,14 @@ def test_no_match_because_missing_one_word(client, jwt, app):
     )
 
 @integration_solr
+def test_no_match_star(client, jwt, app):
+    seed_database_with(client, jwt, 'SCHOLARSHIP')
+    verify_exact_match(client, jwt,
+       query='SCHOL*',
+       expected=None
+    )
+
+@integration_solr
 def test_duplicated_letters(client, jwt, app):
     seed_database_with(client, jwt, 'Damme Trucking Inc')
     verify_exact_match(client, jwt,

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -1,0 +1,309 @@
+from namex.models import User
+import os
+import requests
+import json
+import pytest
+from tests.python import integration_solr, integration_synonym_api
+import urllib
+
+token_header = {
+                "alg": "RS256",
+                "typ": "JWT",
+                "kid": "flask-jwt-oidc-test-client"
+               }
+claims = {
+            "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/sbc",
+            "sub": "43e6a245-0bf7-4ccf-9bd0-e7fb85fd18cc",
+            "aud": "NameX-Dev",
+            "exp": 31531718745,
+            "iat": 1531718745,
+            "jti": "flask-jwt-oidc-test-support",
+            "typ": "Bearer",
+            "username": "test-user",
+            "realm_access": {
+                "roles": [
+                    "{}".format(User.EDITOR),
+                    "{}".format(User.APPROVER),
+                    "viewer",
+                    "user"
+                ]
+            }
+         }
+SOLR_URL = os.getenv('SOLR_TEST_URL')
+SOLR_SYNONYMS_API_URL = os.getenv('SOLR_SYNONYMS_API_URL')
+
+@pytest.fixture(scope="session", autouse=True)
+def reload_schema(request):
+    url = SOLR_URL + '/solr/admin/cores?action=RELOAD&core=possible.conflicts&wt=json'
+    r = requests.get(url)
+
+    assert r.status_code == 200
+
+@integration_solr
+def test_solr_available(app, client, jwt):
+    url = SOLR_URL + '/solr/possible.conflicts/admin/ping'
+    r = requests.get(url)
+
+    assert r.status_code == 200
+
+def clean_database(client, jwt):
+    url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
+    headers = {'content-type': 'text/xml'}
+    data = '<delete><query>id:*</query></delete>'
+    r = requests.post(url, headers=headers, data=data)
+
+    assert r.status_code == 200
+
+def seed_database_with(client, jwt, name, id='1', source='2'):
+    clean_database(client, jwt)
+    url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
+    headers = {'content-type': 'application/json'}
+    data = '[{"source":"' + source + '", "name":"' + name + '", "id":"'+ id +'"}]'
+    r = requests.post(url, headers=headers, data=data)
+
+    assert r.status_code == 200
+
+def verify(data, expected):
+    print(data['names'])
+
+    assert expected == data['names']
+
+def verify_synonym_match_results(client, jwt, query, expected):
+    data = search_synonym_match(client, jwt, query)
+    verify(data, expected)
+
+def verify_synonym_match(client, jwt, query, expected):
+    data = search_synonym_match(client, jwt, query)
+    expect = [
+        { 'name':expected, 'id':'1', 'source':'2' }
+    ]
+    if expected == None:
+        expect = []
+    verify(data, expect)
+
+def search_synonym_match(client, jwt, query):
+    token = jwt.create_jwt(claims, token_header)
+    headers = {'Authorization': 'Bearer ' + token}
+    url = '/api/v1/requests/synonymbucket/' + query
+    print(url)
+    rv = client.get(url, headers=headers)
+
+    assert rv.status_code == 200
+    return json.loads(rv.data)
+
+@integration_synonym_api
+@integration_solr
+def test_find_same_name(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_synonym_match(client, jwt,
+        query='JM',
+        expected='[----JM*,JM]'
+    )
+
+@integration_synonym_api
+@integration_solr
+def test_resist_empty(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_synonym_match(client, jwt,
+        query='',
+        expected=None
+    )
+
+# @integration_solr
+# def test_case_insensitive(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM Van Damme inc')
+#     verify_synonym_match(client, jwt,
+#         query='JM VAN DAMME INC',
+#         expected='JM Van Damme inc'
+#     )
+#
+# @integration_solr
+# def test_no_match(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM Van Damme inc')
+#     verify_synonym_match(client, jwt,
+#         query='Hello BC inc',
+#         expected=None
+#     )
+#
+# @integration_solr
+# def test_ignores_and(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM Van Damme inc')
+#     verify_synonym_match(client, jwt,
+#        query='J and M Van Damme inc',
+#        expected='JM Van Damme inc'
+#     )
+#
+# @integration_solr
+# def test_ignores_dots(client, jwt, app):
+#     seed_database_with(client, jwt, 'J.M. Van Damme Inc')
+#     verify_synonym_match(client, jwt,
+#        query='JM Van Damme Inc',
+#        expected='J.M. Van Damme Inc'
+#     )
+#
+# @integration_solr
+# def test_ignores_ampersand(client, jwt, app):
+#     seed_database_with(client, jwt, 'J&M & Van Damme Inc')
+#     verify_synonym_match(client, jwt,
+#        query='JM Van Damme Inc',
+#        expected='J&M & Van Damme Inc'
+#     )
+#
+# @integration_solr
+# def test_ignores_comma(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM, Van Damme Inc')
+#     verify_synonym_match(client, jwt,
+#        query='JM Van Damme Inc',
+#        expected='JM, Van Damme Inc'
+#     )
+#
+# @integration_solr
+# def test_ignores_exclamation_mark(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM! Van Damme Inc')
+#     verify_synonym_match(client, jwt,
+#        query='JM Van Damme Inc',
+#        expected='JM! Van Damme Inc'
+#     )
+#
+# @integration_solr
+# def test_no_match_because_additional_initial(client, jwt, app):
+#     seed_database_with(client, jwt, 'J.M.J. Van Damme Trucking Inc')
+#     verify_synonym_match(client, jwt,
+#        query='J.M. Van Damme Trucking Inc',
+#        expected=None
+#     )
+#
+# @integration_solr
+# def test_no_match_because_additional_word(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM Van Damme Trucking Inc')
+#     verify_synonym_match(client, jwt,
+#        query='JM Van Damme Trucking International Inc',
+#        expected=None
+#     )
+#
+# @integration_solr
+# def test_no_match_because_missing_one_word(client, jwt, app):
+#     seed_database_with(client, jwt, 'JM Van Damme Physio inc')
+#     verify_synonym_match(client, jwt,
+#        query='JM Van Damme inc',
+#        expected=None
+#     )
+#
+# @integration_solr
+# def test_duplicated_letters(client, jwt, app):
+#     seed_database_with(client, jwt, 'Damme Trucking Inc')
+#     verify_synonym_match(client, jwt,
+#        query='Dame Trucking Inc',
+#        expected='Damme Trucking Inc'
+#     )
+#
+# @integration_solr
+# def test_entity_suffixes(client, jwt, app):
+#     suffixes = [
+#         'limited',
+#         'ltd.',
+#         'ltd',
+#         'incorporated',
+#         'inc',
+#         'inc.',
+#         'corporation',
+#         'corp.',
+#         'limitee',
+#         'ltee',
+#         'incorporee',
+#         'llc',
+#         'l.l.c.',
+#         'limited liability company',
+#         'limited liability co.',
+#         'llp',
+#         'limited liability partnership',
+#         'societe a responsabilite limitee',
+#         'societe en nom collectif a responsabilite limitee',
+#         'srl',
+#         'sencrl',
+#         'ulc',
+#         'unlimited liability company',
+#         'association',
+#         'assoc',
+#         'assoc.',
+#         'assn',
+#         'co',
+#         'co.',
+#         'society',
+#         'soc',
+#         'soc.'
+#     ]
+#     for suffix in suffixes:
+#         seed_database_with(client, jwt, 'Van Trucking ' + suffix)
+#         verify_synonym_match(client, jwt,
+#            query='Van Trucking',
+#            expected='Van Trucking ' + suffix
+#         )
+#
+# @integration_solr
+# def test_numbers_preserved(client, jwt, app):
+#     seed_database_with(client, jwt, 'Van 4 Trucking Inc')
+#     verify_synonym_match(client, jwt,
+#        query='Van 4 Trucking ltd',
+#        expected='Van 4 Trucking Inc'
+#
+#     )
+#
+# @integration_solr
+# @pytest.mark.parametrize("criteria, seed", [
+#     ('J M HOLDINGS', 'J M HOLDINGS INC'),
+#     ('JM Van Damme Inc', 'J&M & Van Damme Inc'),
+#     ('J&M HOLDINGS', 'JM HOLDINGS INC'),
+#     ('J. & M. HOLDINGS', 'JM HOLDINGS INC'),
+#     ('J and M HOLDINGS', 'J and M HOLDINGS'),
+#     ('J AND M HOLDINGS', 'J AND M HOLDINGS'),
+#     ('J or M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J-M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J\'M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J_M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J_\'_-M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J@M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J=M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J!M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J!=@_M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J+M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J\M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('GREAT NORTH OIL AND GAS LIMITED', 'GREAT NORTH OIL AND GAS LIMITED')
+# ])
+# def test_explore_complex_cases(client, jwt, app, criteria, seed):
+#     seed_database_with(client, jwt, seed)
+#     verify_synonym_match(client, jwt,
+#        query=criteria,
+#        expected=seed
+#     )
+#
+# @integration_solr
+# def test_returns_all_fields_that_we_need(client, jwt, app):
+#     seed_database_with(client, jwt, 'Van Trucking Inc', 'any-id', 'any-source')
+#     verify_synonym_match_results(client, jwt,
+#        query='Van Trucking ltd',
+#        expected=[
+#            {'name': 'Van Trucking Inc', 'id':'any-id', 'source':'any-source'}
+#        ]
+#     )
+#
+#
+# @pytest.mark.skip(reason="dont know how to make solr handle those scenarios")
+# @integration_solr
+# @pytest.mark.parametrize("criteria, seed", [
+#     ('{JM} HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('[JM] HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('(JM) HOLDINGS', 'J.M HOLDINGS'),
+#     ('J^M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J~M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J*M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J:M HOLDINGS', 'J. & M. HOLDINGS'),
+#     ('J?M HOLDINGS', 'J. & M. HOLDINGS')
+# ])
+# def test_special_characters(client, jwt, app, criteria, seed):
+#     seed_database_with(client, jwt, seed)
+#     verify_synonym_match(client, jwt,
+#        query=criteria,
+#        expected=seed
+#     )
+

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -759,8 +759,10 @@
 
     <fieldType name="txt_starts_with" class="solr.TextField">
         <analyzer type="index">
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,]*" replacement="" />
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([a-z]{3,})(s\W|s$)" replacement="$1" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s([a-z])\s" replacement="$1$2$3 " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s" replacement="$1$2 " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z]{2})\s" replacement="$1$2 " />
@@ -769,8 +771,10 @@
             <tokenizer class="solr.KeywordTokenizerFactory"/>
         </analyzer>
         <analyzer type="query">
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,]*" replacement="" />
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([a-z]{3,})(s\W|s$)" replacement="$1" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s([a-z])\s" replacement="$1$2$3 " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s" replacement="$1$2 " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z]{2})\s" replacement="$1$2 " />

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -759,27 +759,80 @@
 
     <fieldType name="txt_starts_with" class="solr.TextField">
         <analyzer type="index">
-            <filter class="solr.LowerCaseFilterFactory"/>
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([a-z]{3,})(s\W|s$)" replacement="$1" />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s([a-z])\s" replacement="$1$2$3 " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s" replacement="$1$2 " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z]{2})\s" replacement="$1$2 " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z]{2})\s([a-z])\s" replacement="$1$2 " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(([A-Z]|[a-z]){3,})(S\W|S$)" replacement="$1" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="((^|\W)(and|AND)(\W|$))" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(an|AN)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(are|ARE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(as|AS)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(at|AT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(be|BE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(but|BUT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(by|BY)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(for|FOR)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(if|IF)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(in|IN)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(into|INTO)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(is|IS)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(it|IT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(no|NO)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(not|NOT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(of|OF)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(on|ON)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(or|OR)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(such|SUCH)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(that|THAT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(the|THE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(their|THEIR)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(then|THEN)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(there|THERE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(these|THESE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(they|THEY)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(this|THIS)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(to|TO)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([A-Z]|[a-z])\1" replacement="$1" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s" replacement="" />
+            <filter class="solr.LowerCaseFilterFactory"/>
             <tokenizer class="solr.KeywordTokenizerFactory"/>
         </analyzer>
         <analyzer type="query">
-            <filter class="solr.LowerCaseFilterFactory"/>
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([a-z]{3,})(s\W|s$)" replacement="$1" />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s([a-z])\s" replacement="$1$2$3 " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z])\s" replacement="$1$2 " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z])\s([a-z]{2})\s" replacement="$1$2 " />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([a-z]{2})\s([a-z])\s" replacement="$1$2 " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(([A-Z]|[a-z]){3,})(S\W|S$)" replacement="$1" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="((^|\W(and|AND)\W|$))" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(and|AND)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(an|AN)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(are|ARE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(as|AS)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(at|AT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(be|BE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(but|BUT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(by|BY)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(for|FOR)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(if|IF)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(in|IN)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(into|INTO)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(is|IS)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(it|IT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(no|NO)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(not|NOT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(of|OF)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(on|ON)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(or|OR)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(such|SUCH)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(that|THAT)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(the|THE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(their|THEIR)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(then|THEN)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(there|THERE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(these|THESE)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(they|THEY)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(this|THIS)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(to|TO)\W|$)" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([A-Z]|[a-z])\1" replacement="$1" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s" replacement="" />
+            <filter class="solr.LowerCaseFilterFactory"/>
             <tokenizer class="solr.KeywordTokenizerFactory"/>
         </analyzer>
     </fieldType>


### PR DESCRIPTION
*Issue #, if available:bcgov/entity#12*

*Description of changes:*
- solr tuning on synonym bucket call + exact match call
       - synonym bucket:
       - stop words, s, ', designations (if at the end), double letters
       - exact match:
       - removal of * 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
