### PR TITLE
Assumed Name SOLR View Changes and tests.

### DIFF
--- a/colin-api/app/resources/corporations.py
+++ b/colin-api/app/resources/corporations.py
@@ -193,7 +193,7 @@ class Methods(Resource):
         incorp_ho_addr_id_sql = '\'' + str(incorp_ho_addr_id) + '\''
         incorp_ho_addr_sql = text("select addr_line_1, ADDR_LINE_2, ADDR_LINE_3, city, province, country_typ_cd, postal_cd "
                                   "from bc_registries.address_vw "
-                                  "where addr_id= {};".format(incorp_ho_addr_id_sql))
+                                  "where addr_id= {} AND addr_id IS NOT NULL;".format(incorp_ho_addr_id_sql))
         incorp_head_office_obj = db.engine.execute(incorp_ho_addr_sql)
 
         incorp_attorneys_obj = db.engine.execute(incorp_attorneys_sql)
@@ -210,7 +210,7 @@ class Methods(Resource):
         incorp_reg_addr_sql = text(
             "select addr_line_1, ADDR_LINE_2, ADDR_LINE_3, city, province, country_typ_cd, postal_cd "
             "from bc_registries.address_vw "
-            "where addr_id= {};".format(incorp_reg_addr_id_sql))
+            "where addr_id= {} AND addr_id IS NOT NULL;".format(incorp_reg_addr_id_sql))
         incorp_registered_addr_obj = db.engine.execute(incorp_reg_addr_sql)
         try:
             incorp_rec_addr_id = incorp_addr_ids[1][0]
@@ -221,7 +221,7 @@ class Methods(Resource):
             incorp_rec_addr_sql = text(
                 "select addr_line_1, ADDR_LINE_2, ADDR_LINE_3, city, province, country_typ_cd, postal_cd "
                 "from bc_registries.address_vw "
-                "where addr_id= {};".format(incorp_rec_addr_id_sql))
+                "where addr_id= {} AND addr_id IS NOT NULL;".format(incorp_rec_addr_id_sql))
             incorp_records_addr_obj = db.engine.execute(incorp_rec_addr_sql)
 
         return incorp_registered_addr_obj,incorp_records_addr_obj

--- a/nro-legacy/sql/object/registry/namex/view/solr_dataimport_conflicts_vw.sql
+++ b/nro-legacy/sql/object/registry/namex/view/solr_dataimport_conflicts_vw.sql
@@ -4,14 +4,46 @@ DROP VIEW NAMEX.SOLR_DATAIMPORT_CONFLICTS_VW;
 
 CREATE OR REPLACE FORCE VIEW namex.solr_dataimport_conflicts_vw (ID, NAME, state_type_cd, SOURCE)
 AS
-    SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
-           'CORP' AS SOURCE
-      FROM corporation c LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
-           LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
-           LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
-           LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
-     WHERE corp.end_event_id IS NULL
-       AND corp.corp_name_typ_cd IN ('CO', 'NB')
-       AND cs.end_event_id IS NULL
-       AND op.op_state_typ_cd = 'ACT'
-       AND ct.corp_class IN ('BC', 'SOC', 'OT', 'XPRO');
+SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
+       'CORP' AS SOURCE
+FROM corporation c LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
+                   LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
+                   LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
+                   LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
+WHERE corp.end_event_id IS NULL
+  AND corp.corp_name_typ_cd IN ('CO', 'NB')
+  AND cs.end_event_id IS NULL
+  AND op.op_state_typ_cd = 'ACT'
+  AND ct.corp_class IN ('BC', 'SOC', 'OT')
+UNION ALL
+SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
+       'CORP' AS SOURCE
+FROM corporation c
+         LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
+         LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
+         LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
+         LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
+WHERE corp.end_event_id IS NULL
+  AND corp.corp_name_typ_cd IN ('CO')
+  AND cs.end_event_id IS NULL
+  AND op.op_state_typ_cd = 'ACT'
+  AND ct.corp_class IN ('XPRO')
+  and c.corp_num NOT IN (select cname.corp_num   from corp_name cname
+                         left outer join corporation c1 on c1.corp_num = cname.corp_num
+                         where cname.corp_num = c.corp_num
+                           and cname.corp_name_typ_cd ='AS')
+UNION ALL
+SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
+       'CORP' AS SOURCE
+FROM corporation c
+         LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
+         LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
+         LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
+         LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
+WHERE corp.end_event_id IS NULL
+  AND corp.corp_name_typ_cd IN ('AS')
+  AND cs.end_event_id IS NULL
+  AND op.op_state_typ_cd = 'ACT'
+  AND ct.corp_class IN ('XPRO')
+ORDER BY 1;
+

