### PR TITLE
Jwt cache config

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -56,7 +56,11 @@ class Config(object):
     JWT_OIDC_AUDIENCE = os.getenv('JWT_OIDC_AUDIENCE')
     JWT_OIDC_CLIENT_SECRET = os.getenv('JWT_OIDC_CLIENT_SECRET')
     JWT_OIDC_CACHING_ENABLED = os.getenv('JWT_OIDC_CACHING_ENABLED')
-    JWT_OIDC_JWKS_CACHE_TIMEOUT = os.getenv('JWT_OIDC_JWKS_CACHE_TIMEOUT')
+    try:
+        JWT_OIDC_JWKS_CACHE_TIMEOUT = int(os.getenv('JWT_OIDC_JWKS_CACHE_TIMEOUT'))
+    except:
+        JWT_OIDC_JWKS_CACHE_TIMEOUT = 300
+
 
     TESTING = False,
     DEBUG = False


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Altered config.py to add caching of the JWKS, ansd set the cachetimeout to be an int() as required by the werkzeug caching for type comparison. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
