### PR TITLE
Issue #60 substitute like cobrs

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -302,7 +302,27 @@ class SolrQueries:
 
             previous_token = token
 
+        candidates.extend(cls._get_multiples(candidates))
+
         return candidates
+
+
+    @classmethod
+    def _get_multiples(cls, candidates):
+
+        if len(candidates) < 2:
+            return []
+
+        multiples = []
+
+        for x in range(len(candidates)):
+            if x < len(candidates) - 1:
+                multiples.append("".join(candidates[x:x+2]))
+                if x < len(candidates) - 2:
+                    multiples.append("".join(candidates[x:x+3]))
+
+        return multiples
+
 
     # Call the synonyms API for the given token.
     @classmethod

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -275,6 +275,21 @@ def test_duplicated_letters(client, jwt, app):
        expected_list=None
     )
 
+
+@integration_synonym_api
+@integration_solr
+def test_multi_word_synonyms(client, jwt, app):
+    seed_database_with(client, jwt, "Imagine Four Whole Words")
+    verify_synonym_match(client, jwt,
+                         query="Imagine Four Whole Words",
+                         expected_list=[
+                             '----IMAGINE FOUR WHOLE WORDS* ',
+                             '----IMAGINE FOUR WHOLE* synonyms:(words)',
+                             '----IMAGINE FOUR* synonyms:(whole, words, wholewords)',
+                             '----IMAGINE* synonyms:(four, whole, words, fourwhole, fourwholewords, wholewords)'
+                         ])
+
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [

--- a/api/tests/python/solr/test_query_string.py
+++ b/api/tests/python/solr/test_query_string.py
@@ -88,17 +88,17 @@ def test_tokenz(name_string, expected):
 
 
 name_parse_data = [
-    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records', 'skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
     (['skinny', ' ', '-', '"', 'records', '"'], ['skinny']),
-    (['skinny', ' ', '"', 'puppy', ' ', 'records', '"'], ['skinny', 'puppy', 'records']),
-    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
-    (['skinny', ' ', 'puppy', '-', 'records'], ['skinny', 'puppy', 'records']),
-    (['skinny', ' ', 'puppy', ' ', '-', 'records'], ['skinny', 'puppy']),
+    (['skinny', ' ', '"', 'puppy', ' ', 'records', '"'], ['skinny', 'puppy', 'records','skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
+    (['skinny', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records','skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
+    (['skinny', ' ', 'puppy', '-', 'records'], ['skinny', 'puppy', 'records','skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
+    (['skinny', ' ', 'puppy', ' ', '-', 'records'], ['skinny', 'puppy','skinnypuppy']),
     (['skinny', ' ', '@', 'puppy'], ['skinny']),
     (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"'], ['skinny']),
     (['skinny', ' ', '@', '"', 'puppy', '-', 'records', '"'], ['skinny']),
-    (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"', 'chain'], ['skinny', 'chain']),
-    (['skinny', ' ', '@', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records']),
+    (['skinny', ' ', '@', '"', 'puppy', ' ', 'records', '"', 'chain'], ['skinny', 'chain', 'skinnychain']),
+    (['skinny', ' ', '@', ' ', '"', 'puppy', '-', 'records', '"'], ['skinny', 'puppy', 'records', 'skinnypuppy', 'skinnypuppyrecords', 'puppyrecords']),
 ]
 
 

--- a/api/tests/python/solr/test_solr.py
+++ b/api/tests/python/solr/test_solr.py
@@ -7,11 +7,11 @@ from tests.python import integration_synonym_api
 
 
 solr_name_test_data = [
-    ('some name', 'somename', 'some%20name', 'some%20name'),
+    ('some name', 'somename', 'some%20name', 'some%20name%20somename'),
     ('a longer name jesus and the mary chain'
      ,'alongernamejesusandthemarychain'
      ,'a%20longer%20name%20jesus%20and%20the%20mary%20chain'
-     ,'a%20longer%20name%20jesus%20and%20the%20mary%20chain'),
+     ,'a%20longer%20name%20jesus%20and%20the%20mary%20chain%20alonger%20alongername%20longername%20longernamejesus%20namejesus%20namejesusand%20jesusand%20jesusandthe%20andthe%20andthemary%20themary%20themarychain%20marychain'),
 ]
 
 
@@ -68,7 +68,7 @@ def test_get_results_query_to_solr(mocker, monkeypatch, name, compresed_name, es
 
 
 solr_get_synonym_test_data = [
-    ("DAVE'S AUTO SERVICES LTD.", 'dave%20%27%20s%20auto%20services%20ltd%20.'),
+    ("DAVE'S AUTO SERVICES LTD.", 'dave%20%27%20s%20auto%20services%20ltd%20.%20dave%27%20dave%27s%20%27s%20%27sauto%20sauto%20sautoservices%20autoservices%20autoservicesltd%20servicesltd%20servicesltd.%20ltd.'),
 ]
 
 

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -714,6 +714,10 @@
           <tokenizer class="solr.KeywordTokenizerFactory" />
 
           <filter class="solr.LowerCaseFilterFactory"/>
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\s+)(\$+(\s+|$))+" replacement="$1dollar$3" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\$" replacement="s" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\s+)(¢+(\s+|$))+" replacement="$1cent$3" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\¢" replacement="c" />
           <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability company"  replacement="" replace="all" />
           <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability co."  replacement="" replace="all" />
           <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability partnership"  replacement="" replace="all" />
@@ -759,7 +763,11 @@
 
     <fieldType name="txt_starts_with" class="solr.TextField">
         <analyzer type="index">
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\s+)(\$+(\s+|$))+" replacement="$1DOLLAR$3" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\$" replacement="S" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\s+)(¢+(\s+|$))+" replacement="$1CENT$3" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\¢" replacement="C" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(([A-Z]|[a-z]){3,})(S\W|S$|s\W|s$)" replacement="$1" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="((^|\W)(and|AND)(\W|$))" replacement=" " />
@@ -797,8 +805,11 @@
             <tokenizer class="solr.KeywordTokenizerFactory"/>
         </analyzer>
         <analyzer type="query">
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\$\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />
-            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\s+)(\$+(\s+|$))+" replacement="$1DOLLAR$3" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\$" replacement="S" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\s+)(¢+(\s+|$))+" replacement="$1CENT$3" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\¢" replacement="C" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\']*" replacement="" />            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(([A-Z]|[a-z]){3,})(S\W|S$|s\W|s$)" replacement="$1" />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="((^|\W(and|AND)\W|$))" replacement=" " />
             <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^|\W(and|AND)\W|$)" replacement=" " />


### PR DESCRIPTION
*Issue #, if available: bcgov/entity#60* 

*Description of changes:*

- Update the solr schema index analyzer for any words with $ and ¢ symbols, within the exact_match and the txt_starts_with 'buckets'
- For good measure, update the query analyzer for the txt_starts_with bucket
- Updated broken tests from the multi-word synonym changes.

** TO GO WITH THIS, bcgov/entity#67

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