--- a/nro-legacy/sql/release/201901XX_solr_view/registry/namex/create.sql
+++ b/nro-legacy/sql/release/201901XX_solr_view/registry/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/registry/namex/view/solr_dataimport_conflicts_vw.sql

--- a/nro-legacy/tests/seeds.py
+++ b/nro-legacy/tests/seeds.py
@@ -1,0 +1,55 @@
+from .postgres import Postgres
+
+
+def seed_corp_name(corp_num, start_event_id, corp_name_typ_cd, corp_nme):
+    Postgres().execute("""
+           insert into corp_name(
+                corp_num,
+                start_event_id,
+                end_event_id ,
+                corp_name_typ_cd ,
+                corp_nme
+            )
+        values ('{}','{}',null,'{}','{}')
+     """.format(corp_num, start_event_id, corp_name_typ_cd, corp_nme))
+
+
+def seed_corp_state(corp_num, start_event_id):
+    Postgres().execute("""
+            insert into corp_state(
+                corp_num, 
+                start_event_id,
+                end_event_id,
+                state_typ_cd
+            )
+        values ('{}', '{}',null,'ACT')
+     """.format(corp_num, start_event_id))
+
+
+def seed_corp(corp_num, corp_typ_cd):
+    Postgres().execute("""
+            insert into corporation(
+                corp_num, 
+                corp_typ_cd
+            )
+        values ('{}', '{}')
+     """.format(corp_num, corp_typ_cd))
+
+
+def seed_corp_type(corp_typ_cd, corp_class):
+    Postgres().execute("""
+            insert into corp_type(
+                corp_typ_cd, 
+                corp_class
+            )
+        values ('{}', '{}')
+     """.format(corp_typ_cd, corp_class))
+
+def seed_corp_op_state():
+    Postgres().execute("""
+            insert into corp_op_state(
+            state_typ_cd,
+            op_state_typ_cd
+            )
+        values('ACT', 'ACT')
+        """)

--- a/nro-legacy/tests/sql/create.table.corp.name.sql
+++ b/nro-legacy/tests/sql/create.table.corp.name.sql
@@ -1,0 +1,9 @@
+drop table if exists corp_name;
+
+create table corp_name(
+  corp_num    varchar(10),
+  start_event_id varchar(10),
+  end_event_id  varchar(10),
+  corp_name_typ_cd  varchar(10),
+  corp_nme varchar(100)
+);

--- a/nro-legacy/tests/sql/create.table.corp.op.state.sql
+++ b/nro-legacy/tests/sql/create.table.corp.op.state.sql
@@ -1,0 +1,6 @@
+drop table if exists corp_op_state;
+
+create table corp_op_state(
+  state_typ_cd     varchar(10),
+  op_state_typ_cd  varchar(10)
+);

--- a/nro-legacy/tests/sql/create.table.corp.state.sql
+++ b/nro-legacy/tests/sql/create.table.corp.state.sql
@@ -1,0 +1,8 @@
+drop table if exists corp_state;
+
+create table corp_state(
+  corp_num          varchar(10),
+  start_event_id    varchar(10),
+  end_event_id      varchar(10),
+  state_typ_cd      varchar(10)
+);

--- a/nro-legacy/tests/sql/create.table.corp.type.sql
+++ b/nro-legacy/tests/sql/create.table.corp.type.sql
@@ -1,0 +1,6 @@
+drop table if exists corp_type;
+
+create table corp_type(
+  corp_typ_cd    varchar(10),
+  corp_class     varchar(10)
+);

--- a/nro-legacy/tests/sql/create.table.corporation.sql
+++ b/nro-legacy/tests/sql/create.table.corporation.sql
@@ -1,0 +1,6 @@
+drop table if exists corporation;
+
+create table corporation(
+  corp_num            varchar(10),
+  corp_typ_cd         varchar(10)
+);

