### PR TITLE
fix situation where Request exists in NameX but not NRO

### DIFF
--- a/api/namex/services/nro/oracle_services.py
+++ b/api/namex/services/nro/oracle_services.py
@@ -273,7 +273,9 @@ class NROServices(object):
                 nr.stateCd = State.NRO_UPDATING
                 nr.save_to_db()
 
-                nr = self.fetch_nro_request_and_copy_to_namex_request(user, nr_number=nr.nrNum, name_request=nr)
+                nrf = self.fetch_nro_request_and_copy_to_namex_request(user, nr_number=nr.nrNum, name_request=nr)
+                if nrf:
+                    nr = nrf
                 nr.stateCd = nr_saved_state
                 nr.save_to_db()
                 EventRecorder.record(user, Event.UPDATE_FROM_NRO, nr, {})

--- a/api/tests/python/end_points/test_requests.py
+++ b/api/tests/python/end_points/test_requests.py
@@ -50,6 +50,27 @@ def test_get_next(client, jwt, app):
     assert b'"nameRequest": "NR 0000001"' in rv.data
 
 
+def test_get_next_no_draft_avail(client, jwt, app):
+
+    # add NR to database
+    from namex.models import Request as RequestDAO, State
+    nr = RequestDAO()
+    nr.nrNum='NR 0000001'
+    nr.stateCd = State.APPROVED
+    nr.save_to_db()
+
+    # create JWT & setup header with a Bearer Token using the JWT
+    token = jwt.create_jwt(claims, token_header)
+    headers = {'Authorization': 'Bearer ' + token}
+
+    # get the resource (this is the test)
+    rv = client.get('/api/v1/requests/queues/@me/oldest', headers=headers)
+
+    # should return 404, not found
+    assert 404 == rv.status_code
+
+
+
 def test_get_next_oldest(client, jwt, app):
 
     # add NR to database

--- a/api/tests/python/nro_services/test_nro_services.py
+++ b/api/tests/python/nro_services/test_nro_services.py
@@ -110,6 +110,21 @@ def test_move_control_of_request_from_nro_missing_nr(app, session):
 
     assert warnings is not None
 
+def test_move_control_of_existing_request_from_nro_missing_nr(app, session):
+
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+    user.save_to_db()
+    nr = Request()
+    nr.nrNum = 'NR 9999999'
+    nr.stateCd = State.INPROGRESS
+    nr.nroLastUpdate = EPOCH_DATETIME
+    nr.userId = user.id
+    nr.save_to_db()
+
+    warnings = nro.move_control_of_request_from_nro(nr, user)
+
+    assert warnings is not None
+
 
 @integration_oracle_namesdb
 def test_get_nr_header(app):


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* bcgov/entity#56

*Description of changes:*
added check for when NR exists in NameX, but not NRO. Probably only happens in non-prod environments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
