### PR TITLE
#77 compress search name

### DIFF
--- a/api/namex/services/nro/change_nr.py
+++ b/api/namex/services/nro/change_nr.py
@@ -13,6 +13,7 @@
 """
 
 from flask import current_app
+from .utils import generate_compressed_name
 
 def update_nr (nr, ora_cursor, change_flags):
     """Update the Name Request in NRO
@@ -182,13 +183,13 @@ def _update_nro_names(oracle_cursor, nr, event_id, change_flags):
 
             oracle_cursor.execute("""
             INSERT INTO name_instance (name_instance_id, name_id, choice_number, name, start_event_id, search_name)
-            VALUES (name_instance_seq.nextval, :name_id, :choice, :search_name, :event_id, :name)
+            VALUES (name_instance_seq.nextval, :name_id, :choice, :name, :event_id, :search_name)
             """,
                                   name_id=n_id,
                                   choice=name.choice,
                                   name=name.name,
                                   event_id=event_id,
-                                  search_name=name.name)
+                                  search_name=generate_compressed_name(name.name))
 
 def _update_nro_address(oracle_cursor, nr, event_id, change_flags):
     """find the current address (request_party), set it's end_event_id to event_id

--- a/api/namex/services/nro/utils.py
+++ b/api/namex/services/nro/utils.py
@@ -1,11 +1,10 @@
 
-
 def nro_examiner_name(examiner_name): #-> (str)
     """returns an examiner name, formated and tuncated to fit in NRO
     :examiner_name (str): an examiner name, as found in NameX
     :returns (str): an examiner name that is 7 or less chars in length
     """
-    #namex examiner_names are {domain}{/}{username}
+    # namex examiner_names are {domain}{/}{username}
     start = examiner_name.find('/')+1
     return examiner_name[start:start+7]
 
@@ -41,3 +40,68 @@ def validNRFormat(nr):
         return False
 
     return True
+
+
+def generate_compressed_name(original_name):
+
+    # Removing all instances of "THE " and " THE "; no need to removed " THE".
+    def _delete_the(in_name):
+        out_name = in_name
+        if len(in_name) > 4:
+            if in_name[:4] == "THE ":
+                out_name = in_name[4:]
+
+            out_name = out_name.replace(" THE ", "")
+
+        return out_name
+
+    def _remove_char(in_name):
+        chars = set('ABCDEFGHIJKLMNOPQRSTUVWXYZ#&0123456789')
+
+        out_name = in_name
+
+        for c in out_name:
+            if not (c in chars):
+                out_name = out_name.replace(c, "")
+
+        return out_name
+
+    def _translate_char(in_name):
+        out_name = in_name.replace('&', 'AND')
+        out_name = out_name.replace('#', 'NUMBER')
+        out_name = out_name.replace('1', 'ONE')
+        out_name = out_name.replace('2', 'TWO')
+        out_name = out_name.replace('3', 'THREE')
+        out_name = out_name.replace('4', 'FOUR')
+        out_name = out_name.replace('5', 'FIVE')
+        out_name = out_name.replace('6', 'SIX')
+        out_name = out_name.replace('7', 'SEVEN')
+        out_name = out_name.replace('8', 'EIGHT')
+        out_name = out_name.replace('9', 'NINE')
+        out_name = out_name.replace('0', 'ZERO')
+        return out_name
+
+    def _translate_bc(in_name):
+        out_name = in_name
+        if len(in_name) > 15:
+            if "BRITISHCOLUMBIA" in in_name[:15]:
+                out_name = in_name[:15].replace("BRITISHCOLUMBIA", "BC") + in_name[15:]
+
+        return out_name
+
+    def _truncate(in_name):
+        out_name = in_name
+        if len(in_name) > 30:
+            out_name = in_name[:30]
+
+        return out_name
+
+    result_name = original_name.strip().upper()
+    result_name = _delete_the(result_name)
+    result_name = result_name.replace(" ", "")
+    result_name = _remove_char(result_name)
+    result_name = _translate_char(result_name)
+    result_name = _translate_bc(result_name)
+    result_name = _truncate(result_name)
+
+    return result_name

--- a/api/namex/services/nro/utils.py
+++ b/api/namex/services/nro/utils.py
@@ -1,5 +1,7 @@
+import re
 
-def nro_examiner_name(examiner_name): #-> (str)
+
+def nro_examiner_name(examiner_name):  # -> (str)
     """returns an examiner name, formated and tuncated to fit in NRO
     :examiner_name (str): an examiner name, as found in NameX
     :returns (str): an examiner name that is 7 or less chars in length
@@ -42,8 +44,12 @@ def validNRFormat(nr):
     return True
 
 
-def generate_compressed_name(original_name):
-
+def generate_compressed_name(original_name: str) -> str:
+    """
+    returns a compressed name, formatted and truncated to fit in NRO
+    :param original_name : a company full name
+    :return: (str): a compressed name
+    """
     # Removing all instances of "THE " and " THE "; no need to removed " THE".
     def _delete_the(in_name):
         out_name = in_name
@@ -58,50 +64,39 @@ def generate_compressed_name(original_name):
     def _remove_char(in_name):
         chars = set('ABCDEFGHIJKLMNOPQRSTUVWXYZ#&0123456789')
 
-        out_name = in_name
-
-        for c in out_name:
-            if not (c in chars):
-                out_name = out_name.replace(c, "")
-
-        return out_name
+        return ''.join([c for c in in_name if c in chars])
 
     def _translate_char(in_name):
