### PR TITLE
set expiry date based on utc storage, and us/pacific enforcement time

### DIFF
--- a/api/migrations/versions/84ea2594fc08_.py
+++ b/api/migrations/versions/84ea2594fc08_.py
@@ -1,0 +1,27 @@
+"""empty message
+
+Revision ID: 84ea2594fc08
+Revises: 75b6e6ecfde9
+Create Date: 2018-12-17 10:05:35.807701
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '84ea2594fc08'
+down_revision = '75b6e6ecfde9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        table_name='requests',
+        column_name='expiration_date',
+        type_=sa.TIMESTAMP(timezone=True)
+    )
+
+def downgrade():
+    pass

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -32,7 +32,7 @@ class Request(db.Model):
     requestTypeCd = db.Column('request_type_cd', db.String(10))
     priorityCd = db.Column('priority_cd', db.String(2))
     priorityDate = db.Column('priority_date', db.DateTime)
-    expirationDate = db.Column('expiration_date', db.DateTime)
+    expirationDate = db.Column('expiration_date', db.DateTime(timezone=True))
     consentFlag = db.Column('consent_flag', db.String(1))
     additionalInfo = db.Column('additional_info', db.String(150))
     natureBusinessInfo = db.Column('nature_business_info', db.String(1000))

--- a/jobs/nro-update/requirements/prod.txt
+++ b/jobs/nro-update/requirements/prod.txt
@@ -4,5 +4,6 @@ python-dotenv
 
 Flask
 Flask-SQLAlchemy
+pytz
 
 git+https://github.com/bcgov/namex.git#egg=namex&subdirectory=api


### PR DESCRIPTION
Signed-off-by: Thor Wolpert <thor@wolpert.ca>

*Issue #, if available:* bcgov/entity#50

*Description of changes:*
api: Altered the storage params for Request.expiry_date to be stored with timezone 
nro-update: added new func to calculate expiry date, updated tests to check for before/after 4pm PST to ensure the correct PST date is set. Check that the correct date is being sent to NRO.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
