### PR TITLE
Set cancel status instead of admin status when cancel a NR

### DIFF
--- a/api/namex/services/nro/change_nr.py
+++ b/api/namex/services/nro/change_nr.py
@@ -107,6 +107,16 @@ def _update_nro_request_state(oracle_cursor, nr, event_id, change_flags):
                        )
 
 
+def _cancel_nro_transaction(oracle_cursor, nr, event_id):
+
+    oracle_cursor.execute("""
+    INSERT INTO transaction (transaction_id, request_id, transaction_type_cd, event_id, staff_idir)
+      VALUES (transaction_seq.nextval, :request_id, 'CANCL', :event_id, 'namex')
+    """,
+                          request_id=nr.requestId,
+                          event_id=event_id
+                          )
+
 def _update_request(oracle_cursor, nr, event_id, change_flags):
     """ Update the current request instance.
     """

--- a/api/namex/services/nro/oracle_services.py
+++ b/api/namex/services/nro/oracle_services.py
@@ -9,6 +9,7 @@ from namex.models import State, Request, User, Event
 from namex.services.nro import NROServicesError
 from namex.services import EventRecorder
 from namex.services.nro.change_nr import update_nr, _get_event_id, _create_nro_transaction
+from namex.services.nro.change_nr import update_nr, _get_event_id, _cancel_nro_transaction
 
 from .exceptions import NROServicesError
 from .utils import nro_examiner_name
@@ -342,14 +343,14 @@ class NROServices(object):
 
         try:
             con = self.connection
-            con.begin() # explicit transaction in case we need to do other things than just call the stored proc
+            con.begin()  # explicit transaction in case we need to do other things than just call the stored proc
             try:
                 cursor = con.cursor()
 
                 event_id = _get_event_id(cursor)
                 current_app.logger.debug('got to cancel_nr() for NR:{}'.format(nr.nrNum))
                 current_app.logger.debug('event ID for NR:{}'.format(event_id))
