### PR TITLE
Version 2: Update solr names schema for exact match and do an exact-match histor…

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -28,10 +28,9 @@ class SolrQueries:
     PROX_SYN_CONFLICTS = 'proxsynconflicts'
     OLD_SYN_CONFLICTS = 'oldsynconflicts'
     CONFLICTS = 'conflicts'
-    HISTORY = 'histories'
     TRADEMARKS = 'trademarks'
     RESTRICTED_WORDS = 'restricted_words'
-    VALID_QUERIES = [CONFLICTS, HISTORY, TRADEMARKS]
+    VALID_QUERIES = [CONFLICTS, TRADEMARKS]
 
     #
     # Prototype:
@@ -50,11 +49,6 @@ class SolrQueries:
             '/solr/possible.conflicts/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&'
             'hl=on&indent=on&q={compressed_name}%20OR%20{name}&qf=name_compressed^6%20name_with_synonyms&wt=json&'
             'start={start}&rows={rows}&fl=source,id,name,score&sort=score%20desc{synonyms_clause}{name_copy_clause}',
-        HISTORY:
-            '/solr/names/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&hl=on&'
-            'indent=on&q={compressed_name}%20OR%20{name}&qf=name_compressed^6%20name_with_synonyms&wt=json&'
-            'start={start}&rows={rows}&fl=nr_num,name,score,submit_count,name_state_type_cd&sort=score%20desc'
-            '{synonyms_clause}{name_copy_clause}',
         TRADEMARKS:
             '/solr/trademarks/select?defType=edismax&hl.fl=name&hl.simple.post=%3C/b%3E&hl.simple.pre=%3Cb%3E&hl=on&'
             'indent=on&q={compressed_name}%20OR%20{name}&qf=name_compressed^6%20name_with_synonyms&wt=json&'

--- a/api/namex/resources/__init__.py
+++ b/api/namex/resources/__init__.py
@@ -5,7 +5,7 @@ from .ops import api as nr_ops
 from .document_analysis import api as analysis_api
 from .meta import api as meta_api
 from .exact_match import api as exact_match_api
-
+from .histories import api as histories_api
 
 # This will add the Authorize button to the swagger docs
 # TODO oauth2 & openid may not yet be supported by restplus <- check on this
@@ -30,3 +30,4 @@ api.add_namespace(nr_ops, path='/nr-ops')
 api.add_namespace(analysis_api, path='/documents')
 api.add_namespace(meta_api, path='/meta')
 api.add_namespace(exact_match_api, path='/exact-match')
+api.add_namespace(histories_api, path='/histories')

--- a/api/namex/resources/histories.py
+++ b/api/namex/resources/histories.py
@@ -1,0 +1,46 @@
+from flask import jsonify, request
+from flask_restplus import Resource, Namespace, cors
+from namex.utils.util import cors_preflight
+import json
+from namex import jwt
+import urllib
+from flask import current_app
+
+api = Namespace('historiesMeta', description='Histories Match - Metadata')
+import os
+SOLR_URL = os.getenv('SOLR_BASE_URL')
+
+
+@cors_preflight("GET")
+@api.route("", methods=['GET', 'OPTIONS'])
+class Histories(Resource):
+
+    @staticmethod
+    @cors.crossdomain(origin='*')
+    @jwt.requires_auth
+    def get():
+        query = request.args.get('query')
+        query = query.lower().replace('*','')
+        url = SOLR_URL + '/solr/names' + \
+              '/select?' + \
+              'sow=false' + \
+              '&df=name_exact_match' + \
+              '&wt=json' + \
+              '&q=' + urllib.parse.quote(query)
+        current_app.logger.debug('Histories match query: ' + url)
+        connection = urllib.request.urlopen(url)
+        answer = json.loads(connection.read())
+
+        docs = answer['response']['docs']
+
+        names =[
+            { 'name':doc['name'],
+              'id':doc['id'],
+              'name_state_type_cd':doc['name_state_type_cd'],
+              'submit_count':doc['submit_count'],
+              'nr_num':doc['nr_num']
+              } for doc in docs]
+
+        results = {'names': names}
+        return jsonify(results)
+

