### PR TITLE
108 search single exact

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -54,7 +54,8 @@ class SolrQueries:
             '&start={start}&rows={rows}'
             '&fl=source,id,name,score'
             '&sort=score%20desc,txt_starts_with%20asc'
-            '{synonyms_clause}',
+            '{synonyms_clause}'
+            '{exact_phrase_clause}',
         OLD_SYN_CONFLICTS:
             '/solr/possible.conflicts/select?'
             'hl.fl=name'
@@ -67,7 +68,7 @@ class SolrQueries:
             '&start={start}&rows={rows}'
             '&fl=source,id,name,score'
             '&sort=score%20desc,txt_starts_with%20asc'
-            '{synonyms_clause}{name_copy_clause}',
+            '{synonyms_clause}{exact_phrase_clause}{name_copy_clause}',
         COBRS_PHONETIC_CONFLICTS:
             '/solr/possible.conflicts/select?'
             '&q=cobrs_phonetic:{start_str}'
@@ -119,7 +120,7 @@ class SolrQueries:
     }
 
     @classmethod
-    def get_conflict_results(cls, name, bucket, start=0, rows=100):
+    def get_conflict_results(cls, name, bucket, exact_phrase, start=0, rows=100):
         solr_base_url = current_app.config.get('SOLR_BASE_URL', None)
         if not solr_base_url:
             current_app.logger.error('SOLR: SOLR_BASE_URL is not set')
@@ -147,7 +148,7 @@ class SolrQueries:
 
         synonyms_for_word = cls.get_synonyms_for_words(name_tokens['stemmed_words'])
         if bucket == 'synonym':
-            connections = cls.get_synonym_results(solr_base_url, name, prox_search_strs, old_alg_search_strs, name_tokens, start, rows)
+            connections = cls.get_synonym_results(solr_base_url, name, prox_search_strs, old_alg_search_strs, name_tokens, exact_phrase, start, rows)
 
         elif bucket == 'cobrs_phonetic':
             connections = cls.get_cobrs_phonetic_results(solr_base_url, prox_search_strs, name_tokens, start, rows)
@@ -339,7 +340,7 @@ class SolrQueries:
             return None, 'Internal server error', 500
 
     @classmethod
-    def get_synonym_results(cls, solr_base_url, name, prox_search_strs, old_alg_search_strs, name_tokens, start=0, rows=100):
+    def get_synonym_results(cls, solr_base_url, name, prox_search_strs, old_alg_search_strs, name_tokens, exact_phrase, start=0, rows=100):
 
         try:
             connections = []
@@ -347,8 +348,8 @@ class SolrQueries:
             for prox_search_tuple, old_alg_search in zip(prox_search_strs, old_alg_search_strs):
 
                 old_alg_search_str = old_alg_search[:-2].replace(' ', '%20') + '*'  # [:-2] takes off the last '\ '
-
-                synonyms_clause = cls._get_synonyms_clause(prox_search_tuple[1], prox_search_tuple[2], name_tokens)
+                synonyms_clause = cls._get_synonyms_clause(prox_search_tuple[1], prox_search_tuple[2], name_tokens) if exact_phrase == '' else ''
+                exact_phrase_clause = '&fq=contains_exact_phrase:' + '\"' + parse.quote(exact_phrase).replace('%2A','') + '\"' if exact_phrase != '' else ''
 
                 if name.find('*') == -1:
                     for name in prox_search_tuple[0]:
@@ -358,6 +359,7 @@ class SolrQueries:
                             rows=rows,
                             start_str='\"' + parse.quote(prox_search_str).replace('%2A', '') + '\"~{}'.format(prox_search_tuple[3]),
                             synonyms_clause=synonyms_clause,
