### PR TITLE
Must be this marshmallow version for names schema

### DIFF
--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -20,7 +20,7 @@ Flask-Marshmallow<3
 flask-jwt-oidc>=0.1.5
 python-dotenv==0.8.2
 psycopg2-binary
-marshmallow<3
+marshmallow==2.19.2
 marshmallow-sqlalchemy
 cx_Oracle
 pronouncing


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Caused a 400 when using anything higher than 2.19.2 for the name schema used to make decisions in namex.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
