### PR TITLE
Entity#712 add firefox to e2e

### DIFF
--- a/e2e/Jenkinsfile
+++ b/e2e/Jenkinsfile
@@ -24,7 +24,7 @@ import groovy.json.JsonOutput
     podTemplate(label: e2e_label, name: e2e_label, serviceAccount: 'jenkins', cloud: 'openshift', containers: [
         containerTemplate(
             name: 'jnlp',
-            image: 'docker-registry.default.svc:5000/bcgov/jenkins-slave-bddstack:latest',
+            image: 'docker-registry.default.svc:5000/servicebc-ne-tools/bddstack:latest',
             resourceRequestCpu: '500m',
             resourceLimitCpu: '1000m',
             resourceRequestMemory: '1Gi',

--- a/e2e/Jenkinsfile
+++ b/e2e/Jenkinsfile
@@ -59,9 +59,12 @@ import groovy.json.JsonOutput
                 
                     sh '''
                          cd e2e
-                         npm install
-                         npm run test
+                         npm install                         
                     '''
+            }
+
+            stage ("Sleep to allow rsh time") {		
+                sleep 3000		
             }
     }
 }

--- a/e2e/nightwatch.json
+++ b/e2e/nightwatch.json
@@ -5,24 +5,43 @@
 	"page_objects_path": "./page-objects",
 	"globals_path": "globals.js",
 
-	"webdriver": {
-		"start_process": true,
-		"server_path": "./node_modules/chromedriver/lib/chromedriver/chromedriver",
-		"port": 9515,
-		"cli_args": []
-	},
 	"test_settings": {
 		"default": {
 			"globals": {
 				"NROPath": "https://test.bcregistrynames.gov.bc.ca",
 				"NamexPath": "https://namex-test.pathfinder.gov.bc.ca"
 			},
-
+			"webdriver": {
+				"start_process": true,
+				"server_path": "./node_modules/chromedriver/lib/chromedriver/chromedriver",
+				"port": 9515,
+				"cli_args": []
+			}
+		},
+		"firefox": {
+			"webdriver": {
+				"start_process": true,
+				"server_path": "./node_modules/geckodriver/geckodriver",
+				"port": 4444
+			},
+			"silent": true,
+			"desiredCapabilities": {
+				"browserName": "firefox",
+				"alwaysMatch": {
+					"moz:firefoxOptions": {
+						"args": ["-headless"]
+					}
+				}
+			}
+		},
+		"chrome": {
+			"silent": true,
 			"desiredCapabilities": {
 				"browserName": "chrome",
 				"javascriptEnabled": true,
 				"acceptSslCerts": true,
 				"acceptInsecureCerts": true,
+				"webStorageEnabled": true,
 				"chromeOptions": {
 					"args": [
 						"disable-gpu",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,9 +6,10 @@
     "test": "./node_modules/nightwatch/bin/nightwatch -e chrome,firefox -t ./specs/namex-smoke-test"
   },
   "dependencies": {
-    "nightwatch": "1.0.19",
+    "nightwatch": "1.1.11",
     "geckodriver": "latest",
     "chromedriver": "2.46",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "dotenv": "8.0.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "./node_modules/nightwatch/bin/nightwatch -t ./specs/namex-smoke-test"
+    "test": "./node_modules/nightwatch/bin/nightwatch -e chrome,firefox -t ./specs/namex-smoke-test"
   },
   "dependencies": {
     "nightwatch": "1.0.19",

--- a/e2e/templates/bddstack.bc.yaml
+++ b/e2e/templates/bddstack.bc.yaml
@@ -1,0 +1,107 @@
+# Build config for Jenkins BDDStack functional testing
+#
+# Process this file, creating or replacing imagestreams and builds
+# $ oc process -f openshift/bddstack.bc.yaml | oc [create|replace] -n <PROJECT> -f -
+#
+apiVersion: v1
+kind: Template
+metadata:
+  name: bddstack
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: bddstack
+    labels:
+      build: bddstack
+    annotations:
+      openshift.io/generated-by: OpenShiftNewBuild
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewBuild
+    labels:
+      build: bddstack
+    name: bddstack
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: bddstack:latest
+    source:
+      dockerfile: |
+        # https://github.com/BCDevOps/BDDStack
+        FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+
+        ARG NODE_VERSION=v12.4.0
+
+        EXPOSE 8080
+
+        ENV PATH=$HOME/.local/bin/:$PATH \
+            LC_ALL=en_US.UTF-8 \
+            LANG=en_US.UTF-8
+        
+        ENV SUMMARY="Jenkins slave with chrome and firefox installed for use with functional/BDD tests that use BDDStack." \
+            DESCRIPTION="Jenkins pipeline slave with chrome and firefox for testing application with headless browser. (aka 'BDDStack')"
+
+        LABEL summary="$SUMMARY" \
+              description="$DESCRIPTION" \
+              io.k8s.description="$DESCRIPTION" \
+              io.k8s.display-name="Jenkins-Pipeline-BDDStack" \
+              io.openshift.expose-services="8080:http" \
+              io.openshift.tags="builder,jenkins-jnlp-chrome,jenkins-jnlp-firefox,jenkins-jnlp" \
+              release="1"
+
+        # NOTES:
+        # We need to call 2 (!) yum commands before being able to enable repositories properly
+        # This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+        # Chrome install info: https://access.redhat.com/discussions/917293
+        RUN yum repolist > /dev/null && \
+            yum install -y yum-utils && \
+            yum-config-manager --disable \* &> /dev/null && \
+            yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+            yum-config-manager --enable rhel-7-server-rpms && \
+            yum-config-manager --enable rhel-7-server-optional-rpms && \
+            yum-config-manager --enable rhel-7-server-fastrack-rpms && \
+            UNINSTALL_PKGS="java-1.8.0-openjdk-headless.i686" &&\
+            INSTALL_PKGS="redhat-lsb libXScrnSaver gdk-pixbuf2 xorg-x11-server-Xvfb wget firefox" && \
+            yum remove -y $UNINSTALL_PKGS &&\
+            yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+            rpm -V $INSTALL_PKGS && \
+            yum clean all -y && \
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+            yum -y localinstall google-chrome-stable_current_x86_64.rpm && \
+            rm google-chrome-stable_current_x86_64.rpm && \
+            mkdir -p /home/jenkins/.pki && \
+            chmod 777 /home/jenkins/.pki && \
+            yum info google-chrome-stable \
+            mkdir /opt && \
+            pushd /opt && \
+            curl -sL https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz | tar -Jx && \
+            rm -f node-${NODE_VERSION}-linux-x64.tar.xz
+
+        # Update environment variables
+        ENV NODE_HOME=/opt/node-${NODE_VERSION}-linux-x64 \
+        PATH=$PATH:/opt/node-${NODE_VERSION}-linux-x64/bin
+
+        # Update the version of `npm` that came with the packages above
+        # and install a few additional tools.
+        RUN npm i -g npm@latest yarn@latest nsp@latest nodemon@latest  && \
+            rm -rf ~/.npm && \
+            node -v && \
+            npm -v
+
+        USER 1001
+
+      type: Dockerfile
+    strategy:
+      dockerStrategy:
+        env:
+        - name: OPENSHIFT_JENKINS_JVM_ARCH
+          value: x86_64
+      type: Docker
+    triggers:
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange


### PR DESCRIPTION
*Issue #, if available:*
712

*Description of changes:*
Updated image and changed Nightwatch config to run both Chrome and Firefox
Updated to the latest version of nightwatch.

Note: the scripts themselves will fail on a later assertion, but won't be refactored until after the UI refresh is complete.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