+                            exact_phrase_clause=exact_phrase_clause,
                         )
                         current_app.logger.debug('Query: ' + query)
                         connections.append((json.load(request.urlopen(query)),
@@ -370,6 +372,7 @@ class SolrQueries:
                     rows=rows,
                     start_str=parse.quote(old_alg_search_str).replace('%2A', '*').replace('%5C%2520', '\\%20'),
                     synonyms_clause=synonyms_clause,
+                    exact_phrase_clause=exact_phrase_clause,
                     name_copy_clause=cls._get_name_copy_clause(name)
                 )
                 current_app.logger.debug('Query: ' + query)

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -986,7 +986,7 @@ class RequestsAnalysis(Resource):
         return jsonify(results), 200
 
 @cors_preflight("GET")
-@api.route('/synonymbucket/<string:name>', methods=['GET','OPTIONS'])
+@api.route('/synonymbucket/<string:name>/<string:advanced_search>', methods=['GET','OPTIONS'])
 class SynonymBucket(Resource):
     START = 0
     ROWS = 1000
@@ -994,11 +994,12 @@ class SynonymBucket(Resource):
     @staticmethod
     @cors.crossdomain(origin='*')
     @jwt.requires_auth
-    def get(name, *args, **kwargs):
+    def get(name, advanced_search, *args, **kwargs):
         start = request.args.get('start', SynonymBucket.START)
         rows = request.args.get('rows', SynonymBucket.ROWS)
-
-        results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='synonym', start=start, rows=rows)
+        print(advanced_search)
+        exact_phrase = '' if advanced_search == '*' else advanced_search
+        results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='synonym', exact_phrase=exact_phrase, start=start, rows=rows)
         if code:
             return jsonify(message=msg), code
         return jsonify(results), 200

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -997,7 +997,6 @@ class SynonymBucket(Resource):
     def get(name, advanced_search, *args, **kwargs):
         start = request.args.get('start', SynonymBucket.START)
         rows = request.args.get('rows', SynonymBucket.ROWS)
-        print(advanced_search)
         exact_phrase = '' if advanced_search == '*' else advanced_search
         results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='synonym', exact_phrase=exact_phrase, start=start, rows=rows)
         if code:
@@ -1005,7 +1004,7 @@ class SynonymBucket(Resource):
         return jsonify(results), 200
 
 @cors_preflight("GET")
-@api.route('/cobrsphonetics/<string:name>', methods=['GET','OPTIONS'])
+@api.route('/cobrsphonetics/<string:name>/<string:advanced_search>', methods=['GET','OPTIONS'])
 class CobrsPhoneticBucket(Resource):
     START = 0
     ROWS = 500
@@ -1013,16 +1012,17 @@ class CobrsPhoneticBucket(Resource):
     @staticmethod
     @cors.crossdomain(origin='*')
     @jwt.requires_auth
-    def get(name, *args, **kwargs):
+    def get(name, advanced_search, *args, **kwargs):
         start = request.args.get('start', CobrsPhoneticBucket.START)
         rows = request.args.get('rows', CobrsPhoneticBucket.ROWS)
-        results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='cobrs_phonetic', start=start, rows=rows)
+        exact_phrase = '' if advanced_search == '*' else advanced_search
+        results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='cobrs_phonetic', exact_phrase=exact_phrase, start=start, rows=rows)
         if code:
             return jsonify(message=msg), code
         return jsonify(results), 200
 
 @cors_preflight("GET")
-@api.route('/phonetics/<string:name>', methods=['GET','OPTIONS'])
+@api.route('/phonetics/<string:name>/<string:advanced_search>', methods=['GET','OPTIONS'])
 class PhoneticBucket(Resource):
     START = 0
     ROWS = 100000
@@ -1030,10 +1030,11 @@ class PhoneticBucket(Resource):
     @staticmethod
     @cors.crossdomain(origin='*')
     @jwt.requires_auth
-    def get(name, *args, **kwargs):
+    def get(name, advanced_search,*args, **kwargs):
         start = request.args.get('start', PhoneticBucket.START)
         rows = request.args.get('rows', PhoneticBucket.ROWS)
-        results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='phonetic', start=start, rows=rows)
+        exact_phrase = '' if advanced_search == '*' else advanced_search
+        results, msg, code = SolrQueries.get_conflict_results(name.upper(), bucket='phonetic', exact_phrase=exact_phrase, start=start, rows=rows)
         if code:
             return jsonify(message=msg), code
         return jsonify(results), 200

--- a/api/tests/postman/namex-pipeline-dev.postman_collection.json
+++ b/api/tests/postman/namex-pipeline-dev.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "5146a8ea-fabf-4197-b542-85354ea3641e",
+		"_postman_id": "bc308e4d-34bc-4a53-8bcd-0a31554c9843",
 		"name": "namex-pipeline-dev",
 		"description": "# Introduction\nWhat does your API do?\n\n# Overview\nThings that the developers should know about\n\n# Authentication\nWhat is the preferred way of using the API?\n\n# Error Codes\nWhat errors and status codes can a user expect?\n\n# Rate limit\nIs there a limit to the number of requests an user can send?",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -747,6 +747,107 @@
 								"api",
 								"v1",
 								"documents:restricted_words"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "conflict-search",
