### PR TITLE
Add code to handle Non-ASCII characters only

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -142,7 +142,9 @@ class SolrQueries:
                 name = name[:index]
                 break
 
-        name = name.upper().replace(' AND ',' ').replace('&',' ').replace('+',' ')
+        # handle non-ascii chars in name
+        name = ''.join([i if ord(i) < 128 else parse.quote(i) for i in name])
+        name = name.upper().replace(' AND ', ' ').replace('&', ' ').replace('+', ' ')
         list_name_split = name.split()
 
         def replace_nth(string, deleted_substr, added_substr, n):
@@ -207,9 +209,10 @@ class SolrQueries:
                 solr['response']['numFound'] += result['response']['numFound']
                 solr['response']['start'] = result['response']['start']
 
-                if previous_stack_title.replace(' ','') != connection[1].replace(' ',''):
-                    solr['response']['docs'].append({'name': connection[1]})
-                    previous_stack_title = connection[1]
+                result_name = parse.unquote(connection[1])
+                if previous_stack_title.replace(' ','') != result_name.replace(' ',''):
+                    solr['response']['docs'].append({'name': result_name})
+                    previous_stack_title = parse.unquote(result_name)
 
                 if len(result['response']['docs']) > 0:
 

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -32,6 +32,7 @@ claims = {
 SOLR_URL = os.getenv('SOLR_TEST_URL')
 SOLR_SYNONYMS_API_URL = os.getenv('SOLR_SYNONYMS_API_URL')
 
+
 @pytest.fixture(scope="session", autouse=True)
 def reload_schema(request):
     url = SOLR_URL + '/solr/admin/cores?action=RELOAD&core=possible.conflicts&wt=json'
@@ -39,12 +40,14 @@ def reload_schema(request):
 
     assert r.status_code == 200
 
+
 @integration_solr
 def test_solr_available(app, client, jwt):
     url = SOLR_URL + '/solr/possible.conflicts/admin/ping'
     r = requests.get(url)
 
     assert r.status_code == 200
+
 
 def clean_database(client, jwt):
     url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
@@ -54,6 +57,7 @@ def clean_database(client, jwt):
 
     assert r.status_code == 200
 
+
 def seed_database_with(client, jwt, name, id='1', source='2'):
     clean_database(client, jwt)
     url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
@@ -62,6 +66,7 @@ def seed_database_with(client, jwt, name, id='1', source='2'):
     r = requests.post(url, headers=headers, data=data)
 
     assert r.status_code == 200
+
 
 def verify(data, expected=None, not_expected=None):
 
@@ -78,7 +83,7 @@ def verify(data, expected=None, not_expected=None):
         print('NOT EXPECTED ', not_expected)
 
         if expected is []:
-        # check that the name is the title of a query sent (no real names were returned from solr)
+            # check that the name is the title of a query sent (no real names were returned from solr)
             if name['name'].find('----') == -1:
                 verified = False
                 break
@@ -100,6 +105,7 @@ def verify(data, expected=None, not_expected=None):
 # def verify_synonym_match_results(client, jwt, query, expected):
 #     data = search_synonym_match(client, jwt, query)
 #     verify(data, expected)
+
 
 def verify_synonym_match(client, jwt, query, expected_list=None, not_expected_list=None):
     data = search_synonym_match(client, jwt, query)
@@ -125,6 +131,7 @@ def search_synonym_match(client, jwt, query):
     assert rv.status_code == 200
     return json.loads(rv.data)
 
+
 @integration_synonym_api
 @integration_solr
 def test_find_with_first_word(client, jwt, app):
@@ -133,6 +140,7 @@ def test_find_with_first_word(client, jwt, app):
         query='JM',
         expected_list=['----JM - PROXIMITY SEARCH','JM Van Damme inc ']
     )
+
 
 @pytest.mark.skip(reason="frontend handles empty string for now")
 @integration_synonym_api
@@ -144,6 +152,7 @@ def test_resist_empty(client, jwt, app):
         expected_list=[]
     )
 
+
 @integration_synonym_api
 @integration_solr
 def test_case_insensitive(client, jwt, app):
@@ -152,6 +161,7 @@ def test_case_insensitive(client, jwt, app):
         query='jackles',
         expected_list=['----JACKLES ', 'JacKlEs']
     )
+
 
 @integration_synonym_api
 @integration_solr
@@ -162,6 +172,7 @@ def test_no_match(client, jwt, app):
         expected_list=None
     )
 
+
 @integration_synonym_api
 @integration_solr
 def test_numbers_preserved(client, jwt, app):
@@ -170,6 +181,7 @@ def test_numbers_preserved(client, jwt, app):
        query='VAN 4 TRUCKING',
        expected_list=['VAN 4 TRUCKING INC']
     )
+
 
 @integration_synonym_api
 @integration_solr
