### PR TITLE
Added CONSUME transaction handling in namex feeder

### DIFF
--- a/nro-legacy/sql/object/names/namex/package/namex_pkb.sql
+++ b/nro-legacy/sql/object/names/namex/package/namex_pkb.sql
@@ -53,18 +53,20 @@ CREATE OR REPLACE PACKAGE BODY NAMEX.namex AS
                 FROM request_state 
                 WHERE request_id = row_request_id
                 AND end_event_id is NULL
-                AND state_type_cd in ('C', 'D');
+                AND state_type_cd in ('C', 'D', 'COMPLETED');
                 
             EXCEPTION
                 WHEN NO_DATA_FOUND THEN
                     row_state_type_cd := NULL;
             END;
 
-			IF (row_state_type_cd IN ('C', 'D')
-			    AND 
-			    row_transaction_type_cd IN 
-			         ('ADMIN', 'NRREQ', 'RESUBMIT', 'CANCL', 'MODIF', 'CORRT', 'UPDPR', 'CONSUME')
-			   )
+			IF ((row_state_type_cd IN ('C', 'D')
+			    AND
+			    row_transaction_type_cd IN
+			         ('ADMIN', 'NRREQ', 'RESUBMIT', 'CANCL', 'MODIF', 'CORRT', 'UPDPR')
+			   ) OR (
+			    row_state_type_cd IN ('COMPLETED') AND row_transaction_type_cd IN ('CONSUME')
+			    ))
 			  -- (row_state_type_cd = 'COMPLETED' and row_transaction_type_cd = 'EXTEND')
 			THEN
 				SELECT nr_num INTO row_nr_num FROM transaction NATURAL JOIN request WHERE transaction_id =

--- a/nro-legacy/sql/object/names/namex/package/namex_pkb.sql
+++ b/nro-legacy/sql/object/names/namex/package/namex_pkb.sql
@@ -46,7 +46,7 @@ CREATE OR REPLACE PACKAGE BODY NAMEX.namex AS
             -- If we don't care about it, mark it as ignored.
             status := STATUS_IGNORED;
 
-            -- get the current state, if it's not 'C' or 'D' we're done
+            -- get the current state, if it's not 'C', 'D', or 'COMPLETED' we're done
             BEGIN
                 SELECT state_type_cd 
                 INTO row_state_type_cd 

--- a/nro-legacy/sql/release/201905XX_namex/names/namex/create.sql
+++ b/nro-legacy/sql/release/201905XX_namex/names/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/names/namex/package/namex_pkb.sql


### PR DESCRIPTION
*Issue #, if available:* bcgov/entity#508

*Description of changes:*
Added CONSUME transaction handling in namex feeder; handle in a way that does not include unexpected COMPLETED transactions.

Note: CONSUME transaction type was previously added to condition, but is never executed - see ticket for notes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
