### PR TITLE
Corrected matching on leading vowels

### DIFF
--- a/api/namex/analytics/phonetic/__init__.py
+++ b/api/namex/analytics/phonetic/__init__.py
@@ -1,7 +1,5 @@
 
 def match_consonate(c1, c2):
-    if set(['C', 'G']) == set([c1, c2]):
-        return True
     if set(['C', 'K']) == set([c1, c2]):
         return True
     if set(['CR', 'KR']) == set([c1, c2]):
@@ -32,7 +30,7 @@ def match_consonate(c1, c2):
     return c1 == c2
 
 
-def first_vowels(word):
+def first_vowels(word, leading_vowel = False):
     vowels = ['A', 'E', 'I', 'O', 'U', 'Y']
     value = ''
     first_vowel_found = False
@@ -43,22 +41,25 @@ def first_vowels(word):
             value += letter
             first_vowel_found = True
 
-    if value == 'EY':
-        value = 'A'
-    if value == 'EI':
-        value = 'A'
-    if value == 'EA':
-        value = 'A'
-    if value == 'AY':
-        value = 'A'
-    if value == 'AI':
-        value = 'A'
-    if value == 'Y':
-        value = 'I'
-    if value == 'OY':
-        value = 'OI'
-    if value == 'UE':
-        value = 'U'
+    if leading_vowel == False:
+        if value == 'EY':
+            value = 'A'
+        if value == 'EI':
+            value = 'A'
+        if value == 'EA':
+            value = 'A'
+        if value == 'AY':
+            value = 'A'
+        if value == 'AI':
+            value = 'A'
+        if value == 'Y':
+            value = 'I'
+        if value == 'UE':
+            value = 'U'
+    else:
+        if value == 'OY':
+            value = 'OI'
+
 
     if 'AA' in value:
         value = value.replace('AA', 'A')
@@ -67,7 +68,7 @@ def first_vowels(word):
 
 
 def first_consonants(word):
-    consonants = ['B', 'C', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'X', 'W']
+    consonants = ['B', 'C', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'X', 'W', 'V', 'Z']
     value = ''
     first_consonant_found = False
     for letter in word:
@@ -81,6 +82,13 @@ def first_consonants(word):
         value = value.replace('GG', 'G')
 
     return value
+
+
+def has_leading_vowel(word):
+    if word[0] in ['A', 'E', 'I', 'O', 'U', 'Y']:
+        return True
+    else:
+        return False
 
 
 def designations():

--- a/api/namex/analytics/phonetic/__init__.py
+++ b/api/namex/analytics/phonetic/__init__.py
@@ -1,33 +1,4 @@
 
-def match_consonate(c1, c2):
-    if set(['C', 'K']) == set([c1, c2]):
-        return True
-    if set(['CR', 'KR']) == set([c1, c2]):
-        return True
-    if set(['CHR', 'KR']) == set([c1, c2]):
-        return True
-    if set(['CL', 'KL']) == set([c1, c2]):
-        return True
-    if set(['PH', 'F']) == set([c1, c2]):
-        return True
-    if set(['GH', 'G']) == set([c1, c2]):
-        return True
-    if set(['GN', 'N']) == set([c1, c2]):
-        return True
-    if set(['KN', 'N']) == set([c1, c2]):
-        return True
-    if set(['PN', 'N']) == set([c1, c2]):
-        return True
-    if set(['PS', 'S']) == set([c1, c2]):
-        return True
-    if set(['WR', 'R']) == set([c1, c2]):
-        return True
-    if set(['RH', 'R']) == set([c1, c2]):
-        return True
-    if set(['WH', 'W']) == set([c1, c2]):
-        return True
-
-    return c1 == c2
 
 
 def first_vowels(word, leading_vowel = False):
@@ -78,8 +49,47 @@ def first_consonants(word):
             value += letter
             first_consonant_found = True
 
+    if 'CHR' in value:
+        value = value.replace('CHR', 'KR')
+
     if 'GG' in value:
         value = value.replace('GG', 'G')
+
+    if 'C' in value:
+        value = value.replace('C', 'K')
+
+    if 'CR' in value:
+        value = value.replace('CR', 'KR')
+
+    if 'CL' in value:
+        value = value.replace('CL', 'KL')
+
+    if 'PH' in value:
+        value = value.replace('PH', 'F')
+
+    if 'GH' in value:
+        value = value.replace('GH', 'G')
+
+    if 'GN' in value:
+        value = value.replace('GN', 'N')
+
+    if 'KN' in value:
+        value = value.replace('KN', 'N')
+
+    if 'PN' in value:
+        value = value.replace('PN', 'N')
+
+    if 'PS' in value:
+        value = value.replace('PS', 'S')
+
+    if 'WR' in value:
+        value = value.replace('WR', 'R')
+
+    if 'RH' in value:
+        value = value.replace('RH', 'R')
+
+    if 'WH' in value:
+        value = value.replace('WH', 'W')
 
     return value
 
