### PR TITLE
bug-fix for synonyms

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -362,7 +362,7 @@ class SolrQueries:
     # Look up each token in name, and if it is in the synonyms then we need to search for it separately.
     @classmethod
     def _get_synonyms_clause(cls, name):
-
+        name = name.replace('  ', ' ').replace('  ', ' ')
         current_app.logger.debug('getting synonyms for: {}'.format(name))
         clause = ''
         synonyms = []

--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -6,6 +6,7 @@ from typing import List
 from flask import current_app
 from urllib import request, parse
 from urllib.error import HTTPError
+import re
 
 
 # Use this character in the search strings to indicate that the word should not by synonymized.
@@ -362,7 +363,7 @@ class SolrQueries:
     # Look up each token in name, and if it is in the synonyms then we need to search for it separately.
     @classmethod
     def _get_synonyms_clause(cls, name):
-        name = name.replace('  ', ' ').replace('  ', ' ')
+        name = re.sub(' +', ' ', name)
         current_app.logger.debug('getting synonyms for: {}'.format(name))
         clause = ''
         synonyms = []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- multiple spaces between words in a name caused synonyms being returned in brackets to have weird behavour <- fixed by replacing multiple spaces with a single space

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
