### PR TITLE
Fixed bug for held names, cleaned up scripts (#543)

### DIFF
--- a/solr/database/solr_conflicts_core_vw.sql
+++ b/solr/database/solr_conflicts_core_vw.sql
@@ -1,3 +1,8 @@
+-- Do the following as user "postgres":
+
+CREATE ROLE solr LOGIN PASSWORD '[YOUR PASSWORD HERE]';
+GRANT USAGE ON SCHEMA public TO solr;
+
 
 -- Do this as the normal user for the database:
 
@@ -5,31 +10,24 @@ CREATE OR REPLACE VIEW solr_conflicts_core_vw
     (id, name, state, last_modified)
 AS
 SELECT
-    nr_num AS id,
-    name,
+    requests.nr_num AS id,
+    names.name,
     CASE WHEN
-        state_cd IN ('APPROVED', 'CONDITIONAL') AND
-        expiration_date > NOW() - INTERVAL '1 day' AND
-        consumption_date IS NULL
+        requests.state_cd IN ('APPROVED', 'CONDITIONAL') AND
+        requests.expiration_date > NOW() - INTERVAL '1 day' AND
+        names.consumption_date IS NULL
     THEN
         'ACTIVE'
     ELSE
         'INACTIVE'
     END AS state,
-    last_update AS last_modified
+    requests.last_update AS last_modified
 FROM
     requests LEFT JOIN names ON requests.id = names.nr_id WHERE
-    state IN ('APPROVED', 'CONDITION') AND
-    request_type_cd NOT IN ('CEM', 'CFR', 'CLL', 'CLP', 'FR', 'LIB', 'LL', 'LP', 'NON', 'PAR', 'RLY', 'TMY', 'XCLL',
-                            'XCLP', 'XLL', 'XLP');
+    names.state IN ('APPROVED', 'CONDITION') AND
+    requests.request_type_cd NOT IN ('CEM', 'CFR', 'CLL', 'CLP', 'FR', 'LIB', 'LL', 'LP', 'NON', 'PAR', 'RLY', 'TMY',
+                                     'XCLL', 'XCLP', 'XLL', 'XLP');
 
-COMMIT;
-
-
--- Do the following as user "postgres":
-
-CREATE ROLE solr LOGIN PASSWORD '[YOUR PASSWORD HERE]';
-GRANT USAGE ON SCHEMA public TO solr;
 GRANT SELECT ON solr_conflicts_core_vw TO solr;
 
 COMMIT;

--- a/solr/database/solr_names_core_vw.sql
+++ b/solr/database/solr_names_core_vw.sql
@@ -5,23 +5,19 @@ CREATE OR REPLACE VIEW solr_names_core_vw
     (id, name, state, last_modified)
 AS
 SELECT
-    nr_num || '-' || choice AS id,
-    name,
+    requests.nr_num || '-' || names.choice AS id,
+    names.name,
     CASE WHEN
-        state IN ('APPROVED', 'CONDITION', 'REJECTED')
+        requests.state_cd != 'HOLD' AND
+        names.state IN ('APPROVED', 'CONDITION', 'REJECTED')
     THEN
         'ACTIVE'
     ELSE
         'INACTIVE'
     END AS state,
-    last_update AS last_modified
+    requests.last_update AS last_modified
 FROM
     requests LEFT JOIN names ON requests.id = names.nr_id;
-
-COMMIT;
-
-
--- Do the following as user "postgres":
 
 GRANT SELECT ON solr_names_core_vw TO solr;
 


### PR DESCRIPTION
*Issue #, if available:* 543

*Description of changes:* There was a bug where an NR on HOLD that had previously been examined and then RESET would should up as an ACTIVE name. It should be INACTIVE. Also fixed the ownership of some objects and made column sources more explicit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