@@ -148,3 +158,12 @@ def designations():
         'SOC',
         'SOC.'
     ]
+
+
+def replace_special_leading_sounds(word):
+
+    for (special_leading_sound, replacement) in [['QU', 'KW'], ['EX', 'X'], ['MAC', 'MC']]:
+        if word[:len(special_leading_sound)] == special_leading_sound:
+            word = replacement + word[len(special_leading_sound):]
+
+    return word

--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -7,7 +7,7 @@ from flask import current_app
 from urllib import request, parse
 from urllib.error import HTTPError
 import re
-from namex.analytics.phonetic import first_vowels, match_consonate, designations, first_consonants
+from namex.analytics.phonetic import first_vowels, match_consonate, designations, first_consonants, has_leading_vowel
 
 
 # Use this character in the search strings to indicate that the word should not by synonymized.
@@ -680,11 +680,14 @@ class SolrQueries:
         if query[:3] == 'MAC':
             query = 'MC' + query[3:]
 
+        word_has_leading_vowel = has_leading_vowel(word)
+        query_has_leading_vowel = has_leading_vowel(query)
+
         word_first_consonant = first_consonants(word)
         query_first_consonant = first_consonants(query)
         if match_consonate(query_first_consonant, word_first_consonant):
-            query_first_vowels = first_vowels(query)
-            word_first_vowels = first_vowels(word)
+            query_first_vowels = first_vowels(query, query_has_leading_vowel)
+            word_first_vowels = first_vowels(word, word_has_leading_vowel)
             if query_first_vowels == word_first_vowels:
                 return True
 

--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -7,7 +7,7 @@ from flask import current_app
 from urllib import request, parse
 from urllib.error import HTTPError
 import re
-from namex.analytics.phonetic import first_vowels, match_consonate, designations, first_consonants, has_leading_vowel
+from namex.analytics.phonetic import first_vowels, designations, first_consonants, has_leading_vowel, replace_special_leading_sounds
 
 
 # Use this character in the search strings to indicate that the word should not by synonymized.
@@ -665,30 +665,29 @@ class SolrQueries:
 
     @classmethod
     def keep_phonetic_match(cls, word, query):
-        if word[:2] == 'QU':
-            word = 'KW' + word[2:]
-        if query[:2] == 'QU':
-            query = 'KW' + query[2:]
-
-        if word[:2] == 'EX':
-            word = 'X' + word[2:]
-        if query[:2] == 'EX':
-            query = 'X' + query[2:]
-
-        if word[:3] == 'MAC':
-            word = 'MC' + word[3:]
-        if query[:3] == 'MAC':
-            query = 'MC' + query[3:]
+        word = replace_special_leading_sounds(word)
+        query = replace_special_leading_sounds(query)
 
         word_has_leading_vowel = has_leading_vowel(word)
         query_has_leading_vowel = has_leading_vowel(query)
 
         word_first_consonant = first_consonants(word)
         query_first_consonant = first_consonants(query)
-        if match_consonate(query_first_consonant, word_first_consonant):
-            query_first_vowels = first_vowels(query, query_has_leading_vowel)
-            word_first_vowels = first_vowels(word, word_has_leading_vowel)
-            if query_first_vowels == word_first_vowels:
+
+        query_first_vowels = first_vowels(query, query_has_leading_vowel)
+        word_first_vowels = first_vowels(word, word_has_leading_vowel)
+
+        if query_has_leading_vowel:
+            query_sound = query_first_vowels + query_first_consonant
+        else:
+            query_sound = query_first_consonant + query_first_vowels
+
+        if word_has_leading_vowel:
+            word_sound = word_first_vowels + word_first_consonant
+        else:
+            word_sound = word_first_consonant + word_first_vowels
+
+        if word_sound == query_sound:
                 return True
 
         return False

--- a/api/tests/python/end_points/test_sounds_like.py
+++ b/api/tests/python/end_points/test_sounds_like.py
@@ -759,6 +759,19 @@ def test_leading_vowel_e(solr, client, jwt, app):
 
 
 @integration_solr
