### PR TITLE
corrected timestamp for solr feeder

### DIFF
--- a/nro-legacy/sql/object/names/namex/package/solr_pkb.sql
+++ b/nro-legacy/sql/object/names/namex/package/solr_pkb.sql
@@ -34,8 +34,8 @@ CREATE OR REPLACE PACKAGE BODY NAMEX.solr AS
                     '\"name\": \"' || REPLACE(REPLACE(view_row.name, '\', '\\\\'), '"', '\\\"') || '\", ' ||
                     '\"state_type_cd\": \"' || view_row.state_type_cd || '\", ' ||
                     '\"source\": \"' || view_row.source || '\", ' ||
-		    '\"start_date\": \"' || view_row.start_date || '\", ' ||
-		    '\"jurisdiction\": \"' || view_row.jurisdiction || '\" ' ||
+					'\"start_date\": \"' || to_char(view_row.start_date,'YYYY-MM-DD"T"HH24:MI:SS"Z"') || '\", ' ||
+					'\"jurisdiction\": \"' || view_row.jurisdiction || '\" ' ||
                     '} }, ';
         END IF;
 
@@ -80,7 +80,7 @@ CREATE OR REPLACE PACKAGE BODY NAMEX.solr AS
                         '\"nr_num\": \"' || view_row.nr_num || '\", ' ||
                         '\"submit_count\": \"' || view_row.submit_count || '\", ' ||
                         '\"name_state_type_cd\": \"' || view_row.name_state_type_cd || '\", ' ||
-                        '\"start_date\": \"' || view_row.start_date || '\", ' ||
+                        '\"start_date\": \"' || to_char(view_row.start_date,'YYYY-MM-DD"T"HH24:MI:SS"Z"') || '\", ' ||
                          '\"jurisdiction\": \"' || view_row.jurisdiction || '\" ' ||
                         '} }, ';
             END LOOP;

--- a/nro-legacy/sql/object/registry/namex/package/solr_pkb.sql
+++ b/nro-legacy/sql/object/registry/namex/package/solr_pkb.sql
@@ -32,8 +32,8 @@ CREATE OR REPLACE PACKAGE BODY NAMEX.solr AS
                     '\"name\": \"' || REPLACE(REPLACE(view_row.name, '\', '\\\\'), '"', '\\\"') || '\", ' ||
                     '\"state_type_cd\": \"' || view_row.state_type_cd || '\", ' ||
                     '\"source\": \"' || view_row.source || '\", ' ||
- 		    '\"start_date\": \"' || view_row.start_date || '\", ' ||
-		    '\"jurisdiction\": \"' || view_row.jurisdiction || '\" ' ||
+					'\"start_date\": \"' || to_char(view_row.start_date,'YYYY-MM-DD"T"HH24:MI:SS"Z"') || '\", ' ||
+					'\"jurisdiction\": \"' || view_row.jurisdiction || '\" ' ||
                     '} }, ';
         END IF;
 


### PR DESCRIPTION
Signed-off-by: Lorna Trent <lorna.trent@gov.bc.ca>

*Issue #, if available:*

*Description of changes:*
date format did no work for solr feeder.  needed to be converted to a string timestamp in the format solr expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
