### PR TITLE
Upon reset/re-open, change NR state to INPROGRESS rather than DRAFT.

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -847,10 +847,6 @@ class Request(Resource):
                 except (NROServicesError, Exception) as err:
                     MessageServices.add_message('error', 'reset_request_in_NRO', err)
 
-                # change state to DRAFT
-                nrd.stateCd = State.DRAFT
-                is_changed__request_state = True
-
                 nrd.expirationDate = None
                 is_changed__request = True
 

--- a/api/namex/services/name_request/__init__.py
+++ b/api/namex/services/name_request/__init__.py
@@ -46,13 +46,9 @@ def valid_state_transition(user, nr, new_state):
     if new_state == State.CANCELLED and nr.stateCd in State.CANCELLABLE_STATES:
         return True
 
-    # allow Editor or Approver to move to draft
-    if new_state == State.DRAFT and (jwt.validate_roles([User.APPROVER]) or jwt.validate_roles([User.EDITOR])):
-        return True
-
     # NR is in a final state, but maybe the user wants to pull it back for corrections
     if nr.stateCd in State.COMPLETED_STATE:
-        if not jwt.validate_roles([User.APPROVER]):
+        if not jwt.validate_roles([User.APPROVER]) and not jwt.validate_roles([User.EDITOR]):
             return False
             # return jsonify({"message": "Only Names Examiners can alter completed Requests"}), 401
 

--- a/api/tests/postman/namex-pipeline-dev.postman_collection.json
+++ b/api/tests/postman/namex-pipeline-dev.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e8e8817a-d37c-4ff0-a750-ff8d811334ff",
+		"_postman_id": "5146a8ea-fabf-4197-b542-85354ea3641e",
 		"name": "namex-pipeline-dev",
 		"description": "# Introduction\nWhat does your API do?\n\n# Overview\nThings that the developers should know about\n\n# Authentication\nWhat is the preferred way of using the API?\n\n# Error Codes\nWhat errors and status codes can a user expect?\n\n# Rate limit\nIs there a limit to the number of requests an user can send?",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1916,85 +1916,6 @@
 								"{{NR}}"
 							]
 						}
-					},
-					"response": []
-				},
-				{
-					"name": "requests/NR # change state to INPROGRESS",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "36e019ae-a7c4-4599-8631-564ad3d11ef0",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "346c9a5d-ee8f-48cd-9b21-bad29baf9ecb",
-								"type": "text/javascript",
-								"exec": [
-									"eval(globals.postmanBDD);",
-									"",
-									"tests[\"Response time is acceptable\"] = responseTime < 8000;",
-									"",
-									"it('Should be an success response', () => {",
-									"    response.ok.should.be.true;            // 2XX",
-									"    response.error.should.be.false;          // 4XX or 5XX",
-									"    response.clientError.should.be.false;    // 4XX",
-									"    response.serverError.should.be.false;   // 5XX",
-									"    response.should.have.status(200);",
-									"    response.statusType.should.equal(2);",
-									"});",
-									"",
-									"it('Should return JSON', () => {",
-									"    response.should.be.json;",
-									"    response.should.have.header('Content-Type', 'application/json');",
-									"    response.type.should.equal('application/json');",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"it('Should contain \\'message\\' confirming patch', () => {",
-									"    response.body.should.be.an('object').with.keys(['message']);",
-									"    jsonData.message.should.include('- patched');",
-									"});"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "PATCH",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"state\": \"INPROGRESS\"}"
-						},
-						"url": {
-							"raw": "{{url}}/api/v1/requests/{{NR}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"requests",
-								"{{NR}}"
-							]
-						},
-						"description": "Must change to INPROGRESS before HOLD (next call) because DRAFT to HOLD is not a valid transition."
 					},
 					"response": []
 				},

--- a/api/tests/postman/namex-pipeline-test.postman_collection.json
+++ b/api/tests/postman/namex-pipeline-test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c3c2bf5d-25c7-4296-8d33-7771c6774af5",
+		"_postman_id": "f4078534-fd78-48a1-a4df-7721aeaec1c2",
 		"name": "namex-pipeline-test",
 		"description": "# Introduction\nWhat does your API do?\n\n# Overview\nThings that the developers should know about\n\n# Authentication\nWhat is the preferred way of using the API?\n\n# Error Codes\nWhat errors and status codes can a user expect?\n\n# Rate limit\nIs there a limit to the number of requests an user can send?",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -2025,87 +2025,6 @@
 							]
 						},
 						"description": "Test RESET"
-					},
-					"response": []
-				},
-				{
-					"name": "requests/NR # - change state to INPROGRESS",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "36e019ae-a7c4-4599-8631-564ad3d11ef0",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "346c9a5d-ee8f-48cd-9b21-bad29baf9ecb",
-								"exec": [
-									"eval(globals.postmanBDD);",
-									"",
-									"tests[\"Response time is acceptable\"] = responseTime < 8000;",
-									"",
-									"it('Should be an success response', () => {",
-									"    response.ok.should.be.true;            // 2XX",
-									"    response.error.should.be.false;          // 4XX or 5XX",
-									"    response.clientError.should.be.false;    // 4XX",
-									"    response.serverError.should.be.false;   // 5XX",
-									"    response.should.have.status(200);",
-									"    response.statusType.should.equal(2);",
-									"});",
-									"",
-									"it('Should return JSON', () => {",
-									"    response.should.be.json;",
-									"    response.should.have.header('Content-Type', 'application/json');",
-									"    response.type.should.equal('application/json');",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"it('Should contain \\'message\\' confirming patch', () => {",
-									"    response.body.should.be.an('object').with.keys(['message']);",
-									"    jsonData.message.should.include('- patched');",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PATCH",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"state\": \"INPROGRESS\"}"
-						},
-						"url": {
-							"raw": "{{url}}/api/v1/requests/{{NR}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"requests",
-								"{{NR}}"
-							]
-						},
-						"description": "Must change to INPROGRESS before HOLD (next call) because DRAFT to HOLD is not a valid transition."
 					},
 					"response": []
 				},


### PR DESCRIPTION
*Issue #, if available:* bcgov/entity#118

*Description of changes:*
Per request, change workflow (mainly in front-end) of RESET functionality based on role. Step 1 for all roles is to set to INPROGRESS so NR cannot be "stolen" by another user.

There is a corresponding front-end PR required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
