### PR TITLE
Update call to require only one of the given roles instead of all

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -321,7 +321,7 @@ class Request(Resource):
 
     @staticmethod
     @cors.crossdomain(origin='*')
-    @jwt.requires_roles([User.APPROVER, User.EDITOR, User.VIEWONLY])
+    @jwt.has_one_of_roles([User.APPROVER, User.EDITOR, User.VIEWONLY])
     def get(nr):
         # return jsonify(request_schema.dump(RequestDAO.query.filter_by(nr=nr.upper()).first_or_404()))
         return jsonify(RequestDAO.query.filter_by(nrNum =nr.upper()).first_or_404().json())


### PR DESCRIPTION
*Issue #, if available:*
bcgov/entity#97

*Description of changes:*
Update the call for the nr get so that it only requires one of the listed roles.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).