### PR TITLE
Changed cron nro extractor and updater to run 24x7. #177

### DIFF
--- a/jobs/nro-extractor/openshift/templates/cron-nro-extractor.yml
+++ b/jobs/nro-extractor/openshift/templates/cron-nro-extractor.yml
@@ -13,7 +13,7 @@ objects:
     name: "nro-extractor"
   spec:
     concurrencyPolicy: "Forbid"
-    schedule: "*/1 0-2,14-23 * * *"
+    schedule: "*/1 * * * *"
     suspend: false
     jobTemplate:
       spec:

--- a/jobs/nro-update/openshift/templates/cron-nro-update.yml
+++ b/jobs/nro-update/openshift/templates/cron-nro-update.yml
@@ -13,7 +13,7 @@ objects:
     name: "nro-update"
   spec:
     concurrencyPolicy: "Forbid"
-    schedule: "*/1 0-2,14-23 * * *"
+    schedule: "*/1 * * * *"
     suspend: false
     jobTemplate:
       spec:


### PR DESCRIPTION
*Issue #, if available:* 177

*Description of changes:* Changed nro-extractor and nro-updater to run all day, rather than only during business hours.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
