### PR TITLE
New views for comparing Solr cores. (#524)

### DIFF
--- a/nro-legacy/sql/object/names/namex/view/solr_dataimport_namesfix_vw.sql
+++ b/nro-legacy/sql/object/names/namex/view/solr_dataimport_namesfix_vw.sql
@@ -1,0 +1,32 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+DROP VIEW NAMEX.SOLR_DATAIMPORT_NAMESFIX_VW;
+
+CREATE OR REPLACE FORCE VIEW namex.solr_dataimport_namesfix_vw (ID,
+                                                             name_instance_id,
+                                                             choice_number,
+                                                             corp_num,
+                                                             NAME,
+                                                             nr_num,
+                                                             request_id,
+                                                             submit_count,
+                                                             request_type_cd,
+                                                             name_id,
+                                                             start_event_id,
+                                                             name_state_type_cd
+                                                            )
+AS
+    SELECT r.nr_num || '-' || ni.choice_number AS ID, ni.name_instance_id, ni.choice_number,
+           ni.corp_num, ni.NAME, r.nr_num, r.request_id, r.submit_count, ri.request_type_cd,
+           n.name_id, ni.start_event_id, ns.name_state_type_cd
+      FROM request r INNER JOIN request_instance ri ON ri.request_id = r.request_id
+           INNER JOIN request_state rs ON rs.request_id = r.request_id
+           INNER JOIN NAME n ON n.request_id = r.request_id
+           INNER JOIN name_instance ni ON ni.name_id = n.name_id
+           INNER JOIN name_state ns ON ns.name_id = ni.name_id
+           INNER JOIN event e ON e.event_id = ns.start_event_id
+     WHERE ri.end_event_id IS NULL
+       AND rs.end_event_id IS NULL
+       AND ni.end_event_id IS NULL
+       AND ns.end_event_id IS NULL
+       AND ns.name_state_type_cd IN ('A', 'R', 'C');

--- a/nro-legacy/sql/object/registry/namex/view/solr_dataimport_conflictsfix_vw.sql
+++ b/nro-legacy/sql/object/registry/namex/view/solr_dataimport_conflictsfix_vw.sql
@@ -1,0 +1,47 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+DROP VIEW NAMEX.SOLR_DATAIMPORT_CONFLICTSFIX_VW;
+
+CREATE OR REPLACE FORCE VIEW namex.solr_dataimport_conflictsfix_vw (ID, NAME, state_type_cd, SOURCE)
+AS
+SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
+       'CORP' AS SOURCE
+FROM corporation c LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
+                   LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
+                   LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
+                   LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
+WHERE corp.end_event_id IS NULL
+  AND corp.corp_name_typ_cd IN ('CO', 'NB')
+  AND cs.end_event_id IS NULL
+  AND op.op_state_typ_cd = 'ACT'
+  AND ct.corp_class IN ('BC', 'OT')
+UNION ALL
+SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
+       'CORP' AS SOURCE
+FROM corporation c
+         LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
+         LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
+         LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
+         LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
+WHERE corp.end_event_id IS NULL
+  AND corp.corp_name_typ_cd IN ('CO')
+  AND cs.end_event_id IS NULL
+  AND op.op_state_typ_cd = 'ACT'
+  AND ct.corp_class IN ('SOC', 'XPRO')
+  AND c.corp_num NOT IN (SELECT cname.corp_num FROM corp_name cname
+                         LEFT OUTER JOIN corporation c1 ON c1.corp_num = cname.corp_num
+                         WHERE cname.corp_num = c.corp_num
+                           AND cname.corp_name_typ_cd = 'AS' AND cname.end_event_id IS NULL)
+UNION ALL
+SELECT c.corp_num AS ID, corp.corp_nme AS NAME, op.state_typ_cd AS state_type_cd,
+       'CORP' AS SOURCE
+FROM corporation c
+         LEFT OUTER JOIN corp_name corp ON corp.corp_num = c.corp_num
+         LEFT OUTER JOIN corp_state cs ON cs.corp_num = corp.corp_num
+         LEFT OUTER JOIN corp_op_state op ON op.state_typ_cd = cs.state_typ_cd
+         LEFT OUTER JOIN corp_type ct ON ct.corp_typ_cd = c.corp_typ_cd
+WHERE corp.end_event_id IS NULL
+  AND corp.corp_name_typ_cd IN ('AS')
+  AND cs.end_event_id IS NULL
+  AND op.op_state_typ_cd = 'ACT'
+  AND ct.corp_class IN ('SOC', 'XPRO');

--- a/nro-legacy/sql/release/20190502_solr_views/names/namex/create.sql
+++ b/nro-legacy/sql/release/20190502_solr_views/names/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/names/namex/view/solr_dataimport_namesfix_vw.sql

--- a/nro-legacy/sql/release/20190502_solr_views/registry/namex/create.sql
+++ b/nro-legacy/sql/release/20190502_solr_views/registry/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/registry/namex/view/solr_dataimport_conflictsfix_vw.sql


### PR DESCRIPTION
*Issue #, if available:* 524

*Description of changes:* Added new versions of the Solr dataimport views that fix problems. This will allow the new Solr delta import cores to do comparisons against Oracle and ensure we stay in sync.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
