### PR TITLE
3129 exact matches spaces punctuation

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -336,10 +336,10 @@ class Request(db.Model):
             if len(criteria.filters) > 5:
                 criteria.filters.pop()
             substitutions = ' ?| '.join(map(str, descriptive_element)) + ' ?'
-            criteria.filters.append(func.lower(Name.name).op('~')(r' \y{}\y'.format(substitutions)))
+            criteria.filters.append(func.lower(Name.name).op('~')(r'\s+\y{}\y'.format(substitutions)))
         else:
             substitutions = '|'.join(map(str, descriptive_element))
-            criteria.filters.append(func.lower(Name.name).op('~')(r'^({})\y '.format(substitutions)))
+            criteria.filters.append(func.lower(Name.name).op('~')(r'^\s*\W*({})\y\W*\s+'.format(substitutions)))
             return criteria
 
         results = Request.find_by_criteria(criteria)

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -298,7 +298,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 AnalysisIssueCodes.WORDS_TO_AVOID,
                 AnalysisIssueCodes.TOO_MANY_WORDS,
                 AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
-                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
+                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
                 AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
                 AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
                 AnalysisIssueCodes.CORPORATE_CONFLICT,

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -385,8 +385,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
             dict_matches_counter = {}
             dict_matches_words = {}
+
+            np_svc= self.name_processing_service
             for match in matches:
-                match_list = match.split()
+                np_svc.set_name(match)
+                # TODO: Get rid of this when done refactoring!
+                match_list = np_svc.name_tokens
                 counter = 0
                 for idx, word in enumerate(match_list):
                     # Compare in the same place
@@ -400,7 +404,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                         counter += 0.75
                     elif porter.stem(word.lower()) in all_subs_stem:
                         counter += 0.7
-                similarity=counter / length_original
+                similarity = counter / length_original
                 dict_matches_counter.update({match: similarity})
 
             dict_matches_words.update(

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -9,6 +9,7 @@ from ..auto_analyse import AnalysisIssueCodes, MAX_LIMIT, MAX_MATCHES_LIMIT
 from ..auto_analyse.name_analysis_utils import validate_distinctive_descriptive_lists
 
 from namex.models.request import Request
+from ..auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
 
 '''
 Sample builder
@@ -386,8 +387,9 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             dict_matches_counter = {}
             dict_matches_words = {}
 
-            np_svc= self.name_processing_service
+            service = ProtectedNameAnalysisService()
             for match in matches:
+                np_svc = service.name_processing_service
                 np_svc.set_name(match)
                 # TODO: Get rid of this when done refactoring!
                 match_list = np_svc.name_tokens


### PR DESCRIPTION
*ANALYZE NAME-Correct Conflicts Query to Deal with Leading Space in the Names #3131*

*Description of changes:*
Exact match not working properly because both leading and trailing spaces before it pass the name to auto-analyze so in the conflict search the original name is "FLASH PACK PACKAGING AND SHIPPING LTD.", the one in the database conflict list is " FLASH PACK PACKAGING AND SHIPPING LTD." so it doesnt find it as an exact match. In addition, it is needed to clean the name before any comparison.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
