### PR TITLE
Encode non-ASCII characters when do the conflicts search

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -142,6 +142,7 @@ class SolrQueries:
                 name = name[:index]
                 break
 
+        name = parse.quote(name)
         name = name.upper().replace(' AND ',' ').replace('&',' ').replace('+',' ')
         list_name_split = name.split()
 
@@ -208,8 +209,8 @@ class SolrQueries:
                 solr['response']['start'] = result['response']['start']
 
                 if previous_stack_title.replace(' ','') != connection[1].replace(' ',''):
-                    solr['response']['docs'].append({'name': connection[1]})
-                    previous_stack_title = connection[1]
+                    solr['response']['docs'].append({'name': parse.unquote(connection[1])})
+                    previous_stack_title = parse.unquote(connection[1])
 
                 if len(result['response']['docs']) > 0:
 

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -417,3 +417,18 @@ def test_exact_word_order_stack_title_with_wilcards(client, jwt, app):
         expected_list=['----TESTING* WILDCARDS* - EXACT WORD ORDER', '----TESTING* - EXACT WORD ORDER'],
         not_expected_list=['----TESTING** - EXACT WORD ORDER']
     )
+
+@integration_synonym_api
+@integration_solr
+@pytest.mark.parametrize("criteria, seed", [
+    ('WALTER’S “WAFFLE” HOUSE', '----WALTER’S “WAFFLE” HOUSE - PROXIMITY SEARCH'),
+    ('TJ´S BACKCOUNTRY ADVENTURES.', '----TJ´S BACKCOUNTRY ADVENTURES. - PROXIMITY SEARCH'),
+    ('THE HOUSE OF BÜBÜ AN DA WOLF.', '----THE HOUSE OF BÜBÜ AN DA WOLF. - PROXIMITY SEARCH'),
+    ('DIAMANTÉ DIAMOND SETTING', '----DIAMANTÉ DIAMOND SETTING - PROXIMITY SEARCH'),
+])
+def test_bypass_nonascii_characters(client, jwt, app, criteria, seed):
+    # seed_database_with(client, jwt, seed)
+    verify_synonym_match(client, jwt,
+        query=criteria,
+        expected_list=[seed]
+    )


### PR DESCRIPTION
*Issue #: [bcgov/entity#65](https://github.com/bcgov/entity/issues/65)*

*Description of changes:*
Using urllib parse quote function to encode the name to avoid 500 error happen in solr search. Also, using urllib parse unquote function to decode the result from solr.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
