### PR TITLE
37 complete dates to utc

### DIFF
--- a/api/migrations/versions/21b953f6b653_.py
+++ b/api/migrations/versions/21b953f6b653_.py
@@ -1,0 +1,51 @@
+"""empty message
+
+Revision ID: 21b953f6b653
+Revises: 8a5fb0cadb6e
+Create Date: 2019-02-07 20:35:14.501374
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '21b953f6b653'
+down_revision = '8a5fb0cadb6e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    op.alter_column(
+        table_name='names',
+        column_name='consumption_date',
+        type_=sa.TIMESTAMP(timezone=True),
+        postgresql_using="(consumption_date::timestamp || 'PST')::timestamptz"
+    )
+
+    op.alter_column(
+        table_name='partner_name_system',
+        column_name='partner_name_date',
+        type_=sa.TIMESTAMP(timezone=True),
+        postgresql_using="date_trunc('day', (partner_name_date::timestamp || 'PST')::timestamptz)"
+    )
+
+    op.alter_column(
+        table_name='requests',
+        column_name='nro_last_update',
+        type_=sa.TIMESTAMP(timezone=True),
+        postgresql_using="(nro_last_update::timestamp || 'PST')::timestamptz"
+    )
+
+    op.alter_column(
+        table_name='requests',
+        column_name='submitted_date',
+        type_=sa.TIMESTAMP(timezone=True),
+        postgresql_using="date_trunc('day', (submitted_date::timestamp || 'PST')::timestamptz)"
+    )
+
+
+def downgrade():
+    pass

--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -12,7 +12,7 @@ class Name(db.Model):
     state = db.Column(db.String(15), default='NE') # NE=Not Examined; R=Rejected; A=Accepted; C=Cond. Accepted
     choice = db.Column(db.Integer)
     designation = db.Column(db.String(50), default=None)
-    consumptionDate = db.Column('consumption_date', db.DateTime)
+    consumptionDate = db.Column('consumption_date', db.DateTime(timezone=True))
     remoteNameId = db.Column('remote_name_id', db.BigInteger)
 
     # decision info

--- a/api/namex/models/nwpta.py
+++ b/api/namex/models/nwpta.py
@@ -10,7 +10,7 @@ class PartnerNameSystem(db.Model):
     partnerNameTypeCd = db.Column('partner_name_type_cd', db.String(10))
     partnerNameNumber = db.Column('partner_name_number', db.String(20))
     partnerJurisdictionTypeCd = db.Column('partner_jurisdiction_type_cd', db.String(3))
-    partnerNameDate = db.Column('partner_name_date', db.DateTime)
+    partnerNameDate = db.Column('partner_name_date', db.DateTime(timezone=True))
     partnerName = db.Column('partner_name', db.String(255))
 
     # "do it for me" (ie: NWPTA requested) indicator, set when data comes from Oracle so we have a

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -25,7 +25,7 @@ class Request(db.Model):
 
     # core fields
     id = db.Column(db.Integer, primary_key=True)
-    submittedDate = db.Column('submitted_date', db.DateTime, default=datetime.utcnow, index=True)
+    submittedDate = db.Column('submitted_date', db.DateTime(timezone=True), default=datetime.utcnow, index=True)
     lastUpdate = db.Column('last_update', db.DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow)
 
     nrNum = db.Column('nr_num', db.String(10), unique=True)
@@ -53,7 +53,7 @@ class Request(db.Model):
     requestId = db.Column('request_id', db.Integer)
     previousRequestId = db.Column('previous_request_id', db.Integer)
     submitCount = db.Column('submit_count', db.Integer)
-    nroLastUpdate = db.Column('nro_last_update', db.DateTime)
+    nroLastUpdate = db.Column('nro_last_update', db.DateTime(timezone=True))
 
     # Relationship State
     stateCd = db.Column('state_cd', db.String(40), db.ForeignKey('states.cd'), index=True)

--- a/api/namex/services/nro/request_utils.py
+++ b/api/namex/services/nro/request_utils.py
@@ -210,7 +210,7 @@ def get_nr_header(session, nr_num):
         ' where nr_num = :nr'
     )
     sql_lu = (
-        'select last_update'
+        'select SYS_EXTRACT_UTC (cast(last_update as timestamp)) as last_update'
         ' from req_instance_max_event'
         ' where request_id = :id'
     )
@@ -254,7 +254,7 @@ def get_nr_submitter(session, request_id):
     # get the NR Submitter
     #############################
     sql = (
-        'select submitted_date,'
+        'select SYS_EXTRACT_UTC (cast(SUBMITTED_DATE as timestamp)) as SUBMITTED_DATE,'
         ' submitter'
         ' from submitter_vw'
         ' where request_id = :req_id'
@@ -308,7 +308,7 @@ def get_exam_comments(session, request_id):
         'select examiner_IDIR,'
         ' examiner_comment,'
         ' state_comment,'
-        ' event_timestamp'
+        ' SYS_EXTRACT_UTC (cast(event_timestamp as timestamp)) as event_timestamp'
         ' from examiner_comments_vw'
         ' where request_id= :req_id'
     )
@@ -326,15 +326,17 @@ def get_exam_comments(session, request_id):
 def get_nwpta(session, request_id):
     # get the NR NWPTA Partner information
     #############################
-    sql = 'select partner_name_type_cd,' \
-          ' partner_name_number,' \
-          ' partner_jurisdiction_type_cd,' \
-          ' partner_name_date,' \
-          ' partner_name,' \
-          ' last_update_id' \
-          ' from partner_name_system_vw pns' \
-          ' where end_event_id IS NULL' \
-          ' and pns.request_id= :req_id'
+    sql = (
+        ' select partner_name_type_cd,' 
+        ' partner_name_number,' 
+        ' partner_jurisdiction_type_cd,' 
+        '  SYS_EXTRACT_UTC (cast(partner_name_date as timestamp)) as partner_name_date,' 
+        ' partner_name,' 
+        ' last_update_id' 
+        ' from partner_name_system_vw pns' 
+        ' where end_event_id IS NULL' 
+        ' and pns.request_id= :req_id'
+    )
 
     result = session.execute(sql, req_id=request_id)
     col_names = [row[0] for row in session.description]
@@ -353,12 +355,14 @@ def get_names(session, request_id):
     To support reset functionality - keep decision data in Namex but clear it in NRO - this
     function will not overwrite name decision data if the reset flag is true.
     """