+def test_leading_vowel_not_match_consonant(solr, client, jwt, app):
+    clean_database(solr)
+    seed_database_with(solr, 'HELENAH WU & CO. INC.', id='1')
+    seed_database_with(solr, 'A BETTER WAY HERBALS LTD.', id='2')
+    verify_results(client, jwt,
+       query='EH',
+       expected=[
+           {'name': '----EH - PHONETIC SEARCH'}
+       ]
+    )
+
+
+@integration_solr
 def test_unusual_result(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'DOUBLE J AVIATION LTD.', id='1')

--- a/api/tests/python/end_points/test_sounds_like.py
+++ b/api/tests/python/end_points/test_sounds_like.py
@@ -2,7 +2,7 @@ from namex.models import User
 import requests
 import json
 import pytest
-from tests.python import integration_solr
+from tests.python import integration_solr, integration_synonym_api
 import urllib
 from hamcrest import *
 
@@ -96,7 +96,7 @@ def search(client, jwt, query):
     return json.loads(rv.data)
 
 
-
+@integration_synonym_api
 @integration_solr
 def test_all_good(solr, client, jwt, app):
     clean_database(solr)
@@ -110,8 +110,10 @@ def test_all_good(solr, client, jwt, app):
     )
 
 
+@pytest.mark.skip(reason="Rhyming not implemented yet")
+@integration_synonym_api
 @integration_solr
-def sounds_like(solr, client, jwt, app):
+def test_sounds_like(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'GAYLEDESIGNS INC.', id='1')
     seed_database_with(solr, 'GOLDSTREAM ELECTRICAL CORP', id='2')