--- a/api/tests/python/end_points/test_histories.py
+++ b/api/tests/python/end_points/test_histories.py
@@ -1,0 +1,300 @@
+from namex.models import User
+import os
+import requests
+import json
+import pytest
+from tests.python import integration_solr
+import urllib
+
+token_header = {
+                "alg": "RS256",
+                "typ": "JWT",
+                "kid": "flask-jwt-oidc-test-client"
+               }
+claims = {
+            "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/sbc",
+            "sub": "43e6a245-0bf7-4ccf-9bd0-e7fb85fd18cc",
+            "aud": "NameX-Dev",
+            "exp": 31531718745,
+            "iat": 1531718745,
+            "jti": "flask-jwt-oidc-test-support",
+            "typ": "Bearer",
+            "username": "test-user",
+            "realm_access": {
+                "roles": [
+                    "{}".format(User.EDITOR),
+                    "{}".format(User.APPROVER),
+                    "viewer",
+                    "user"
+                ]
+            }
+         }
+SOLR_URL = os.getenv('SOLR_TEST_URL')
+
+@pytest.fixture(scope="session", autouse=True)
+def reload_schema(request):
+    url = SOLR_URL + '/solr/admin/cores?action=RELOAD&core=names&wt=json'
+    r = requests.get(url)
+
+    assert r.status_code == 200
+
+@integration_solr
+def test_solr_available(app, client, jwt):
+    url = SOLR_URL + '/solr/names/admin/ping'
+    r = requests.get(url)
+
+    assert r.status_code == 200
+
+def clean_database(client, jwt):
+    url = SOLR_URL + '/solr/names/update?commit=true'
+    headers = {'content-type': 'text/xml'}
+    data = '<delete><query>id:*</query></delete>'
+    r = requests.post(url, headers=headers, data=data)
+
+    assert r.status_code == 200
+
+def seed_database_with(client, jwt, name, id='1', name_state_type_cd='A', submit_count='1', nr_num='NR 12345' ):
+    clean_database(client, jwt)
+    url = SOLR_URL + '/solr/names/update?commit=true'
+    headers = {'content-type': 'application/json'}
+    data = '[{"name":"' + name + \
+           '", "id":"'+ id +\
+           '", "name_state_type_cd":"' + name_state_type_cd +\
+           '", "submit_count":"' +submit_count +\
+           '", "nr_num":"' + nr_num + '"}]'
+
+    print(data)
+    r = requests.post(url, headers=headers, data=data)
+    assert r.status_code == 200
+
+def verify(data, expected):
+    assert expected == data['names']
+
+def verify_exact_match_results(client, jwt, query, expected):
+    data = search_histories(client, jwt, query)
+    verify(data, expected)
+
+def verify_exact_match(client, jwt, query, expected):
+    data = search_histories(client, jwt, query)
+    expect = [
+            {
+                'id': '1',
+                'name': expected,
+                'name_state_type_cd': 'A',
+                'nr_num': 'NR 12345',
+                'submit_count': 1,
+            }
+        ]
+    if expected == None:
+        expect = []
+    verify(data, expect)
+
+def search_histories(client, jwt, query):
+    token = jwt.create_jwt(claims, token_header)
+    headers = {'Authorization': 'Bearer ' + token}
+    url = '/api/v1/histories?query=' + urllib.parse.quote(query)
+    print(url)
+    rv = client.get(url, headers=headers)
+
+    assert rv.status_code == 200
+    return json.loads(rv.data)
+
+@integration_solr
+def test_find_same_name(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+        query='JM Van Damme inc',
+        expected='JM Van Damme inc'
+    )
+
+@integration_solr
+def test_resist_empty(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+                       query='',
+                       expected=None
+                       )
+
+@integration_solr
+def test_resists_different_type(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+                       query='JM Van Damme ltd',
+                       expected='JM Van Damme inc'
+                       )
+
+@integration_solr
+def test_case_insensitive(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+                       query='JM VAN DAMME INC',
+                       expected='JM Van Damme inc'
+                       )
+
+@integration_solr
+def test_no_match(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+                       query='Hello BC inc',
+                       expected=None
+                       )
+
+@integration_solr
+def test_ignores_and(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme inc')
+    verify_exact_match(client, jwt,
+                       query='J and M Van Damme inc',
+                       expected='JM Van Damme inc'
+                       )
+
+@integration_solr
+def test_ignores_dots(client, jwt, app):
+    seed_database_with(client, jwt, 'J.M. Van Damme Inc')
+    verify_exact_match(client, jwt,
+                       query='JM Van Damme Inc',
+                       expected='J.M. Van Damme Inc'
+                       )
+
+@integration_solr
+def test_ignores_ampersand(client, jwt, app):
+    seed_database_with(client, jwt, 'J&M & Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='J&M & Van Damme Inc'
+    )
+
+@integration_solr
+def test_ignores_comma(client, jwt, app):
+    seed_database_with(client, jwt, 'JM, Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='JM, Van Damme Inc'
+    )
+
+@integration_solr
+def test_ignores_exclamation_mark(client, jwt, app):
+    seed_database_with(client, jwt, 'JM! Van Damme Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Inc',
+       expected='JM! Van Damme Inc'
+    )
+
+@integration_solr
+def test_no_match_because_additional_initial(client, jwt, app):
+    seed_database_with(client, jwt, 'J.M.J. Van Damme Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='J.M. Van Damme Trucking Inc',
+       expected=None
+    )
+
+@integration_solr
+def test_no_match_because_additional_word(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme Trucking International Inc',
+       expected=None
+    )
+
+@integration_solr
+def test_no_match_because_missing_one_word(client, jwt, app):
+    seed_database_with(client, jwt, 'JM Van Damme Physio inc')
+    verify_exact_match(client, jwt,
+       query='JM Van Damme inc',
+       expected=None
+    )
+
+@integration_solr
+def test_no_match_star(client, jwt, app):
+    seed_database_with(client, jwt, 'SCHOLARSHIP')
+    verify_exact_match(client, jwt,
+       query='SCHOL*',
+       expected=None
+    )
+
+@integration_solr
+def test_duplicated_letters(client, jwt, app):
+    seed_database_with(client, jwt, 'Damme Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='Dame Trucking Inc',
+       expected='Damme Trucking Inc'
+    )
+
+@integration_solr
+def test_entity_suffixes(client, jwt, app):
+    suffixes = [
+        'limited',
+        'ltd.',
+        'ltd',
+        'incorporated',
+        'inc',
+        'inc.',
+        'corporation',
+        'corp.',
+        'limitee',
+        'ltee',
+        'incorporee',
+        'llc',
+        'l.l.c.',
+        'limited liability company',
+        'limited liability co.',
+        'llp',
+        'limited liability partnership',
+        'societe a responsabilite limitee',
+        'societe en nom collectif a responsabilite limitee',
+        'srl',
+        'sencrl',
+        'ulc',
+        'unlimited liability company',
+        'association',
+        'assoc',
+        'assoc.',
+        'assn',
+        'co',
+        'co.',
+        'society',
+        'soc',
+        'soc.'
+    ]
+    for suffix in suffixes:
+        seed_database_with(client, jwt, 'Van Trucking ' + suffix)
+        verify_exact_match(client, jwt,
+           query='Van Trucking',
+           expected='Van Trucking ' + suffix
+        )
+
+@integration_solr
+def test_numbers_preserved(client, jwt, app):
+    seed_database_with(client, jwt, 'Van 4 Trucking Inc')
+    verify_exact_match(client, jwt,
+       query='Van 4 Trucking ltd',
+       expected='Van 4 Trucking Inc'
+
+    )
+
+@integration_solr
+@pytest.mark.parametrize("criteria, seed", [
+    ('J M HOLDINGS', 'J M HOLDINGS INC'),
+    ('JM Van Damme Inc', 'J&M & Van Damme Inc'),
+    ('J&M HOLDINGS', 'JM HOLDINGS INC'),
+    ('J. & M. HOLDINGS', 'JM HOLDINGS INC'),
+    ('J and M HOLDINGS', 'J and M HOLDINGS'),
+    ('J AND M HOLDINGS', 'J AND M HOLDINGS'),
+    ('J or M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J-M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J\'M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J_M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J_\'_-M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J@M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J=M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J!M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J!=@_M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J+M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('J\M HOLDINGS', 'J. & M. HOLDINGS'),
+    ('GREAT NORTH OIL AND GAS LIMITED', 'GREAT NORTH OIL AND GAS LIMITED')
+])
+def test_explore_complex_cases(client, jwt, app, criteria, seed):
+    seed_database_with(client, jwt, seed)
+    verify_exact_match(client, jwt,
+       query=criteria,
+       expected=seed
+    )

--- a/solr/cores/names/conf/managed-schema
+++ b/solr/cores/names/conf/managed-schema
@@ -144,6 +144,8 @@
     <field name="name_with_synonyms" type="text_name_singular_synonyms" multiValued="false" indexed="true"
         stored="true"/>
     <field name="name_compressed" type="text_name_compressed" multiValued="false" indexed="true" stored="true"/>
+    <field name="name_exact_match" type="text_name_exact_match" multiValued="false" indexed="true" stored="true"/>
+
 
     <!-- Only enabled in the "schemaless" data-driven example (assuming the client
          does not know what fields may be searched) because it's very expensive to index everything twice. -->
@@ -719,6 +721,54 @@
       </analyzer>
     </fieldType>
 
+    <fieldType name="text_name_exact_match" class="solr.TextField" positionIncrementGap="100" multiValued="false">
+      <analyzer>
+          <tokenizer class="solr.KeywordTokenizerFactory" />
+
+          <filter class="solr.LowerCaseFilterFactory"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability company"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability co."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited liability partnership"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" societe a responsabilite limitee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" societe en nom collectif a responsabilite limitee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" incorporee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" unlimited liability company"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limited"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ltd."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ltd"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" incorporated"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" inc."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" inc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" corporation"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" corp."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" limitee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ltee"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" llc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" llp"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" l.l.c."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" srl"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" sencrl"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" ulc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" association"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" assoc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" assoc."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" assn"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" co"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" co."  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" society"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" soc"  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" soc."  replacement="" replace="all" />
+
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" and "  replacement="" replace="all" />
+          <filter class="solr.PatternReplaceFilterFactory" pattern=" or "  replacement="" replace="all" />
+
+          <filter class="solr.PatternReplaceFilterFactory" pattern="(\.|\!|-|_|'|,|&amp;|@|\=)" replacement="" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="\+" replacement="" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="([a-z])\1+" replacement="$1" replace="all"/>
+          <filter class="solr.PatternReplaceFilterFactory" pattern="\s" replacement="" replace="all"/>
+      </analyzer>
+    </fieldType>
+
     <!-- some examples for different languages (generally ordered by ISO code) -->
 
     <!-- Arabic -->
@@ -1148,4 +1198,5 @@
     <copyField source="name" dest="name_copy"/>
     <copyField source="name" dest="name_with_synonyms"/>
     <copyField source="name" dest="name_compressed"/>
+    <copyField source="name" dest="name_exact_match"/>
 </schema>


### PR DESCRIPTION
**NOTE** Only this pr (480), or the alternative (479) should be accepted, but NOT BOTH!!

*Issue #, if available:* namex/entity#73

*Description of changes:*
- update solr names core with an exact_match field to match the 'exact_match' found in the possible.conflicts core.
- add test 
- update API to have a new histories endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