+			"item": [
+				{
+					"name": "synonym_bucket_exactphrase",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "83bbced6-bf73-4814-b326-079cef0b8d46",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "53d9f6ae-6779-4a7f-9b05-615b9891d03c",
+								"exec": [
+									"eval(globals.postmanBDD);",
+									"",
+									"tests[\"Response time is acceptable\"] = responseTime < 10000;",
+									"",
+									"it('should be an success response', () => {",
+									"    response.ok.should.be.true;            // 2XX",
+									"    response.error.should.be.false;          // 4XX or 5XX",
+									"    response.clientError.should.be.false;    // 4XX",
+									"    response.serverError.should.be.false;   // 5XX",
+									"    response.should.have.status(200);",
+									"    response.statusType.should.equal(2);",
+									"});",
+									"",
+									"it('should return JSON', () => {",
+									"    response.should.be.json;",
+									"    response.should.have.header('Content-Type', 'application/json');",
+									"    response.type.should.equal('application/json');",
+									"});",
+									"",
+									"it('should contain the un-parsed JSON text', () => {",
+									"    response.text.should.be.a('string').with.length.above(10);",
+									"});",
+									"",
+									"it('should contain the parsed JSON keys', () => {",
+									"    response.body.should.be.an('object').with.keys(['highlighting', 'names', 'response']);",
+									"});",
+									"",
+									"it('should match against a JSON Schema', () => {",
+									"    // For more information about JSON Schema, see https://spacetelescope.github.io/understanding-json-schema/basics.html",
+									"    response.body.should.have.schema({",
+									"        type: 'object',",
+									"        required: ['names', 'highlighting', 'response']",
+									"    });",
+									"});",
+									"",
+									"it('should only return names that contain \\'on the\\'', () => {",
+									"   var results = response.body.names",
+									"   for (var i=0;i<results.length;i++) {",
+									"       name_info = results[i].name_info",
+									"       if (name_info.id) name_info.name.toUpperCase().should.include('ON THE')",
+									"       ",
+									"   }",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/requests/synonymbucket/on the ball/on the",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"requests",
+								"synonymbucket",
+								"on the ball",
+								"on the"
 							]
 						}
 					},

--- a/api/tests/postman/namex-pipeline-test.postman_collection.json
+++ b/api/tests/postman/namex-pipeline-test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f4078534-fd78-48a1-a4df-7721aeaec1c2",
+		"_postman_id": "b864d9f1-c26e-4fe0-8b04-a73629fae8a8",
 		"name": "namex-pipeline-test",
 		"description": "# Introduction\nWhat does your API do?\n\n# Overview\nThings that the developers should know about\n\n# Authentication\nWhat is the preferred way of using the API?\n\n# Error Codes\nWhat errors and status codes can a user expect?\n\n# Rate limit\nIs there a limit to the number of requests an user can send?",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -747,6 +747,107 @@
 								"api",
 								"v1",
 								"documents:restricted_words"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "conflict-search",
+			"item": [
+				{
+					"name": "synonym_bucket_exactphrase",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "83bbced6-bf73-4814-b326-079cef0b8d46",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "53d9f6ae-6779-4a7f-9b05-615b9891d03c",
+								"exec": [
+									"eval(globals.postmanBDD);",
+									"",
+									"tests[\"Response time is acceptable\"] = responseTime < 10000;",
+									"",
+									"it('should be an success response', () => {",
+									"    response.ok.should.be.true;            // 2XX",
+									"    response.error.should.be.false;          // 4XX or 5XX",
+									"    response.clientError.should.be.false;    // 4XX",
+									"    response.serverError.should.be.false;   // 5XX",
+									"    response.should.have.status(200);",
+									"    response.statusType.should.equal(2);",
+									"});",
+									"",
+									"it('should return JSON', () => {",
+									"    response.should.be.json;",
+									"    response.should.have.header('Content-Type', 'application/json');",
+									"    response.type.should.equal('application/json');",
+									"});",
+									"",
+									"it('should contain the un-parsed JSON text', () => {",
+									"    response.text.should.be.a('string').with.length.above(10);",
+									"});",
+									"",
+									"it('should contain the parsed JSON keys', () => {",
+									"    response.body.should.be.an('object').with.keys(['highlighting', 'names', 'response']);",
+									"});",
+									"",
+									"it('should match against a JSON Schema', () => {",
+									"    // For more information about JSON Schema, see https://spacetelescope.github.io/understanding-json-schema/basics.html",
+									"    response.body.should.have.schema({",
+									"        type: 'object',",
+									"        required: ['names', 'highlighting', 'response']",
+									"    });",
+									"});",
+									"",
+									"it('should only return names that contain \\'on the\\'', () => {",
+									"   var results = response.body.names",
+									"   for (var i=0;i<results.length;i++) {",
+									"       name_info = results[i].name_info",
+									"       if (name_info.id) name_info.name.toUpperCase().should.include('ON THE')",
+									"       ",
+									"   }",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/requests/synonymbucket/on the ball/on the",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"requests",
+								"synonymbucket",
+								"on the ball",
+								"on the"
 							]
 						}
 					},