@@ -180,6 +192,7 @@ def test_designation_removal(client, jwt, app):
         expected_list=['----DESIGNATION - PROXIMITY SEARCH', 'DESIGNATION TEST'],
         not_expected_list=['----DESIGNATION LIMITED ']
     )
+
 
 @integration_synonym_api
 @integration_solr
@@ -201,6 +214,7 @@ def test_handles_s_and_possession(client, jwt, app, criteria, seed):
         expected_list=[seed]
     )
 
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [
@@ -212,6 +226,7 @@ def test_handles_dollar_cent(client, jwt, app, criteria, seed):
         query=criteria,
         expected_list=[seed]
     )
+
 
 # TODO: fill out tests for all stop words
 @integration_synonym_api
@@ -230,6 +245,7 @@ def test_stopwords(client, jwt, app, criteria, seed):
         expected_list=[seed]
     )
 
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [
@@ -243,6 +259,7 @@ def test_finds_names_with_word_to_left_of_distinctive(client, jwt, app, criteria
         expected_list=[seed]
     )
 
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [
@@ -255,6 +272,7 @@ def test_word_order_mixed(client, jwt, app, criteria, seed):
         query=criteria,
         expected_list=[seed]
     )
+
 
 @pytest.mark.skip(reason="duplicates not handled yet")
 @integration_synonym_api
@@ -301,6 +319,7 @@ def test_finds_variations_on_initials(client, jwt, app, criteria, seed):
         expected_list=[seed]
     )
 
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [
@@ -319,6 +338,7 @@ def test_wildcard_operator(client, jwt, app, criteria, seed):
         query=criteria,
         expected_list=[seed]
     )
+
 
 @integration_synonym_api
 @integration_solr
@@ -399,6 +419,7 @@ def test_special_characters(client, jwt, app, criteria, seed):
        expected_list=[seed]
     )
 
+
 @integration_synonym_api
 @integration_solr
 def test_prox_search_ignores_wildcards(client, jwt, app):
@@ -409,6 +430,7 @@ def test_prox_search_ignores_wildcards(client, jwt, app):
         not_expected_list=['----TESTING* @WILDCARDS - PROXIMITY SEARCH']
     )
 
+
 @integration_synonym_api
 @integration_solr
 def test_exact_word_order_stack_title_with_wilcards(client, jwt, app):
@@ -418,17 +440,21 @@ def test_exact_word_order_stack_title_with_wilcards(client, jwt, app):
         not_expected_list=['----TESTING** - EXACT WORD ORDER']
     )
 
+
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("criteria, seed", [
-    ('WALTER’S “WAFFLE” HOUSE', '----WALTER’S “WAFFLE” HOUSE - PROXIMITY SEARCH'),
     ('TJ´S BACKCOUNTRY ADVENTURES.', '----TJ´S BACKCOUNTRY ADVENTURES. - PROXIMITY SEARCH'),
     ('THE HOUSE OF BÜBÜ AN DA WOLF.', '----THE HOUSE OF BÜBÜ AN DA WOLF. - PROXIMITY SEARCH'),
     ('DIAMANTÉ DIAMOND SETTING', '----DIAMANTÉ DIAMOND SETTING - PROXIMITY SEARCH'),
+    ('MICHELLE¿S BEAR ESSENTIALS.', '----MICHELLE¿S BEAR ESSENTIALS. - PROXIMITY SEARCH'),
+    ('TEST àâçèéêëîïôöùûü BEAR.', '----TEST àâçèéêëîïôöùûü BEAR. - PROXIMITY SEARCH'),
+    ('TEST ÀÂÇÈÉÊËÎÏÔÖÙÛÜS BEAR.', '----TEST ÀÂÇÈÉÊËÎÏÔÖÙÛÜS BEAR. - PROXIMITY SEARCH'),
+    ('TEST °£÷¥·©§¶¼½`¾¢!¦«ª¡¹²³»¿¬±¤®× BEAR.', '----TEST °£÷¥·©§¶¼½`¾¢!¦«ª¡¹²³»¿¬±¤®× BEAR. - PROXIMITY SEARCH'),
 ])
 def test_bypass_nonascii_characters(client, jwt, app, criteria, seed):
-    # seed_database_with(client, jwt, seed)
-    verify_synonym_match(client, jwt,
-        query=criteria,
-        expected_list=[seed]
-    )
+    seed_database_with(client, jwt, seed)
+    verify_synonym_match(client,
+                         jwt,
+                         query=criteria,
+                         expected_list=[seed])


### PR DESCRIPTION
Signed-off-by: PWEI <patrick.wei@gov.bc.ca>

*Issue #, if available:*
[bcgov/entity#65](https://github.com/bcgov/entity/issues/65)

*Description of changes:*
Using parse quote function to encode non-ASCII characters one by one of search name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
