### PR TITLE
search no longer filters names with synonyms from multiple synonym lists

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -206,8 +206,9 @@ class SolrQueries:
                         for item in result['response']['docs']:
                             if item['name'] not in seen_ordered_names:
                                 ordered_names.append({'name_info': item, 'stems': []})
-                    for missed in missed_names:
-                        current_app.logger.error('MISSED results: ', missed)
+
+                    if len(missed_names) > 0:
+                        current_app.logger.error('MISSED results: {}'.format(missed_names))
                     final_names_list = []
 
                     # order based on alphabetization of swapped in synonyms
@@ -635,7 +636,13 @@ class SolrQueries:
             # Not sure what it is, pass it up.
             raise http_error
 
-        return json.load(connection)[1][0].split(',')
+        results = json.load(connection)
+        synonym_list = []
+        # in case a token is part of multiple synonym lists
+        for synonyms in results[1]:
+            synonym_list += synonyms.split(',')
+
+        return synonym_list
 
     # Look up each token in name, and if it is in the synonyms then we need to search for it separately.
     @classmethod

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -486,11 +486,12 @@ def test_strips_stop_words(client, jwt, app, criteria, seed):
         query=criteria,
         expected_list=[seed]
     )
+
 @integration_postgres_solr
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("query, ordered_list", [
-    ('TESTING ORDER DEVELOPMENTS SYNONYMS', ['----TESTING ORDER DEVELOPMENTS SYNONYMS - PROXIMITY SEARCH',
+    ('TESTING ORDER DEVELOPMENT SYNONYMS', ['----TESTING ORDER DEVELOPMENT SYNONYMS - PROXIMITY SEARCH',
                                                   'TESTING ORDER DEVELOPMENT SYNONYMS',
                                                   'TESTING ORDER CONSTRUCTION SYNONYMS',
                                                   'TESTING ORDER STRUCTURE SYNONYMS',
@@ -498,7 +499,7 @@ def test_strips_stop_words(client, jwt, app, criteria, seed):
 ])
 def test_order(client, jwt, app, query, ordered_list):
     #  for loop didn't work for seeding so manual
-    seed_database_with(client, jwt, 'TESTING ORDER CONSTRUCTION SYNONYMS', id='1', source='2', clear=False)
+    seed_database_with(client, jwt, 'TESTING ORDER CONSTRUCTION SYNONYMS', id='1', source='2')
     seed_database_with(client, jwt, 'TESTING ORDER DEVELOPMENT SYNONYMS', id='2', source='4', clear=False)
     seed_database_with(client, jwt, 'TESTING ORDER STRUCTURE SYNONYMS', id='3', source='3', clear=False)
     verify_order(client, jwt, query=query, expected_order=ordered_list)
@@ -517,4 +518,16 @@ def test_order(client, jwt, app, query, ordered_list):
 ])
 def test_stems(client, jwt, app, query, stems):
     verify_stems(client, jwt, query=query, stems=stems)
+
+@integration_postgres_solr
+@integration_synonym_api
+@integration_solr
+@pytest.mark.parametrize("query, expected_list", [
+    ('PACIFIC FASTFOOD', ['PACIFIC TAKEOUT', 'PACIFIC CONCESSION']),
+])
+def test_synonyms_match_on_all_synonym_lists_(client, jwt, app, query, expected_list):
+    #  some synonyms are part of multiple lists so check that they return matches on both
+    seed_database_with(client, jwt, 'PACIFIC TAKEOUT', id='1', source='2')
+    seed_database_with(client, jwt, 'PACIFIC CONCESSION', id='2', source='2', clear=False)
+    verify_synonym_match(client, jwt, query=query, expected_list=expected_list)
 


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #, if available:bcgov/entity#69 bcgov/entity#74*

*Description of changes:*
- fixed bug where search would filter out names that included synonyms part of more than 1 synonym list (if a name was returned because it had a synonym of what was searched and that synonym was not in the first list of synonyms for that word it would get filtered out)
- pytests added/pass locally
- logging error message also fixed 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