-                _create_nro_transaction(cursor, nr, event_id)
+                _cancel_nro_transaction(cursor, nr, event_id)
 
                 # get request_state record, with all fields
                 cursor.execute("""
@@ -394,13 +395,13 @@ class NROServices(object):
                 if con:
                     con.rollback()
                 raise NROServicesError({"code": "unable_to_set_state",
-                        "description": "Unable to set the state of the NR in NRO"}, 500)
+                                        "description": "Unable to set the state of the NR in NRO"}, 500)
             except Exception as err:
                 current_app.logger.error(err.with_traceback(None))
                 if con:
                     con.rollback()
                 raise NROServicesError({"code": "unable_to_set_state",
-                        "description": "Unable to set the state of the NR in NRO"}, 500)
+                                        "description": "Unable to set the state of the NR in NRO"}, 500)
 
         except Exception as err:
             # something went wrong, roll it all back
@@ -408,7 +409,7 @@ class NROServices(object):
             if con:
                 con.rollback()
             raise NROServicesError({"code": "unable_to_set_state",
-                        "description": "Unable to set the state of the NR in NRO"}, 500)
+                                    "description": "Unable to set the state of the NR in NRO"}, 500)
 
         return None
 

--- a/api/tests/python/nro_services/test_update_request.py
+++ b/api/tests/python/nro_services/test_update_request.py
@@ -11,6 +11,45 @@ from namex.services.nro.change_nr import \
 
 
 @integration_oracle_namesdb
+def test_nro_connection(app):
+
+    conn = nro.connection
+    assert type(conn) is cx_Oracle.Connection
+
+
+class FakeRequest:
+    requestId = '42'
+    previousRequestId = '15'
+
+
+@integration_oracle_namesdb
+@integration_oracle_local_namesdb
+def test_preserves_previous_request_id(app):
+    con = nro.connection
+    cursor = con.cursor()
+    cursor.execute("""
+        declare exist number;
+        begin
+            select count(1) into exist from user_tables where table_name='REQUEST';
+            if exist = 1 then
+                execute immediate 'drop table request';
+            end if;
+        end;        
+    """)
+    cursor.execute('create table request (request_id varchar(10), previous_request_id varchar(10))')
+    cursor.execute("insert into request(request_id, previous_request_id) values('42', '99')")
+    _update_request(cursor, FakeRequest(), None, {
+        'is_changed__request': False,
+        'is_changed__previous_request': True
+    })
+
+    cursor.execute("select previous_request_id from request")
+    (value,) = cursor.fetchone()
+
+    assert '99' == value
+
+
+@integration_oracle_namesdb
 def test_create_nro_transaction(app):
     con = nro.connection
     cursor = con.cursor()
@@ -29,6 +68,73 @@ def test_create_nro_transaction(app):
     assert value != 0
     assert value != None
     assert transaction_type_cd == 'ADMIN'
+
+@integration_oracle_namesdb
+def test_create_nro_transaction_with_type(app):
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+
+    _create_nro_transaction(cursor, fake_request, eid, 'CORRT')
+
+    cursor.execute("select event_id, transaction_type_cd from transaction where request_id = {} order by event_id desc".format(fake_request.requestId))
+    (value, transaction_type_cd) = cursor.fetchone()
+
+    assert eid == value
+    assert transaction_type_cd == 'CORRT'
+
+
+@integration_oracle_namesdb
+def test_update_nro_request_state_to_draft(app):
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+    fake_request.stateCd = 'DRAFT'
+    fake_request.activeUser = user
+
+    _update_nro_request_state(cursor, fake_request, eid, {'is_changed__request_state': True})
+
+    cursor.execute("select state_type_cd from request_state where request_id = {} and start_event_id = {}"
+                   .format(fake_request.requestId, eid))
+    (state_type_cd,) = cursor.fetchone()
+
+    assert state_type_cd == 'D'
+
+
+@integration_oracle_namesdb
+def test_update_nro_request_state_to_approved(app):
+    """
+    Code should not allow us to set state to anything except Draft
+    """
+    con = nro.connection
+    cursor = con.cursor()
+
+    eid = _get_event_id(cursor)
+
+    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
+
+    fake_request = FakeRequest()
+    fake_request.requestId = 884047
+    fake_request.stateCd = 'APPROVED'
+    fake_request.activeUser = user
+
+    _update_nro_request_state(cursor, fake_request, eid, {'is_changed__request_state': True})
+
+    cursor.execute("select state_type_cd from request_state where request_id = {} and start_event_id = {}"
+                   .format(fake_request.requestId, eid))
+    resultset = cursor.fetchone()
+
+    assert resultset is None
 
 
 @integration_oracle_local_namesdb

--- a/api/tests/python/nro_services/test_update_request.py
+++ b/api/tests/python/nro_services/test_update_request.py
@@ -6,8 +6,7 @@ from namex.services.nro.change_nr import \
     _update_request, \
     _get_event_id, \
     _create_nro_transaction, \
-    _update_nro_request_state, \
-    _cancel_nro_transaction
+    _update_nro_request_state
 
 
 @integration_oracle_namesdb
@@ -68,6 +67,7 @@ def test_create_nro_transaction(app):
     assert value != 0
     assert value != None
     assert transaction_type_cd == 'ADMIN'
+
 
 @integration_oracle_namesdb
 def test_create_nro_transaction_with_type(app):
@@ -137,27 +137,3 @@ def test_update_nro_request_state_to_approved(app):
     assert resultset is None
 
 
-@integration_oracle_local_namesdb
-def test_create_cancel_nro_transaction(app):
-    con = nro.connection
-    cursor = con.cursor()
-
-    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP TABLE transaction'; EXCEPTION WHEN OTHERS THEN "
-                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
-    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE transaction_seq'; EXCEPTION WHEN OTHERS THEN "
-                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
-
-    cursor.execute('create sequence transaction_seq minvalue 1 maxvalue 9999999999 increment by 1 start with 1')
-    cursor.execute('create table transaction (transaction_id number(10), request_id varchar2(10), '
-                   'transaction_type_cd varchar2(10), event_id number(10),staff_idir varchar2(8))')
-    _cancel_nro_transaction(cursor, FakeRequest(), None)
-
-    cursor.execute("select transaction_type_cd from transaction")
-    (value,) = cursor.fetchone()
-
-    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP TABLE transaction'; EXCEPTION WHEN OTHERS THEN "
-                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
-    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE transaction_seq'; EXCEPTION WHEN OTHERS THEN "
-                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
-
-    assert 'CANCL' == value

--- a/api/tests/python/nro_services/test_update_request.py
+++ b/api/tests/python/nro_services/test_update_request.py
@@ -2,62 +2,14 @@ import cx_Oracle
 from namex import nro
 from namex.models import User
 from tests.python import integration_oracle_namesdb, integration_oracle_local_namesdb
-<<<<<<< HEAD
-<<<<<<< HEAD
 from namex.services.nro.change_nr import \
     _update_request, \
     _get_event_id, \
     _create_nro_transaction, \
-    _update_nro_request_state
-=======
-from namex.services.nro.change_nr import _update_request, _cancel_nro_transaction
->>>>>>> Set cancel status instead of admin status when cancel a NR
-=======
-from namex.services.nro.change_nr import _update_request, _cancel_nro_transaction
->>>>>>> c38389a4df40324987e72adac61e0f9897a2144d
+    _update_nro_request_state, \
+    _cancel_nro_transaction
 
 
-@integration_oracle_namesdb
-def test_nro_connection(app):
-
-    conn = nro.connection
-    assert type(conn) is cx_Oracle.Connection
-
-
-class FakeRequest:
-    requestId = '42'
-    previousRequestId = '15'
-
-
-@integration_oracle_namesdb
-@integration_oracle_local_namesdb
-def test_preserves_previous_request_id(app):
-    con = nro.connection
-    cursor = con.cursor()
-    cursor.execute("""
-        declare exist number;
-        begin
-            select count(1) into exist from user_tables where table_name='REQUEST';
-            if exist = 1 then
-                execute immediate 'drop table request';
-            end if;
-        end;        
-    """)
-    cursor.execute('create table request (request_id varchar(10), previous_request_id varchar(10))')
-    cursor.execute("insert into request(request_id, previous_request_id) values('42', '99')")
-    _update_request(cursor, FakeRequest(), None, {
-        'is_changed__request': False,
-        'is_changed__previous_request': True
-    })
-
-    cursor.execute("select previous_request_id from request")
-    (value,) = cursor.fetchone()
-
-    assert '99' == value
-
-
-<<<<<<< HEAD
-<<<<<<< HEAD
 @integration_oracle_namesdb
 def test_create_nro_transaction(app):
     con = nro.connection
@@ -78,75 +30,7 @@ def test_create_nro_transaction(app):
     assert value != None
     assert transaction_type_cd == 'ADMIN'
 
-@integration_oracle_namesdb
-def test_create_nro_transaction_with_type(app):
-    con = nro.connection
-    cursor = con.cursor()
 
-    eid = _get_event_id(cursor)
-
-    fake_request = FakeRequest()
-    fake_request.requestId = 884047
-
-    _create_nro_transaction(cursor, fake_request, eid, 'CORRT')
-
-    cursor.execute("select event_id, transaction_type_cd from transaction where request_id = {} order by event_id desc".format(fake_request.requestId))
-    (value, transaction_type_cd) = cursor.fetchone()
-
-    assert eid == value
-    assert transaction_type_cd == 'CORRT'
-
-
-@integration_oracle_namesdb
-def test_update_nro_request_state_to_draft(app):
-    con = nro.connection
-    cursor = con.cursor()
-
-    eid = _get_event_id(cursor)
-
-    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
-
-    fake_request = FakeRequest()
-    fake_request.requestId = 884047
-    fake_request.stateCd = 'DRAFT'
-    fake_request.activeUser = user
-
-    _update_nro_request_state(cursor, fake_request, eid, {'is_changed__request_state': True})
-
-    cursor.execute("select state_type_cd from request_state where request_id = {} and start_event_id = {}"
-                   .format(fake_request.requestId, eid))
-    (state_type_cd,) = cursor.fetchone()
-
-    assert state_type_cd == 'D'
-
-
-@integration_oracle_namesdb
-def test_update_nro_request_state_to_approved(app):
-    """
-    Code should not allow us to set state to anything except Draft
-    """
-    con = nro.connection
-    cursor = con.cursor()
-
-    eid = _get_event_id(cursor)
-
-    user = User('idir/bob', 'bob', 'last', 'idir', 'localhost')
-
-    fake_request = FakeRequest()
-    fake_request.requestId = 884047
-    fake_request.stateCd = 'APPROVED'
-    fake_request.activeUser = user
-
-    _update_nro_request_state(cursor, fake_request, eid, {'is_changed__request_state': True})
-
-    cursor.execute("select state_type_cd from request_state where request_id = {} and start_event_id = {}"
-                   .format(fake_request.requestId, eid))
-    resultset = cursor.fetchone()
-
-    assert resultset is None
-=======
-=======
->>>>>>> c38389a4df40324987e72adac61e0f9897a2144d
 @integration_oracle_local_namesdb
 def test_create_cancel_nro_transaction(app):
     con = nro.connection
@@ -171,7 +55,3 @@ def test_create_cancel_nro_transaction(app):
                    "IF SQLCODE != -942 THEN NULL; END IF; END;")
 
     assert 'CANCL' == value
-<<<<<<< HEAD
->>>>>>> Set cancel status instead of admin status when cancel a NR
-=======
->>>>>>> c38389a4df40324987e72adac61e0f9897a2144d

--- a/api/tests/python/nro_services/test_update_request.py
+++ b/api/tests/python/nro_services/test_update_request.py
@@ -2,11 +2,15 @@ import cx_Oracle
 from namex import nro
 from namex.models import User
 from tests.python import integration_oracle_namesdb, integration_oracle_local_namesdb
+<<<<<<< HEAD
 from namex.services.nro.change_nr import \
     _update_request, \
     _get_event_id, \
     _create_nro_transaction, \
     _update_nro_request_state
+=======
+from namex.services.nro.change_nr import _update_request, _cancel_nro_transaction
+>>>>>>> Set cancel status instead of admin status when cancel a NR
 
 
 @integration_oracle_namesdb
@@ -48,6 +52,7 @@ def test_preserves_previous_request_id(app):
     assert '99' == value
 
 
+<<<<<<< HEAD
 @integration_oracle_namesdb
 def test_create_nro_transaction(app):
     con = nro.connection
@@ -134,3 +139,29 @@ def test_update_nro_request_state_to_approved(app):
     resultset = cursor.fetchone()
 
     assert resultset is None
+=======
+@integration_oracle_local_namesdb
+def test_create_cancel_nro_transaction(app):
+    con = nro.connection
+    cursor = con.cursor()
+
+    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP TABLE transaction'; EXCEPTION WHEN OTHERS THEN "
+                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
+    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE transaction_seq'; EXCEPTION WHEN OTHERS THEN "
+                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
+
+    cursor.execute('create sequence transaction_seq minvalue 1 maxvalue 9999999999 increment by 1 start with 1')
+    cursor.execute('create table transaction (transaction_id number(10), request_id varchar2(10), '
+                   'transaction_type_cd varchar2(10), event_id number(10),staff_idir varchar2(8))')
+    _cancel_nro_transaction(cursor, FakeRequest(), None)
+
+    cursor.execute("select transaction_type_cd from transaction")
+    (value,) = cursor.fetchone()
+
+    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP TABLE transaction'; EXCEPTION WHEN OTHERS THEN "
+                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
+    cursor.execute("BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE transaction_seq'; EXCEPTION WHEN OTHERS THEN "
+                   "IF SQLCODE != -942 THEN NULL; END IF; END;")
+
+    assert 'CANCL' == value
+>>>>>>> Set cancel status instead of admin status when cancel a NR


### PR DESCRIPTION
*Issue #, [bcgov/entity#36](https://github.com/bcgov/entity/issues/36):*

*Description of changes:*
Add a new create cancel status transaction function and modify the change nr function when NR get cancelled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