--- a/nro-legacy/tests/test_solr_corp_vw.py
+++ b/nro-legacy/tests/test_solr_corp_vw.py
@@ -1,0 +1,92 @@
+import os
+import pytest
+from hamcrest import *
+from .postgres import Postgres
+from .seeds import *
+
+release = 'sql/release/201901XX_solr_view/registry/namex/'
+migration = 'create.sql'
+
+
+def sut():
+    content = open(release + migration).read()
+    target = content[content.find('@') + 1:]
+    return open(release + target.strip(), 'r').read()
+
+
+def extract_select():
+    source = sut()
+    sql = source[source.find('AS') + 2:]
+    return sql[:sql.find(';')]
+
+
+def test_sut_can_be_reached():
+    assert_that(sut(), contains_string('VIEW namex.solr_dataimport_conflicts_vw'))
+
+
+def test_environment_ready():
+    assert_that(os.getenv('COLIN_DATABASE'), is_not(None))
+    assert_that(os.getenv('COLIN_USER'), is_not(None))
+    assert_that(os.getenv('COLIN_PASSWORD'), is_not(None))
+
+
+@pytest.fixture(autouse=True)
+def before_each_test():
+    Postgres().execute(open('tests/sql/create.table.corporation.sql').read())
+    Postgres().execute(open('tests/sql/create.table.corp.state.sql').read())
+    Postgres().execute(open('tests/sql/create.table.corp.name.sql').read())
+    Postgres().execute(open('tests/sql/create.table.corp.op.state.sql').read())
+    Postgres().execute(open('tests/sql/create.table.corp.type.sql').read())
+
+
+def test_view():
+    seed_corp_type('A', 'XPRO')
+    seed_corp_type('BC', 'BC')
+    seed_corp_type('QD', 'BC')
+    seed_corp_op_state()
+    seed_corp('A0012419', 'A')
+    seed_corp('A0012445', 'A')
+    seed_corp('A0008461', 'A')
+    seed_corp_name('A0012419', '19', 'CO', 'ONLINE SEALING SERVICES LTD.')
+    seed_corp_name('A0012445', '20', 'CO', 'HOWIE MEEKER ENTERPRISES LIMITED')
+    seed_corp_name('A0008461', '21', 'CO', 'W.H. ODELL DRUGS LTD.')
+    seed_corp_state('A0012419', '7')
+    seed_corp_state('A0012445', '8')
+    seed_corp_state('A0008461', '9')
+
+    seed_corp('0000160', 'BC')
+    seed_corp('QD0000162', 'QD')
+    seed_corp('0000558', 'BC')
+    seed_corp_name('0000160','10', 'CO','BRITISH COLUMBIA GOLF CLUB, LIMITED')
+    seed_corp_name('QD0000162', '11', 'CO', 'THE VERNON JOCKEY CLUB LIMITED LIABILITY')
+    seed_corp_name('0000558', '12', 'CO', 'COLUMBIA ESTATE COMPANY LIMITED')
+    seed_corp_state('0000160', '1')
+    seed_corp_state('QD0000162', '2')
+    seed_corp_state('0000558', '3')
+
+    seed_corp('A0037274', 'A')
+    seed_corp('A0038332', 'A')
+    seed_corp('A0041224', 'A')
+    seed_corp_name('A0037274','15','AS','ASSUMED ROBEV VENTURES LTD.')
+    seed_corp_name('A0038332', '16','AS', 'ASSUMED RED-L HOSE DISTRIBUTORS LTD.')
+    seed_corp_name('A0041224', '17', 'AS','ASSUMED 571266 SASKATCHEWAN INC.')
+    seed_corp_state('A0037274', '4')
+    seed_corp_state('A0038332','5')
+    seed_corp_state('A0041224','6')
+
+
+    result = Postgres().select("select * from corporation where corp_typ_cd= 'A' ")
+    assert_that(len(result), equal_to(6))
+
+    result = Postgres().select("select * from corporation where corp_typ_cd IN ('BC','QD') ")
+    assert_that(len(result),equal_to(3))
+
+    result = Postgres().select(extract_select())
+    assert_that(len(result),equal_to(9))
+
+    seed_corp_name('A0037274','18','CO','ROBEV VENTURES LTD.')
+    seed_corp_name('A0038332', '19','CO', 'RED-L HOSE DISTRIBUTORS LTD.')
+    seed_corp_name('A0041224', '20', 'CO','571266 SASKATCHEWAN INC.')
+
+    result = Postgres().select(extract_select())
+    assert_that(len(result),equal_to(9))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/bcgov/entity/issues/55



*Description of changes:*
Changed the view used to feed solr corporations from colin.  Assumed names were missing.  Assumed names apply to XPROs . An XPRO may have both an assumed name (AS) as well as a corporate name (CO) therefore the view must only return one in these circumstances (only the AS name).  

The pytest adds the necessary corp tables and seeds the data to ensure the view is working as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