--- a/api/tests/python/end_points/test_cobrs_phonetic_match.py
+++ b/api/tests/python/end_points/test_cobrs_phonetic_match.py
@@ -119,7 +119,7 @@ def verify_match(client, jwt, query, expected_list=[], not_expected_list=None):
 def search_cobrs_phonetic_match(client, jwt, query):
     token = jwt.create_jwt(claims, token_header)
     headers = {'Authorization': 'Bearer ' + token}
-    url = '/api/v1/requests/cobrsphonetics/' + query
+    url = '/api/v1/requests/cobrsphonetics/' + query + '/*'
     print(url)
     rv = client.get(url, headers=headers)
 

--- a/api/tests/python/end_points/test_sounds_like.py
+++ b/api/tests/python/end_points/test_sounds_like.py
@@ -88,7 +88,7 @@ def verify_results(client, jwt, query, expected):
 def search(client, jwt, query):
     token = jwt.create_jwt(claims, token_header)
     headers = {'Authorization': 'Bearer ' + token}
-    url = '/api/v1/requests/phonetics/' + urllib.parse.quote(query)
+    url = '/api/v1/requests/phonetics/' + urllib.parse.quote(query) + '/*'
     print(url)
     rv = client.get(url, headers=headers)
 

--- a/api/tests/python/end_points/test_synonym_match.py
+++ b/api/tests/python/end_points/test_synonym_match.py
@@ -91,7 +91,7 @@ def verify(data, expected=None, not_expected=None):
             else:
                 verified = True
         # if the expected name is in the names returned this will set 'verified' to true before the loop finishes
-        elif expected.lower().find(name['name'].lower()) != -1:
+        elif expected and expected.lower().find(name['name'].lower()) != -1:
             verified = True
             break
 
@@ -100,10 +100,9 @@ def verify(data, expected=None, not_expected=None):
             if not_expected.lower().find(name['name'].lower()) != -1:
                 verified = False
                 break
-
     assert verified
 
-def verify_synonym_match(client, jwt, query, expected_list=None, not_expected_list=None, exact_phrase=''):
+def verify_synonym_match(client, jwt, query, expected_list=None, not_expected_list=None, exact_phrase='*'):
     data = search_synonym_match(client, jwt, query, exact_phrase)
     if expected_list:
         if expected_list is []:
@@ -133,10 +132,10 @@ def verify_stems(client, jwt, query, stems):
         print('Expected: ', expected)
         assert actual.upper() == expected.upper()
 
-def search_synonym_match(client, jwt, query, exact_phrase=''):
+def search_synonym_match(client, jwt, query, exact_phrase='*'):
     token = jwt.create_jwt(claims, token_header)
     headers = {'Authorization': 'Bearer ' + token}
-    url = '/api/v1/requests/synonymbucket/' + query + exact_phrase
+    url = '/api/v1/requests/synonymbucket/' + query + '/' + exact_phrase
     print(url)
     rv = client.get(url, headers=headers)
 
@@ -337,10 +336,10 @@ def test_finds_variations_on_initials(client, jwt, app, criteria, seed):
     ('W* FORE* TIMBER', 'WEST FOREST TIMBER'),
     ('W*T FOR*T TI*BER', 'WEST FOREST TIMBER'),
     ('W*T FORE* TI*BER', 'WEST FOREST TIMBER'),
