### PR TITLE
31 - Additional change re. setting back to DRAFT.

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -393,10 +393,14 @@ class Request(Resource):
                 if not services.name_request.valid_state_transition(user, nrd, state):
                     return jsonify(message='you are not authorized to make these changes'), 401
 
-                # if the user has an existing (different) INPROGRESS NR, put it on hold
+                # if the user has an existing (different) INPROGRESS NR, revert to previous state (default to HOLD)
                 existing_nr = RequestDAO.get_inprogress(user)
                 if existing_nr:
-                    existing_nr.stateCd = State.HOLD
+                    if existing_nr.previousStateCd:
+                        existing_nr.stateCd = existing_nr.previousStateCd
+                        existing_nr.previousStateCd = None
+                    else:
+                        existing_nr.stateCd = State.HOLD
                     existing_nr.save_to_db()
 
                 # if the NR is in DRAFT then LOGICALLY lock the record in NRO


### PR DESCRIPTION
*Issue #, if available:* bcgov/namex#31

*Description of changes:*
31 - Additional change re. setting back to DRAFT - when is mid-edit and navigates away to another NR and starts exam/edit (makes it their new INPROGRESS NR).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
