### PR TITLE
Correction to the view and updated tests

### DIFF
--- a/nro-legacy/sql/object/registry/namex/view/solr_dataimport_conflicts_vw.sql
+++ b/nro-legacy/sql/object/registry/namex/view/solr_dataimport_conflicts_vw.sql
@@ -31,7 +31,7 @@ WHERE corp.end_event_id IS NULL
   and c.corp_num NOT IN (select cname.corp_num   from corp_name cname
                          left outer join corporation c1 on c1.corp_num = cname.corp_num
                          where cname.corp_num = c.corp_num
-                           and cname.corp_name_typ_cd ='AS')
+                           and cname.corp_name_typ_cd ='AS' and cname.end_event_id IS NULL)
 UNION ALL
 SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
        'CORP' AS SOURCE

--- a/nro-legacy/tests/seeds.py
+++ b/nro-legacy/tests/seeds.py
@@ -2,16 +2,28 @@ from .postgres import Postgres
 
 
 def seed_corp_name(corp_num, start_event_id, corp_name_typ_cd, corp_nme):
+      Postgres().execute("""
+           insert into corp_name(
+                corp_num,
+                start_event_id,
+                corp_name_typ_cd ,
+                corp_nme
+            )
+        values ('{}','{}','{}','{}')
+     """.format(corp_num, start_event_id, corp_name_typ_cd, corp_nme))
+
+
+def seed_corp_expired_name(corp_num, start_event_id, end_event_id, corp_name_typ_cd, corp_nme):
     Postgres().execute("""
            insert into corp_name(
                 corp_num,
                 start_event_id,
-                end_event_id ,
+                end_event_id,
                 corp_name_typ_cd ,
                 corp_nme
             )
-        values ('{}','{}',null,'{}','{}')
-     """.format(corp_num, start_event_id, corp_name_typ_cd, corp_nme))
+        values ('{}','{}', null, '{}','{}')
+     """.format(corp_num, start_event_id, end_event_id,corp_name_typ_cd, corp_nme))
 
 
 def seed_corp_state(corp_num, start_event_id):

--- a/nro-legacy/tests/test_solr_corp_vw.py
+++ b/nro-legacy/tests/test_solr_corp_vw.py
@@ -89,7 +89,16 @@ def test_view():
     seed_corp_name('A0038332', '19','CO', 'RED-L HOSE DISTRIBUTORS LTD.')
     seed_corp_name('A0041224', '20', 'CO','571266 SASKATCHEWAN INC.')
 
-    #ensure these XPRO CO rows do not appear in the view
+    #ensure these XPRO CO rows  are not included in the view
+    result = Postgres().select(extract_select())
+    assert_that(len(result),equal_to(9))
+
+    #seed expired Assumed Names are not included in the view
+    seed_corp_expired_name('A0037274','21','30', 'AS','ROBEV VENTURES LTD.')
+    seed_corp_expired_name('A0038332', '22','31','AS', 'RED-L HOSE DISTRIBUTORS LTD.')
+    seed_corp_expired_name('A0041224', '23','32','AS','571266 SASKATCHEWAN INC.')
+
+    #ensure expired names do not
     result = Postgres().select(extract_select())
     assert_that(len(result),equal_to(9))
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the solr conflict view for colin to include assumed names.
Added the missing end_event_id is null for xpros.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