-    ('WEST FORE?T TIMBER', 'WEST FOREST TIMBER'),
-    ('WE?? FOREST TIMBER', 'WEST FOREST TIMBER'),
-    ('WE?? FORE?T TI??ER', 'WEST FOREST TIMBER'),
-    ('WE?? FO*ST T?M*R', 'WEST FOREST TIMBER'),
+    ('WEST FORE*T TIMBER', 'WEST FOREST TIMBER'),
+    ('WE** FOREST TIMBER', 'WEST FOREST TIMBER'),
+    ('WE** FORE*T TI**ER', 'WEST FOREST TIMBER'),
+    ('W*S* F**ST T*M*R', 'WEST FOREST TIMBER'),
 ])
 def test_wildcard_operator(client, jwt, app, criteria, seed):
     seed_database_with(client, jwt, seed)
@@ -519,12 +518,12 @@ def test_stems(client, jwt, app, query, stems):
 @integration_synonym_api
 @integration_solr
 @pytest.mark.parametrize("query, expected_list", [
-    ('PACIFIC FASTFOOD', ['PACIFIC TAKEOUT', 'PACIFIC CONCESSION']),
+    ('PACIFIC TAKEOUT', ['PACIFIC FASTFOOD', 'PACIFIC DINER']),
 ])
 def test_synonyms_match_on_all_synonym_lists(client, jwt, app, query, expected_list):
     #  some synonyms are part of multiple lists so check that they return matches on both
-    seed_database_with(client, jwt, 'PACIFIC TAKEOUT', id='1', source='2')
-    seed_database_with(client, jwt, 'PACIFIC CONCESSION', id='2', source='2', clear=False)
+    seed_database_with(client, jwt, 'PACIFIC FASTFOOD', id='1', source='2')
+    seed_database_with(client, jwt, 'PACIFIC DINER', id='2', source='2', clear=False)
     verify_synonym_match(client, jwt, query=query, expected_list=expected_list)
 
 @integration_postgres_solr

--- a/solr/cores/possible.conflicts/conf/managed-schema
+++ b/solr/cores/possible.conflicts/conf/managed-schema
@@ -137,6 +137,7 @@
     <field name="cobrs_phonetic" type="cobrs_phonetic" multiValued="false" indexed="true" stored="true"/>
     <field name="txt_starts_with" type="txt_starts_with" multiValued="false" indexed="true" stored="false"/>
     <field name="name_no_synonyms" type="name_no_synonyms" multiValued="false" indexed="true" stored="false"/>
+    <field name="contains_exact_phrase" type="contains_exact_phrase" multiValued="false" indexed="true" stored="true"/>
 
     <!-- Only enabled in the "schemaless" data-driven example (assuming the client
          does not know what fields may be searched) because it's very expensive to index everything twice. -->
@@ -984,6 +985,21 @@
         </analyzer>
     </fieldType>
 
+    <fieldType name="contains_exact_phrase" class="solr.TextField" positionIncrementGap="100" multiValued="false">
+      <analyzer>
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\'][N|n])" replacement="" />-->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\!\@\#\%\^&amp;\(\)\{\}\[\]\+\-\|\\\?\/\.\,\_\']*" replacement="" />
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]{2,})" replacement=" " />-->
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^|\W([a-z|A-Z]{1})\W([a-z|A-Z])\W([a-z|A-Z])\W|$" replacement=" $1$2$3 " />-->
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^|\W([a-z|A-Z]{1})\W([a-z|A-Z])\W|$" replacement=" $1$2 " />-->
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^|\W([a-z|A-Z]{1})\W([a-z|A-Z][a-z|A-Z])\W|$" replacement=" $1$2 " />-->
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^|\W([a-z|A-Z][a-z|A-Z])\W([a-z|A-Z])\W|$" replacement=" $1$2 " />-->
+        <!--<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s" replacement="" />-->
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>F
+      </analyzer>
+    </fieldType>
+
     <!-- some examples for different languages (generally ordered by ISO code) -->
 
     <!-- Arabic -->
@@ -1418,4 +1434,5 @@
     <copyField source="name" dest="dblmetaphone_name"/>
     <copyField source="name" dest="txt_starts_with"/>
     <copyField source="name" dest="name_no_synonyms"/>
+    <copyField source="name" dest="contains_exact_phrase"/>
 </schema>


### PR DESCRIPTION
*Issue #, if available:bcgov/entity#108*

*Description of changes:*
- added exact_phrase field in request
- added contains_exact_phrase field in managed_schema
      - used as a fq to narrow result set on that phrase
- pm + pytests added (all pass)
- should be coordinated with frontend PR otherwise frontend will error with 404
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
