### PR TITLE
Set NR to draft in NRO when set to draft in Namex.

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -799,40 +799,36 @@ class Request(Resource):
                         return jsonify(errors=warning_and_errors), 400
 
 
-            # update oracle if this nr was reset
             if reset:
+                nrd.stateCd = State.DRAFT
+                is_changed__request_state = True
+
                 nrd.expirationDate = None
-                current_app.logger.debug('set state to h')
-                try:
-                    nro.set_request_status_to_h(nr, user.username)
-                except (NROServicesError, Exception) as err:
-                    MessageServices.add_message('error', 'reset_request_in_NRO', err)
-                    # flash(err.error, 'error')
+                is_changed__request = True
 
-            ### Update NR Details in NRO (not for reset)
-            else:
-                try:
-                    change_flags = {
-                        'is_changed__request': is_changed__request,
-                        'is_changed__previous_request': is_changed__previous_request,
-                        'is_changed__applicant': is_changed__applicant,
-                        'is_changed__address': is_changed__address,
-                        'is_changed__name1': is_changed__name1,
-                        'is_changed__name2': is_changed__name2,
-                        'is_changed__name3': is_changed__name3,
-                        'is_changed__nwpta_ab': is_changed__nwpta_ab,
-                        'is_changed__nwpta_sk': is_changed__nwpta_sk,
-                        'is_changed__request_state': is_changed__request_state,
-                    }
+            ### Update NR Details in NRO
+            try:
+                change_flags = {
+                    'is_changed__request': is_changed__request,
+                    'is_changed__previous_request': is_changed__previous_request,
+                    'is_changed__applicant': is_changed__applicant,
+                    'is_changed__address': is_changed__address,
+                    'is_changed__name1': is_changed__name1,
+                    'is_changed__name2': is_changed__name2,
+                    'is_changed__name3': is_changed__name3,
+                    'is_changed__nwpta_ab': is_changed__nwpta_ab,
+                    'is_changed__nwpta_sk': is_changed__nwpta_sk,
+                    'is_changed__request_state': is_changed__request_state,
+                }
 
-                    # if any data has changed from an NR Details edit, update it in Oracle
-                    if any(value is True for value in change_flags.values()):
-                        warnings = nro.change_nr(nrd, change_flags)
-                        if warnings:
-                            MessageServices.add_message(MessageServices.ERROR, 'change_request_in_NRO', warnings)
+                # if any data has changed from an NR Details edit, update it in Oracle
+                if any(value is True for value in change_flags.values()):
+                    warnings = nro.change_nr(nrd, change_flags)
+                    if warnings:
+                        MessageServices.add_message(MessageServices.ERROR, 'change_request_in_NRO', warnings)
 
-                except (NROServicesError, Exception) as err:
-                    MessageServices.add_message('error', 'change_request_in_NRO', err)
+            except (NROServicesError, Exception) as err:
+                MessageServices.add_message('error', 'change_request_in_NRO', err)
 
             # if there were errors, return the set of errors
             warning_and_errors = MessageServices.get_all_messages()

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -569,12 +569,14 @@ class Request(Resource):
             # check if any of the Oracle db fields have changed, so we can send them back
             is_changed__request = False
             is_changed__previous_request = False
+            is_changed__request_state = False
             if nrd.requestTypeCd != orig_nrd['requestTypeCd']: is_changed__request = True
             if nrd.expirationDate != orig_nrd['expirationDate']: is_changed__request = True
             if nrd.xproJurisdiction != orig_nrd['xproJurisdiction']: is_changed__request = True
             if nrd.additionalInfo != orig_nrd['additionalInfo']: is_changed__request = True
             if nrd.natureBusinessInfo != orig_nrd['natureBusinessInfo']: is_changed__request = True
             if nrd.previousRequestId != orig_nrd['previousRequestId']: is_changed__previous_request = True
+            if nrd.stateCd != orig_nrd['state']: is_changed__request_state = True
 
             ### END request header ###
 
