### PR TITLE
changed path for stopwords file

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -726,7 +726,7 @@ class SolrQueries:
 
         stop_words = []
         try:
-            with open('../solr/cores/possible.conflicts/conf/stopwords.txt') as stop_words_file:
+            with open('../solr/mycores/possible.conflicts/conf/stopwords.txt') as stop_words_file:
                 stop_words = []
                 for line in stop_words_file.readlines():
                     if line.find('#') == -1:


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #, if available:bcgov/entity#69 bcgov/entity#74*

*Description of changes:*
- path of stopword file is in 'mycores' dir not 'cores' dir in openshift - changed code to match

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
