### PR TITLE
Updated cronjob configs to use new postgresdb-dev|test|prod database …

### DIFF
--- a/jobs/inprogress_update/openshift/templates/cron-inprogress-update.yml
+++ b/jobs/inprogress_update/openshift/templates/cron-inprogress-update.yml
@@ -31,19 +31,19 @@ objects:
                     valueFrom:
                       secretKeyRef:
                         key: database-user
-                        name: postgresql
+                        name: postgresql-${ENV_TAG}
                   - name: DATABASE_PASSWORD
                     valueFrom:
                       secretKeyRef:
                         key: database-password
-                        name: postgresql
+                        name: postgresql-${ENV_TAG}
                   - name: DATABASE_NAME
                     valueFrom:
                       secretKeyRef:
                         key: database-name
                         name: postgresql
                   - name: DATABASE_HOST
-                    value: 'postgresql'
+                    value: 'postgresql-${ENV_TAG}'
                   - name: DATABASE_PORT
                     value: '5432'
                   - name: MAX_ROWS

--- a/jobs/nro-extractor/openshift/templates/cron-nro-extractor.yml
+++ b/jobs/nro-extractor/openshift/templates/cron-nro-extractor.yml
@@ -32,19 +32,19 @@ objects:
                     valueFrom:
                       secretKeyRef:
                         key: database-user
-                        name: postgresql
+                        name: postgresql-${ENV_TAG}
                   - name: PG_PASSWORD
                     valueFrom:
                       secretKeyRef:
                         key: database-password
-                        name: postgresql
+                        name: postgresql-${ENV_TAG}
                   - name: PG_NAME
                     valueFrom:
                       secretKeyRef:
                         key: database-name
                         name: postgresql
                   - name: PG_HOST
-                    value: 'postgresql'
+                    value: 'postgresql-${ENV_TAG}'
                   - name: PG_PORT
                     value: '5432'
                   - name: MAX_ROWS

--- a/jobs/nro-update/openshift/templates/cron-nro-update.yml
+++ b/jobs/nro-update/openshift/templates/cron-nro-update.yml
@@ -32,19 +32,19 @@ objects:
                     valueFrom:
                       secretKeyRef:
                         key: database-user
-                        name: postgresql
+                        name: postgresql-${ENV_TAG}
                   - name: PG_PASSWORD
                     valueFrom:
                       secretKeyRef:
                         key: database-password
-                        name: postgresql
+                        name: postgresql-${ENV_TAG}
                   - name: PG_DB_NAME
                     valueFrom:
                       secretKeyRef:
                         key: database-name
                         name: postgresql
                   - name: PG_HOST
-                    value: 'postgresql'
+                    value: 'postgresql-${ENV_TAG}'
                   - name: PG_PORT
                     value: '5432'
                   - name: MAX_ROWS


### PR DESCRIPTION
*Issue #, if available:* bcgov/entity#311

*Description of changes:*
Updated cronjob configs to use new postgresdb-dev|test|prod database and secrets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
