### PR TITLE
fixed stem list for edge case stems(property, equity, etc.)

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -895,8 +895,8 @@ class SolrQueries:
                 for text in processed_words['analysis']['field_names']['name']['index'][count]:
                     processed_list.append(text['text'])
 
-                stem_in_name = False
                 for item in list_of_words:
+                    stem_in_name = False
                     for processed_synonym in processed_list:
                         if processed_synonym.upper() in item.upper():
                             stem_in_name = True

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -513,6 +513,7 @@ def test_order(client, jwt, app, query, ordered_list):
     ('CONSULTING CONSTRUCTION DEVELOPMENT', ['CONSULT', 'CONSTRUCT', 'DEVELOP']),
     ('PROPERTY', ['PROPERTY', 'PROPERTI']),
     ('PROPERTIES', ['PROPERTI']),
+    ('MANAGEMENT PROPERTY', ['MANAG','PROPERTY','PROPERTI']),
 ])
 def test_stems(client, jwt, app, query, stems):
     verify_stems(client, jwt, query=query, stems=stems)

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -513,7 +513,7 @@ def test_order(client, jwt, app, query, ordered_list):
     ('CONSULTING CONSTRUCTION DEVELOPMENT', ['CONSULT', 'CONSTRUCT', 'DEVELOP']),
     ('PROPERTY', ['PROPERTY', 'PROPERTI']),
     ('PROPERTIES', ['PROPERTI']),
-    ('MANAGEMENT PROPERTY', ['MANAG','PROPERTY','PROPERTI']),
+    ('MANAGEMENT PROPERTY', ['PROPERTY','MANAG','PROPERTI']),
 ])
 def test_stems(client, jwt, app, query, stems):
     verify_stems(client, jwt, query=query, stems=stems)


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #, if available: bcgov/entity#69 bcgov/entity#74*

*Description of changes:*
 - logic error fixed in method that finds the stems for each word

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
