### PR TITLE
Fix names missing from synonyms match. #185

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -229,6 +229,7 @@ class SolrQueries:
                     else:
                         for item in result['response']['docs']:
                             if item['name'] not in seen_ordered_names:
+                                seen_ordered_names.append(item['name'])
                                 ordered_names.append({'name_info': item, 'stems': []})
 
                     if len(missed_names) > 0:
@@ -316,9 +317,8 @@ class SolrQueries:
                         final_names_list += ordered_names
                     else:
                         for item in ordered_names:
-                            if item['name_info']['name'] not in seen_ordered_names:
-                                final_names_list.append(item)
-                                seen_ordered_names.append(item['name_info']['name'])
+                            final_names_list.append(item)
+                            seen_ordered_names.append(item['name_info']['name'])
 
                     seen_names += seen_ordered_names.copy()
                     seen_ordered_names.clear()

--- a/api/tests/python/end_points/test_cobrs_phonetic_match.py
+++ b/api/tests/python/end_points/test_cobrs_phonetic_match.py
@@ -54,8 +54,11 @@ def clean_database(client, jwt):
 
     assert r.status_code == 200
 
-def seed_database_with(client, jwt, name, id='1', source='2'):
-    clean_database(client, jwt)
+
+def seed_database_with(client, jwt, name, id='1', source='2', clean=True):
+    if clean:
+        clean_database(client, jwt)
+
     url = SOLR_URL + '/solr/possible.conflicts/update?commit=true'
     headers = {'content-type': 'application/json'}
     data = '[{"source":"' + source + '", "name":"' + name + '", "id":"'+ id +'"}]'
@@ -221,3 +224,15 @@ def test_stack_ignores_wildcards(client, jwt, app):
         not_expected_list=['----TESTING* @WILDCARDS']
     )
 
+
+@integration_synonym_api
+@integration_solr
+def test_stack_contains_synonyms(client, jwt, app):
+    seed_database_with(client, jwt, 'PACIFIC LUMBER PRODUCTS LTD.', id='1')
+    seed_database_with(client, jwt, 'PACIFIC FOREST PRODUCTS LTD.', id='2', clean=False)
+
+    verify_match(client, jwt,
+                 query='PACIFIK LUMBER',
+                 expected_list=['----PACIFIK LUMBER', 'PACIFIC LUMBER PRODUCTS LTD.', '----PACIFIK synonyms:(LUMBER)',
+                                'PACIFIC FOREST PRODUCTS LTD.']
+                 )


### PR DESCRIPTION
*Issue #, if available:* 185

*Description of changes:* Removed the double-check of existence in array that was causing results to be left out of the solr response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