@@ -136,6 +138,8 @@ def sounds_like(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_liberti(solr, client, jwt, app):
     clean_database(solr)
@@ -148,6 +152,8 @@ def test_liberti(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_deeper(solr, client, jwt, app):
     clean_database(solr)
@@ -162,6 +168,8 @@ def test_deeper(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_jasmine(solr, client, jwt, app):
     clean_database(solr)
@@ -174,6 +182,7 @@ def test_jasmine(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_fey(solr, client, jwt, app):
     clean_database(solr)
@@ -187,6 +196,7 @@ def test_fey(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_venizia(solr, client, jwt, app):
     clean_database(solr)
@@ -203,6 +213,7 @@ def test_venizia(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_ys_and_is(solr, client, jwt, app):
     clean_database(solr)
@@ -216,19 +227,7 @@ def test_ys_and_is(solr, client, jwt, app):
     )
 
 
-@integration_solr
-def gold_and_cold(solr, client, jwt, app):
-    clean_database(solr)
-    seed_database_with(solr, 'GOLDSMITHS', id='1')
-    verify_results(client, jwt,
-       query='COLDSTREAM',
-       expected=[
-           {'name': '----COLDSTREAM'},
-           {'name': 'GOLDSMITHS'},
-       ]
-    )
-
-
+@integration_synonym_api
 @integration_solr
 def test_cs_and_ks(solr, client, jwt, app):
     clean_database(solr)
@@ -242,6 +241,7 @@ def test_cs_and_ks(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_cs_and_ks_again(solr, client, jwt, app):
     clean_database(solr)
@@ -256,6 +256,7 @@ def test_cs_and_ks_again(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_resist_short_word(solr, client, jwt, app):
     clean_database(solr)
@@ -267,6 +268,8 @@ def test_resist_short_word(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_resist_single_vowel(solr, client, jwt, app):
     clean_database(solr)
@@ -279,6 +282,7 @@ def test_resist_single_vowel(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_feel(solr, client, jwt, app):
     clean_database(solr)
@@ -291,6 +295,7 @@ def test_feel(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_bear(solr, client, jwt, app):
     clean_database(solr)
@@ -304,6 +309,7 @@ def test_bear(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_ignore_corp(solr, client, jwt, app):
     clean_database(solr)
@@ -316,6 +322,7 @@ def test_ignore_corp(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_designation_in_query_is_ignored(solr, client, jwt, app):
     clean_database(solr)
@@ -328,6 +335,7 @@ def test_designation_in_query_is_ignored(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def leak(solr, client, jwt, app):
     clean_database(solr)
@@ -339,6 +347,8 @@ def leak(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_plank(solr, client, jwt, app):
     clean_database(solr)
@@ -351,6 +361,8 @@ def test_plank(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_krystal(solr, client, jwt, app):
     clean_database(solr)
@@ -364,6 +376,7 @@ def test_krystal(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_christal(solr, client, jwt, app):
     clean_database(solr)
@@ -377,6 +390,7 @@ def test_christal(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_kl(solr, client, jwt, app):
     clean_database(solr)
@@ -389,6 +403,8 @@ def test_kl(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_pheel(solr, client, jwt, app):
     clean_database(solr)
@@ -401,6 +417,8 @@ def test_pheel(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_ghable(solr, client, jwt, app):
     clean_database(solr)
@@ -413,6 +431,8 @@ def test_ghable(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_gnat(solr, client, jwt, app):
     clean_database(solr)
@@ -425,6 +445,8 @@ def test_gnat(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_kn(solr, client, jwt, app):
     clean_database(solr)
@@ -437,6 +459,8 @@ def test_kn(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_pn(solr, client, jwt, app):
     clean_database(solr)
@@ -449,6 +473,8 @@ def test_pn(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_wr(solr, client, jwt, app):
     clean_database(solr)
@@ -461,6 +487,8 @@ def test_wr(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_rh(solr, client, jwt, app):
     clean_database(solr)
@@ -473,6 +501,8 @@ def test_rh(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_soft_c_is_not_k(solr, client, jwt, app):
     clean_database(solr)
@@ -484,6 +514,8 @@ def test_soft_c_is_not_k(solr, client, jwt, app):
        ]
     )
 
+
+@integration_synonym_api
 @integration_solr
 def test_oi_oy(solr, client, jwt, app):
     clean_database(solr)
@@ -497,6 +529,7 @@ def test_oi_oy(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_dont_add_match_twice(solr, client, jwt, app):
     clean_database(solr)
@@ -511,6 +544,7 @@ def test_dont_add_match_twice(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_neighbour(solr, client, jwt, app):
     clean_database(solr)
@@ -524,6 +558,7 @@ def test_neighbour(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_mac_mc(solr, client, jwt, app):
     clean_database(solr)
@@ -537,6 +572,7 @@ def test_mac_mc(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_ex_x(solr, client, jwt, app):
     clean_database(solr)
@@ -550,6 +586,7 @@ def test_ex_x(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_wh(solr, client, jwt, app):
     clean_database(solr)
@@ -563,6 +600,7 @@ def test_wh(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_qu(solr, client, jwt, app):
     clean_database(solr)
@@ -576,6 +614,7 @@ def test_qu(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_ps(solr, client, jwt, app):
     clean_database(solr)
@@ -589,8 +628,10 @@ def test_ps(solr, client, jwt, app):
     )
 
 
+@pytest.mark.skip(reason="not handled yet")
+@integration_synonym_api
 @integration_solr
-def terra(solr, client, jwt, app):
+def test_terra(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'TERRA', id='1')
     verify_results(client, jwt,
@@ -601,6 +642,7 @@ def terra(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_ayaan(solr, client, jwt, app):
     clean_database(solr)
@@ -614,6 +656,7 @@ def test_ayaan(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_aggri(solr, client, jwt, app):
     clean_database(solr)
@@ -627,6 +670,7 @@ def test_aggri(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_kofi(solr, client, jwt, app):
     clean_database(solr)
@@ -640,6 +684,7 @@ def test_kofi(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_tru(solr, client, jwt, app):
     clean_database(solr)
@@ -653,8 +698,10 @@ def test_tru(solr, client, jwt, app):
     )
 
 
+@pytest.mark.skip(reason="not handled yet")
+@integration_synonym_api
 @integration_solr
-def dymond(solr, client, jwt, app):
+def test_dymond(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'DYMOND', id='1')
     verify_results(client, jwt,
@@ -665,8 +712,10 @@ def dymond(solr, client, jwt, app):
     )
 
 
+@pytest.mark.skip(reason="compound words not handled yet")
+@integration_synonym_api
 @integration_solr
-def bee_kleen(solr, client, jwt, app):
+def test_bee_kleen(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'BEE KLEEN', id='1')
     verify_results(client, jwt,
@@ -677,6 +726,7 @@ def bee_kleen(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_ignore_exact_match_keep_phonetic(solr, client, jwt, app):
     clean_database(solr)
@@ -692,6 +742,7 @@ def test_ignore_exact_match_keep_phonetic(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_match_both_words(solr, client, jwt, app):
     clean_database(solr)
@@ -705,6 +756,7 @@ def test_match_both_words(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_match_at_right_level(solr, client, jwt, app):
     clean_database(solr)
@@ -719,6 +771,7 @@ def test_match_at_right_level(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_resists_qword_matching_several_words(solr, client, jwt, app):
     clean_database(solr)
@@ -733,6 +786,7 @@ def test_resists_qword_matching_several_words(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_leading_vowel_a(solr, client, jwt, app):
     clean_database(solr)
@@ -746,6 +800,7 @@ def test_leading_vowel_a(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_leading_vowel_e(solr, client, jwt, app):
     clean_database(solr)
@@ -758,6 +813,7 @@ def test_leading_vowel_e(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_leading_vowel_not_match_consonant(solr, client, jwt, app):
     clean_database(solr)
@@ -771,6 +827,7 @@ def test_leading_vowel_not_match_consonant(solr, client, jwt, app):
     )
 
 
+@integration_synonym_api
 @integration_solr
 def test_unusual_result(solr, client, jwt, app):
     clean_database(solr)

--- a/api/tests/python/end_points/test_sounds_like.py
+++ b/api/tests/python/end_points/test_sounds_like.py
@@ -111,7 +111,7 @@ def test_all_good(solr, client, jwt, app):
 
 
 @integration_solr
-def test_sounds_like(solr, client, jwt, app):
+def sounds_like(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'GAYLEDESIGNS INC.', id='1')
     seed_database_with(solr, 'GOLDSTREAM ELECTRICAL CORP', id='2')
@@ -217,7 +217,7 @@ def test_ys_and_is(solr, client, jwt, app):
 
 
 @integration_solr
-def test_gold_and_cold(solr, client, jwt, app):
+def gold_and_cold(solr, client, jwt, app):
     clean_database(solr)
     seed_database_with(solr, 'GOLDSMITHS', id='1')
     verify_results(client, jwt,
@@ -729,5 +729,42 @@ def test_resists_qword_matching_several_words(solr, client, jwt, app):
            {'name': '----BEHAVIOUR INTERVENTION'},
            {'name': '----BEHAVIOUR'},
            {'name': 'ANDERSON BEHAVIOR BEHAVIOR'}
+       ]
+    )
+
+
+@integration_solr
+def test_leading_vowel_a(solr, client, jwt, app):
+    clean_database(solr)
+    seed_database_with(solr, 'AILEEN ENTERPRISES', id='1')
+    verify_results(client, jwt,
+       query='ALAN HARGREAVES CORPORATION',
+       expected=[
+           {'name': '----ALAN HARGREAVES - PHONETIC SEARCH'},
+           {'name': '----ALAN - PHONETIC SEARCH'}
+       ]
+    )
+
+
+@integration_solr
+def test_leading_vowel_e(solr, client, jwt, app):
+    clean_database(solr)
+    seed_database_with(solr, 'ACME', id='1')
+    verify_results(client, jwt,
+       query='EQUIOM',
+       expected=[
+           {'name': '----EQUIOM - PHONETIC SEARCH'}
+       ]
+    )
+
+
+@integration_solr
+def test_unusual_result(solr, client, jwt, app):
+    clean_database(solr)
+    seed_database_with(solr, 'DOUBLE J AVIATION LTD.', id='1')
+    verify_results(client, jwt,
+       query='TABLE',
+       expected=[
+           {'name': '----TABLE - PHONETIC SEARCH'}
        ]
     )

--- a/api/tests/python/end_points/test_sounds_like.py
+++ b/api/tests/python/end_points/test_sounds_like.py
@@ -740,8 +740,8 @@ def test_leading_vowel_a(solr, client, jwt, app):
     verify_results(client, jwt,
        query='ALAN HARGREAVES CORPORATION',
        expected=[
-           {'name': '----ALAN HARGREAVES - PHONETIC SEARCH'},
-           {'name': '----ALAN - PHONETIC SEARCH'}
+           {'name': '----ALAN HARGREAVES'},
+           {'name': '----ALAN'}
        ]
     )
 
@@ -753,7 +753,7 @@ def test_leading_vowel_e(solr, client, jwt, app):
     verify_results(client, jwt,
        query='EQUIOM',
        expected=[
-           {'name': '----EQUIOM - PHONETIC SEARCH'}
+           {'name': '----EQUIOM'}
        ]
     )
 
@@ -766,7 +766,7 @@ def test_leading_vowel_not_match_consonant(solr, client, jwt, app):
     verify_results(client, jwt,
        query='EH',
        expected=[
-           {'name': '----EH - PHONETIC SEARCH'}
+           {'name': '----EH'}
        ]
     )
 
@@ -778,6 +778,6 @@ def test_unusual_result(solr, client, jwt, app):
     verify_results(client, jwt,
        query='TABLE',
        expected=[
-           {'name': '----TABLE - PHONETIC SEARCH'}
+           {'name': '----TABLE'}
        ]
     )


### PR DESCRIPTION
*Issue #, if available:*
44

*Description of changes:*
The order of the sounds is now respected so that leading vowels no longer match words with leading consonants in unexpected ways.
e.g.: "eh" no longer matches "herb"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
