### PR TITLE
Update Oracle wallet location on Oracle 12 servers. #15

### DIFF
--- a/nro-legacy/sql/release/20190202_oracle_12/names/namex/update.sql
+++ b/nro-legacy/sql/release/20190202_oracle_12/names/namex/update.sql
@@ -1,0 +1,8 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlNoDataSourceInspectionForFile
+
+-- Update the location of the Oracle Wallet used to make web service calls.
+
+UPDATE configuration
+    SET value = 'file:/u01/app/oracle/product/12.2.0.1/dbhome_1/data/wallet'
+    WHERE application = 'GLOBAL' AND name = 'oracle_wallet';


### PR DESCRIPTION
*Issue #, if available:* 15

*Description of changes:* added an update script to be run on the NAMES database after the upgrade to Oracle 12.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
