### PR TITLE
fix job name in run.sh

### DIFF
--- a/jobs/nro-extractor/run.sh
+++ b/jobs/nro-extractor/run.sh
@@ -6,5 +6,5 @@ export PATH=/opt/app-root/bin:/opt/rh/rh-python35/root/usr/bin::/opt/rh/httpd24/
 
 cd /opt/app-root/src
 echo 'run nro_extractor'
-/opt/app-root/bin/python job.py
+/opt/app-root/bin/python nro_extractor.py
 


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* n/a

*Description of changes:*
changed job target in run.sh from job.py to nro_extractor.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