-    sql = 'select choice_number,' \
-          ' name,' \
-          ' designation,' \
-          ' name_state_type_cd' \
-          ' from names_vw' \
-          ' where request_id = :req_id'
+    sql = (
+        'select choice_number,'
+        ' name,'
+        ' designation,'
+        ' name_state_type_cd'
+        ' from names_vw'
+        ' where request_id = :req_id'
+    )
     result = session.execute(sql, req_id=request_id)
     col_names = [row[0] for row in session.description]
     names = []

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -5,7 +5,7 @@ Flask-Script
 Flask-Moment
 Flask-SQLAlchemy
 Flask-RESTplus
-Flask-Marshmallow
+Flask-Marshmallow<3
 flask-jwt-oidc>=0.1.5
 python-dotenv==0.8.2
 psycopg2-binary

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -1,3 +1,7 @@
+[pycodestyle]
+max_line_length = 120
+ignore = E501
+
 [aliases]
 test=pytest
 

--- a/api/tests/python/end_points/test_requests.py
+++ b/api/tests/python/end_points/test_requests.py
@@ -1,6 +1,10 @@
 from flask import jsonify
 from flask import json
+
 from namex.models import User
+
+from tests.python import integration_oracle_namesdb
+
 
 token_header = {
                 "alg": "RS256",
@@ -211,6 +215,7 @@ def test_put_nr_view_only(client, jwt, app):
     assert expected_response == rv.data
 
 
+@integration_oracle_namesdb
 def test_add_new_name_to_nr(client, jwt, app):
 
     # add NR to database
@@ -249,6 +254,7 @@ def test_add_new_name_to_nr(client, jwt, app):
     assert len(data['names']) == 2
 
 
+@integration_oracle_namesdb
 def test_remove_name_from_nr(client, jwt, app):
 
     # add NR to database


### PR DESCRIPTION
*Issue #, if available:* bcgov/entity#37

*Description of changes:*
 - added callback to oracle session to set TZ to Vancouver
 - added Oracle calls to change dates to sys_extract_utc dates
 - added sys_extract_utc to nro_services calls
 - updated models for the remaining dates to be stored with TZ data
 - added migration script, including migrating the data from old PST to UTC
 - changed requirements/prod.txt to hold marshmallow to < v3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
