### PR TITLE
815 solr

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -52,7 +52,7 @@ class SolrQueries:
             '&q=name:{start_str}'
             '&wt=json'
             '&start={start}&rows={rows}'
-            '&fl=source,id,name,score'
+            '&fl=source,id,name,score,start_date,jurisdiction'
             '&sort=score%20desc,txt_starts_with%20asc'
             '{synonyms_clause}'
             '{exact_phrase_clause}',
@@ -66,7 +66,7 @@ class SolrQueries:
             '&q=txt_starts_with:{start_str}'
             '&wt=json'
             '&start={start}&rows={rows}'
-            '&fl=source,id,name,score'
+            '&fl=source,id,name,score,start_date,jurisdiction'
             '&sort=score%20desc,txt_starts_with%20asc'
             '{synonyms_clause}{exact_phrase_clause}{name_copy_clause}',
         COBRS_PHONETIC_CONFLICTS:
@@ -97,12 +97,12 @@ class SolrQueries:
             '&qf=name_compressed^6%20name_with_synonyms'
             '&wt=json'
             '&start={start}&rows={rows}'
-            '&fl=source,id,name,score'
+            '&fl=source,id,name,score,start_date,jurisdiction'
             '&sort=score%20desc'
             '{synonyms_clause}{name_copy_clause}',
         HISTORY:
             '/solr/names/select?sow=false&df=name_exact_match&wt=json&&rows={rows}&q={name}'
-            '&fl=nr_num,name,score,submit_count,name_state_type_cd',
+            '&fl=nr_num,name,score,submit_count,name_state_type_cd,start_date,jurisdiction',
         TRADEMARKS:
             '/solr/trademarks/select?'
             'defType=edismax'

--- a/api/namex/resources/exact_match.py
+++ b/api/namex/resources/exact_match.py
@@ -31,6 +31,6 @@ class ExactMatch(Resource):
         connection = urllib.request.urlopen(url)
         answer = json.loads(connection.read())
         docs = answer['response']['docs']
-        names =[{ 'name':doc['name'], 'id':doc['id'], 'source':doc['source'] } for doc in docs ]
+        names =[{ 'name':doc['name'], 'id':doc['id'], 'source':doc['source'], 'start_date':doc['start_date'], 'jurisdiction':doc['jurisdiction'] } for doc in docs ]
 
         return jsonify({ 'names':names })

--- a/api/namex/resources/histories.py
+++ b/api/namex/resources/histories.py
@@ -39,7 +39,9 @@ class Histories(Resource):
               'id':doc['id'],
               'name_state_type_cd':doc['name_state_type_cd'],
               'submit_count':doc['submit_count'],
-              'nr_num':doc['nr_num']
+              'nr_num':doc['nr_num'],
+              'start_date':doc['start_date'],
+              'jurisdiction':doc['jurisdiction']
               } for doc in docs]
 
         results = {'names': names}

--- a/api/tests/postman/namex-pipeline-dev.postman_collection.json
+++ b/api/tests/postman/namex-pipeline-dev.postman_collection.json
@@ -305,16 +305,17 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "83bbced6-bf73-4814-b326-079cef0b8d46",
+								"type": "text/javascript",
 								"exec": [
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
-								"id": "53d9f6ae-6779-4a7f-9b05-615b9891d03c",
+								"id": "f1525c80-0a8b-40e7-af29-59c54e1b5cb1",
+								"type": "text/javascript",
 								"exec": [
 									"eval(globals.postmanBDD);",
 									"",
@@ -350,9 +351,11 @@
 									"        required: ['names', 'highlighting', 'response']",
 									"    });",
 									"});",
+									"it(\"Should return the required fields for a Conflict Row\", () => {",
+									"    response.body.names[0].should.be.an('object').with.keys(['id','jurisdiction', 'name', 'score','source','start_date']);",
+									"});",
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
 						}
 					],
@@ -385,11 +388,13 @@
 							"query": [
 								{
 									"key": "start",
-									"value": "0"
+									"value": "0",
+									"equals": true
 								},
 								{
 									"key": "rows",
-									"value": "35"
+									"value": "35",
+									"equals": true
 								}
 							]
 						},