-        out_name = in_name.replace('&', 'AND')
-        out_name = out_name.replace('#', 'NUMBER')
-        out_name = out_name.replace('1', 'ONE')
-        out_name = out_name.replace('2', 'TWO')
-        out_name = out_name.replace('3', 'THREE')
-        out_name = out_name.replace('4', 'FOUR')
-        out_name = out_name.replace('5', 'FIVE')
-        out_name = out_name.replace('6', 'SIX')
-        out_name = out_name.replace('7', 'SEVEN')
-        out_name = out_name.replace('8', 'EIGHT')
-        out_name = out_name.replace('9', 'NINE')
-        out_name = out_name.replace('0', 'ZERO')
-        return out_name
 
-    def _translate_bc(in_name):
-        out_name = in_name
-        if len(in_name) > 15:
-            if "BRITISHCOLUMBIA" in in_name[:15]:
-                out_name = in_name[:15].replace("BRITISHCOLUMBIA", "BC") + in_name[15:]
+        rep = {"&": "AND",
+               "#": "NUMBER",
+               "1": "ONE",
+               "2": "TWO",
+               "3": "THREE",
+               "4": "FOUR",
+               "5": "FIVE",
+               "6": "SIX",
+               "7": "SEVEN",
+               "8": "EIGHT",
+               "9": "NINE",
+               "0": "ZERO"}  # define desired replacements here
 
-        return out_name
+        rep = dict((re.escape(k), v) for k, v in rep.items())
+        pattern = re.compile("|".join(rep.keys()))
 
-    def _truncate(in_name):
-        out_name = in_name
-        if len(in_name) > 30:
-            out_name = in_name[:30]
-
-        return out_name
+        return pattern.sub(lambda m: rep[re.escape(m.group(0))], in_name)
 
     result_name = original_name.strip().upper()
     result_name = _delete_the(result_name)
     result_name = result_name.replace(" ", "")
     result_name = _remove_char(result_name)
     result_name = _translate_char(result_name)
-    result_name = _translate_bc(result_name)
-    result_name = _truncate(result_name)
+
+    if result_name.startswith("BRITISHCOLUMBIA"):
+        result_name = result_name.replace("BRITISHCOLUMBIA", "BC", 1)
+
+    result_name = result_name[:30]  # Maximum 30 chars
 
     return result_name
+
+

--- a/api/tests/python/nro_services/test_nro_utils.py
+++ b/api/tests/python/nro_services/test_nro_utils.py
@@ -14,6 +14,12 @@ testdata = [
 ]
 
 
+@pytest.mark.parametrize("username,expected", testdata)
+def test_nro_examiner_name(username, expected):
+    en = utils.nro_examiner_name(username)
+    assert expected == en
+
+
 compress_name_test_data = [
     ('the Waffle the Mania the', 'WAFFLEMANIATHE'),
     ('the Waffle 123 the Mania the', 'WAFFLEONETWOTHREEMANIATHE'),
@@ -22,12 +28,6 @@ compress_name_test_data = [
     ('the Waffle & the Mania the', 'WAFFLEANDMANIATHE'),
     ('BRITISHCOLUMBIA the Waffle the Mania BRITISHCOLUMBIA the', 'BCWAFFLEMANIABRITISHCOLUMBIATH')
 ]
-
-
-@pytest.mark.parametrize("username,expected", testdata)
-def test_nro_examiner_name(username, expected):
-    en = utils.nro_examiner_name(username)
-    assert expected == en
 
 
 @pytest.mark.parametrize("original_name,expected", compress_name_test_data)

--- a/api/tests/python/nro_services/test_nro_utils.py
+++ b/api/tests/python/nro_services/test_nro_utils.py
@@ -14,7 +14,24 @@ testdata = [
 ]
 
 
+compress_name_test_data = [
+    ('the Waffle the Mania the', 'WAFFLEMANIATHE'),
+    ('the Waffle 123 the Mania the', 'WAFFLEONETWOTHREEMANIATHE'),
+    ('the Waffle !@$%^*()_+{}:"?><,./;[]\| the Mania the', 'WAFFLEMANIATHE'),
+    ('the Waffle #$ the Mania the', 'WAFFLENUMBERMANIATHE'),
+    ('the Waffle & the Mania the', 'WAFFLEANDMANIATHE'),
+    ('BRITISHCOLUMBIA the Waffle the Mania BRITISHCOLUMBIA the', 'BCWAFFLEMANIABRITISHCOLUMBIATH')
+]
+
+
 @pytest.mark.parametrize("username,expected", testdata)
 def test_nro_examiner_name(username, expected):
     en = utils.nro_examiner_name(username)
     assert expected == en
+
+
+@pytest.mark.parametrize("original_name,expected", compress_name_test_data)
+def test_nro_generate_compressed_name(original_name, expected):
+    result_name = utils.generate_compressed_name(original_name)
+    assert expected == result_name
+


### PR DESCRIPTION
Issue # bcgov/entity#77
If a name is edited in NAMEX, the NAMESP.NAMESDB.name_instance.search_name value is not being set to the "compressed" or "search" name. This means that if the user does a name search in NRO, the proper name requests are not being found.

Soultion:

Add a compressed name function into utils.py;
--Set uppercase;
--Remove "THE "and " THE ";
--Remove space;
--Remove chars not in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ#&0123456789';
--Translate the char into words;
--Translate "BRITISHCOLUMBIA" into "BC";
--The name length is limited to 30 characters;
Add test;
Call the compressed name function when insert a record into name instance table;
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).

