### PR TITLE
Add multi-word concatenation to the synonyms list

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -302,7 +302,27 @@ class SolrQueries:
 
             previous_token = token
 
+        candidates.extend(cls._get_multiples(candidates))
+
         return candidates
+
+
+    @classmethod
+    def _get_multiples(cls, candidates):
+
+        if len(candidates) < 2:
+            return []
+
+        multiples = []
+
+        for x in range(len(candidates)):
+            if x < len(candidates) - 1:
+                multiples.append("".join(candidates[x:x+2]))
+                if x < len(candidates) - 2:
+                    multiples.append("".join(candidates[x:x+3]))
+
+        return multiples
+
 
     # Call the synonyms API for the given token.
     @classmethod

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -275,6 +275,21 @@ def test_duplicated_letters(client, jwt, app):
        expected_list=None
     )
 
+
+@integration_synonym_api
+@integration_solr
+def test_multi_word_synonyms(client, jwt, app):
+    seed_database_with(client, jwt, "Imagine Four Whole Words")
+    verify_synonym_match(client, jwt,
+                         query="Imagine Four Whole Words",
+                         expected_list=[
+                             '----IMAGINE FOUR WHOLE WORDS* ',
+                             '----IMAGINE FOUR WHOLE* synonyms:(words)',
+                             '----IMAGINE FOUR* synonyms:(whole, words, wholewords)',
+                             '----IMAGINE* synonyms:(four, whole, words, fourwhole, fourwholewords, wholewords)'
+                         ])
+
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -88,17 +88,17 @@ def test_tokenz(name_string, expected):
 
 
 name_parse_data = [
-    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records', 'skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
     (['skinny', ' ', '-', '"', 'records', '"'], ['skinny']),
-    (['skinny', ' ', '"', 'puppy', ' ', 'records', '"'], ['skinny', 'puppy', 'records']),
-    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
-    (['skinny', ' ', 'puppy', '-', 'records'], ['skinny', 'puppy', 'records']),
-    (['skinny', ' ', 'puppy', ' ', '-', 'records'], ['skinny', 'puppy']),
+    (['skinny', ' ', '"', 'puppy', ' ', 'records', '"'], ['skinny', 'puppy', 'records','skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
+    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records','skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
+    (['skinny', ' ', 'puppy', '-', 'records'], ['skinny', 'puppy', 'records','skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
+    (['skinny', ' ', 'puppy', ' ', '-', 'records'], ['skinny', 'puppy','skinnypuppy']),
     (['skinny', ' ', '@', 'puppy'], ['skinny']),
     (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"'], ['skinny']),
     (['skinny', ' ', '@', '"', 'puppy', '-', 'records', '"'], ['skinny']),
-    (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"', 'chain'], ['skinny', 'chain']),
-    (['skinny', ' ', '@', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"', 'chain'], ['skinny', 'chain', 'skinnychain']),
+    (['skinny', ' ', '@', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records', 'skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
 ]
 
 


### PR DESCRIPTION
*Issue # bcgov/entity#52*

*Description of changes:*
To support finding synonyms that consist of more than one word, such as "Four two zero" matching "Cannabis". 
Solution @kialj876 and I collaborated on was to concatenate multi-word synonyms and add them to the list of single word synonyms.  So now, for a name like "Joes four two zero" instead of searching just for *four, two, zero* we search for *four, two, zero, fourtwo, fourtwozero, twozero*

- Wrote tests for expected output from synonym search
- Made the tests pass by updating the solr api method that finds synonym candidates from the name tokens
- Updated related tests that started to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
