### PR TITLE
added empty string handling for candidate

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -1089,4 +1089,6 @@ class SolrQueries:
     @classmethod
     def keep_candidate(cls, candidate, name, names):
         if len([doc['id'] for doc in names if doc['id'] == candidate['id']]) == 0:
-            names.append({'name': name, 'id': candidate['id'], 'source': candidate['source'], 'jurisdiction': candidate['jurisdiction'],'start_date': candidate['start_date'] })
+            names.append({'name': name, 'id': candidate['id'], 'source': candidate['source'],
+                          'jurisdiction': candidate.get('jurisdiction', ''),
+                          'start_date': candidate.get('start_date', '')})


### PR DESCRIPTION
*Issue #, if available:*
Address missing jurisdictions in colin in production that causes a 500 error in the phonetic solr search
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