@@ -820,6 +822,7 @@ class Request(Resource):
                         'is_changed__name3': is_changed__name3,
                         'is_changed__nwpta_ab': is_changed__nwpta_ab,
                         'is_changed__nwpta_sk': is_changed__nwpta_sk,
+                        'is_changed__request_state': is_changed__request_state,
                     }
 
                     # if any data has changed from an NR Details edit, update it in Oracle

--- a/api/namex/services/name_request/__init__.py
+++ b/api/namex/services/name_request/__init__.py
@@ -46,6 +46,10 @@ def valid_state_transition(user, nr, new_state):
     if new_state == State.CANCELLED and nr.stateCd in State.CANCELLABLE_STATES:
         return True
 
+    # allow Editor or Approver to move to draft
+    if new_state == State.DRAFT and (jwt.validate_roles([User.APPROVER]) or jwt.validate_roles([User.EDITOR])):
+        return True
+
     # NR is in a final state, but maybe the user wants to pull it back for corrections
     if nr.stateCd in State.COMPLETED_STATE:
         if not jwt.validate_roles([User.APPROVER]):

--- a/api/tests/python/nro_services/test_update_request.py
+++ b/api/tests/python/nro_services/test_update_request.py
@@ -1,7 +1,12 @@
 import cx_Oracle
 from namex import nro
+from namex.models import User
 from tests.python import integration_oracle_namesdb, integration_oracle_local_namesdb
-from namex.services.nro.change_nr import _update_request
+from namex.services.nro.change_nr import \
+    _update_request, \
+    _get_event_id, \
+    _create_nro_transaction, \
+    _update_nro_request_state
 
 
 @integration_oracle_namesdb
@@ -41,3 +46,91 @@ def test_preserves_previous_request_id(app):
     (value,) = cursor.fetchone()
 
     assert '99' == value
+
+
+@integration_oracle_namesdb
+def test_create_nro_transaction(app):
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+
+    _create_nro_transaction(cursor, fake_request, eid)
+
+    cursor.execute("select event_id, transaction_type_cd from transaction where request_id = {} order by event_id desc".format(fake_request.requestId))
+    (value, transaction_type_cd) = cursor.fetchone()
+
+    assert eid == value
+    assert value != 0
+    assert value != None
+    assert transaction_type_cd == 'ADMIN'
+
+@integration_oracle_namesdb
+def test_create_nro_transaction_with_type(app):
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+
+    _create_nro_transaction(cursor, fake_request, eid, 'CORRT')
+
+    cursor.execute("select event_id, transaction_type_cd from transaction where request_id = {} order by event_id desc".format(fake_request.requestId))
+    (value, transaction_type_cd) = cursor.fetchone()
+
+    assert eid == value
+    assert transaction_type_cd == 'CORRT'
+
+
+@integration_oracle_namesdb
+def test_update_nro_request_state_to_draft(app):
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+    fake_request.stateCd = 'DRAFT'
+    fake_request.activeUser = user
+
+    _update_nro_request_state(cursor, fake_request, eid, {'is_changed__request_state': True})
+
+    cursor.execute("select state_type_cd from request_state where request_id = {} and start_event_id = {}"
+                   .format(fake_request.requestId, eid))
+    (state_type_cd,) = cursor.fetchone()
+
+    assert state_type_cd == 'D'
+
+
+@integration_oracle_namesdb
+def test_update_nro_request_state_to_approved(app):
+    """
+    Code should not allow us to set state to anything except Draft
+    """
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+    fake_request.stateCd = 'APPROVED'
+    fake_request.activeUser = user
+
+    _update_nro_request_state(cursor, fake_request, eid, {'is_changed__request_state': True})
+
+    cursor.execute("select state_type_cd from request_state where request_id = {} and start_event_id = {}"
+                   .format(fake_request.requestId, eid))
+    resultset = cursor.fetchone()
+
+    assert resultset is None


### PR DESCRIPTION
*Issue #, if available:* bcgov/entity#26 + bcgov/entity#40

*Description of changes:*
Set NR back to Draft ("D") in NRO when set back to Draft in Namex, for regular edits as well as RESET.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