@@ -413,7 +418,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b9e1eabe-cf5b-4d1f-b451-4859541cd9bf",
+								"id": "8628fd3d-aae9-4f24-8a14-ac9b6b9b73ce",
 								"type": "text/javascript",
 								"exec": [
 									"eval(globals.postmanBDD);",
@@ -450,7 +455,9 @@
 									"        required: ['names', 'highlighting', 'response']",
 									"    });",
 									"});",
-									""
+									"it(\"Should return the required fields for a Name History Row\", () => {",
+									"    response.body.names[0].should.be.an('object').with.keys(['jurisdiction', 'name', 'name_state_type_cd', 'nr_num','score','start_date','submit_count']);",
+									"});"
 								]
 							}
 						}
@@ -484,11 +491,13 @@
 							"query": [
 								{
 									"key": "start",
-									"value": "1"
+									"value": "1",
+									"equals": true
 								},
 								{
 									"key": "rows",
-									"value": "32"
+									"value": "32",
+									"equals": true
 								}
 							]
 						},

--- a/api/tests/postman/namex-pipeline-test.postman_collection.json
+++ b/api/tests/postman/namex-pipeline-test.postman_collection.json
@@ -314,7 +314,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "53d9f6ae-6779-4a7f-9b05-615b9891d03c",
+								"id": "4b954239-fbca-4d8c-b836-5eee504bb4a8",
 								"type": "text/javascript",
 								"exec": [
 									"eval(globals.postmanBDD);",
@@ -350,6 +350,9 @@
 									"        type: 'object',",
 									"        required: ['names', 'highlighting', 'response']",
 									"    });",
+									"});",
+									"it(\"Should return the required fields for a Conflict Row\", () => {",
+									"    response.body.names[0].should.be.an('object').with.keys(['id','jurisdiction', 'name', 'score','source','start_date']);",
 									"});",
 									""
 								]
@@ -385,11 +388,13 @@
 							"query": [
 								{
 									"key": "start",
-									"value": "3"
+									"value": "3",
+									"equals": true
 								},
 								{
 									"key": "rows",
-									"value": "35"
+									"value": "35",
+									"equals": true
 								}
 							]
 						},
@@ -413,7 +418,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b9e1eabe-cf5b-4d1f-b451-4859541cd9bf",
+								"id": "942a0248-973a-4f21-8c33-bfcadc48b515",
 								"type": "text/javascript",
 								"exec": [
 									"eval(globals.postmanBDD);",
@@ -450,6 +455,9 @@
 									"        required: ['names', 'highlighting', 'response']",
 									"    });",
 									"});",
+									"it(\"Should return the required fields for a Name History Row\", () => {",
+									"    response.body.names[0].should.be.an('object').with.keys(['jurisdiction', 'name', 'name_state_type_cd', 'nr_num','score','start_date','submit_count']);",
+									"});",
 									""
 								]
 							}
@@ -484,11 +492,13 @@
 							"query": [
 								{
 									"key": "start",
-									"value": "1"
+									"value": "1",
+									"equals": true
 								},
 								{
 									"key": "rows",
-									"value": "32"
+									"value": "32",
+									"equals": true
 								}
 							]
 						},
@@ -3296,7 +3306,7 @@
 					},
 					"response": [
 						{
-							"id": "0166404f-de1c-49c3-8c24-10d506d82191",
+							"id": "8055718f-0772-45e9-b581-02a23ab6a4d9",
 							"name": "requests/NR 8765456",
 							"originalRequest": {
 								"method": "GET",
@@ -3505,7 +3515,7 @@
 					},
 					"response": [
 						{
-							"id": "937293ae-5304-4a0e-ab8f-5764a9b47c77",
+							"id": "c66b6396-c83d-4cc4-b289-1812a6ca7ba2",
 							"name": "requests/NR 8765456",
 							"originalRequest": {
 								"method": "GET",

--- a/api/tests/python/solr/test_solr.py
+++ b/api/tests/python/solr/test_solr.py
@@ -51,7 +51,7 @@ def test_get_results_query_to_solr(mocker, monkeypatch, name, compresed_name, es
             + '%20OR%20' \
             + escaped_name \
             + '&qf=name_compressed^6%20name_with_synonyms&wt=json' \
-              '&start=0&rows=10&fl=source,id,name,score&sort=score%20desc' \
+              '&start=0&rows=10&fl=source,id,name,score,start_date,jurisdiction&sort=score%20desc' \
               '&fq=name_with_synonyms:(' \
             + synonym_tokens.upper() \
             + ')'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates solr queries to include two new fields in the field list that are returned to the front-end, start_date and jurisdiction for both name history and possible conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
