### PR TITLE
3141 v2 strip out numbers

### DIFF
--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -110,8 +110,7 @@ class NameProcessingService(GetSynonymListsMixin):
 
         syn_svc = self.synonym_service
 
-        words = text.lower()
-        words = remove_stop_words(words, stop_words)
+        words = remove_stop_words(self.name_original_tokens, stop_words)
         words = remove_french(words)
         exceptions_ws = syn_svc.exception_regex(words)
         tokens = syn_svc.regex_transform(words, designation_all, prefix_list, number_list, exceptions_ws)

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -3,16 +3,16 @@ class GetDesignationsListsMixin(object):
     _designated_any_words = []
 
     # Designation_any_list_user and designation_end_list_user based on entity type typed by user:
-    _designation_any_list_user = []
-    _designation_end_list_user = []
+    _designation_any_list_correct = []
+    _designation_end_list_correct = []
     _all_designations_user = []
 
     # All designations for entity type typed bu user
     designations_entity_type_user = []
 
     # Designation_any_list and designation_end_list based on company name typed by user
-    #_designation_any_list = []
-    #_designation_end_list = []
+    # _designation_any_list = []
+    # _designation_end_list = []
     _all_designations = []
 
     # Wrong any_list and end_list based on company name typed by user

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -65,15 +65,10 @@ def remove_french(text):
     return " ".join(text.split())
 
 
-def remove_stop_words(original_name, stop_words):
-    stop_words_rgx = '|'.join(stop_words)
-    regex = re.compile(r'\b({})\b'.format(stop_words_rgx))
-    found_stop_words = regex.findall(original_name.lower())
+def remove_stop_words(original_name_list, stop_words):
+    words = ' '.join([word for x, word in enumerate(original_name_list) if word not in stop_words])
 
-    for word in found_stop_words:
-        original_name = original_name.replace(word, "")
-
-    return re.sub(' +', ' ', original_name)
+    return words
 
 
 def list_distinctive_descriptive_same(name_list):

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -57,7 +57,7 @@ Rules:  1) Before and after slash has to be at least two words to removed string
 
 
 def remove_french(text):
-    text = re.sub(r'(^\w+(?:[^\w\n]+\w+)+[^\w\n]*)/(\w+(?:[^\w\n]+\w+)+[^\w\n]*$)?',
+    text = re.sub(r'(^[A-Z]+(?:[^A-Z\n]+[A-Z]+)+[^A-Z\n]*)/(\w+(?:[^A-Z\n]+[A-Z]+)+[^A-Z\n]*$)+',
                   r'\1 ',
                   text,
                   0,

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -40,49 +40,41 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
     def __init__(self):
         super(ProtectedNameAnalysisService, self).__init__()
 
+    '''
+    Set designations in <any> and <end> positions regardless the entity type. 
+    designation_any_list: Retrieves all designations found anywhere in the name regardless the entity type.
+                          <Entity type>-Valid English Designations_any Stop
+                          English Designations_any Stop
+    designation_end_list: Retrieves all designations found at the end in the name regardless the entity type
+                          <Entity type>-Valid English Designations_end Stop
+                          English Designations_end Stop,
+    Note: The previous lists contain designations that are in the correct position. For instance, designations with <end> position 
+          found anywhere are not counted here, they are counted in _set_designations_incorrect_position_by_input_name.
+    '''
+
     def _set_designations_by_input_name(self):
         syn_svc = self.synonym_service
         original_name = self.get_original_name()
 
         designation_any_list = syn_svc.get_designation_any_in_name(original_name)
         designation_end_list = syn_svc.get_designation_end_in_name(original_name)
-        all_designations = syn_svc.get_designation_all_in_name(original_name)
-
-        for idx, designation in enumerate(designation_any_list):
-            if designation not in all_designations:
-                designation_any_list.pop(idx)
-
-        for idx, designation in enumerate(designation_end_list):
-            if designation not in all_designations:
-                designation_end_list.pop(idx)
 
         self._designation_any_list = designation_any_list
         self._designation_end_list = designation_end_list
-        self._all_designations = all_designations
 
-    def _set_misplaced_designation_in_input_name(self):
+        self._all_designations = self._designation_any_list + self._designation_end_list
+
+
+    '''
+    Set designations in position <end> found any other place in the company name, these designations are misplaced.
+    '''
+
+    def _set_designations_incorrect_position_by_input_name(self):
         syn_svc = self.synonym_service
         original_name = self.get_original_name()
-        # TODO: Arturo why the change? These lines were like this:
-        # correct_designation_end_list = self._designation_end_list
-        # correct_designation_any_list = self._designation_any_list
-        # TODO: Arturo why the change?
-        correct_designation_end_list = self._designation_end_list_user
-        correct_designation_any_list = self._designation_any_list_user
 
-        self._misplaced_designation_any_list = syn_svc.get_misplaced_any_designations(original_name, correct_designation_any_list)
-        self._misplaced_designation_end_list = syn_svc.get_misplaced_end_designations(original_name, correct_designation_end_list)
-
-        self._misplaced_designation_all_list = self._misplaced_designation_any_list + self._misplaced_designation_end_list
-
-    # TODO: I don't see this called anywhere (was prev called: set_all_entity_types)
-    def _set_all_entity_types(self):
-        self._all_entity_types = [item for item, count in collections.Counter(
-            self._entity_type_any_designation + self._entity_type_end_designation
-        ).items() if count > 1]
-
-        if not self._all_entity_types:
-            self._all_entity_types = self._entity_type_any_designation + self._entity_type_end_designation
+        designation_end_misplaced_list = syn_svc.get_incorrect_designation_end_in_name(original_name)
+        self._misplaced_designation_end_list = designation_end_misplaced_list
 
     def _set_designations_by_entity_type_user(self):
         syn_svc = self.synonym_service
@@ -99,14 +91,12 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         any_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.ANY, 'english')
         end_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.END, 'english')
 
-        # TODO: This was the code that was previously getting called
-        # self._designation_any_list_user.extend(any_list)
-        # self._designation_end_list_user.extend(end_list)
-        # TODO: We were getting duplicate lists as result of extending lists
-        #  _designation_any_list_user and / or _designation_end_list_user are being set more than o:q
-        #  which may or may not be an issue - just ensure that this is expected behavior
-        self._designation_any_list_user = any_list
-        self._designation_end_list_user = end_list
+        self._designation_any_list_correct = any_list
+        self._designation_end_list_correct = end_list
+
+    '''
+    Set the corresponding entity type for designations <any> found in name
+    '''
 
     def _set_entity_type_any_designation(self):
         syn_svc = self.synonym_service
@@ -116,6 +106,10 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         self._entity_type_any_designation = syn_svc.get_entity_type_any_designation(
             syn_svc.get_all_end_designations(), designation_any_list
         )
+
+    '''
+    Set the corresponding entity type for designations <end> found in name
+    '''
 
     def _set_entity_type_end_designation(self):
         syn_svc = self.synonym_service
@@ -127,20 +121,30 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         )
 
     def _set_designations(self):
+        # Set available designations for entity type selected by user (by default designations related to 'CR' entity type)
+        # _designation_any_list_user and _designation_end_list_user contain the only correct designations
         self._set_designations_by_entity_type_user()
-        # Set _designation_any_list and _designation_end_list based on company name typed by user
-        self._set_designations_by_input_name()
-        # TODO: Double check this to make sure it works
-        # Set _entity_type_any_designation for designations based on company name typed by user
-        self._set_entity_type_any_designation()
-        # TODO: Double check this to make sure it works
-        # Set _entity_type_end_designation for designations based on company name typed by user
-        self._set_entity_type_end_designation()
-        # Set _misplaced_designation_all based on company name typed by user
-        self._set_misplaced_designation_in_input_name()
 
-        # Set all designations based on entity type typed by user
-        self._all_designations_user = self._designation_any_list_user + self._designation_end_list_user
+        # Set _designation_any_list and _designation_end_list based on company name typed by user
+        # Set _all_designations (general list) based on company name typed by user
+        # All previous set designations have correct position, but may belong to wrong entity type
+        self._set_designations_by_input_name()
+
+        # Set _misplaced_designation_end_list which contains <end> designations in other part of the name
+        self._set_designations_incorrect_position_by_input_name()
+
+        # Set _entity_type_any_designation for designations found on company name typed by user
+        self._set_entity_type_any_designation()
+
+        # Set _entity_type_end_designation for designations found on company name typed by user
+        self._set_entity_type_end_designation()
+
+        # Set _misplaced_designation_all based on company name typed by user
+        # self._set_misplaced_designation_in_input_name()
+
+        # Set all designations based on entity type typed by user,'CR' by default
+        self._all_designations_user = self._designation_any_list_correct + self._designation_end_list_correct
+
         # Set all designations based on company name typed by user
         # self._all_designations = self._designation_any_list + self._designation_end_list
 
@@ -162,19 +166,20 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
             self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(self.name_tokens)
 
         else:
-            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive(self.name_tokens, self.token_classifier.distinctive_word_tokens, self.token_classifier.descriptive_word_tokens)
+            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive(self.name_tokens,
+                                                                                        self.token_classifier.distinctive_word_tokens,
+                                                                                        self.token_classifier.descriptive_word_tokens)
 
         # Return any combination of these checks
-        check_conflicts = builder.search_conflicts(self._list_dist_words, self._list_desc_words, self.name_tokens, self.processed_name)
+        check_conflicts = builder.search_conflicts(self._list_dist_words, self._list_desc_words, self.name_tokens,
+                                                   self.processed_name)
 
         if not check_conflicts.is_valid:
             results.append(check_conflicts)
 
-        # TODO: Use the list_name array, don't use a string in the method!
-        # check_words_requiring_consent = builder.check_words_requiring_consent(list_name)  # This is correct
         check_words_requiring_consent = builder.check_words_requiring_consent(
             self.name_tokens, self.processed_name
-        )  # This is incorrect
+        )
 
         if not check_words_requiring_consent.is_valid:
             results.append(check_words_requiring_consent)
@@ -194,9 +199,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
 
         check_designation_misplaced = builder.check_designation_misplaced(
             self.get_original_name_tokenized(),
-            self.get_misplaced_designation_any(),
-            self.get_misplaced_designation_end(),
-            self.get_misplaced_designation_all()
+            self.get_misplaced_designation_end()
         )
 
         if not check_designation_misplaced.is_valid:

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -5,7 +5,7 @@ import collections
 from namex.constants import \
     BCProtectedNameEntityTypes, BCUnprotectedNameEntityTypes, XproUnprotectedNameEntityTypes
 
-from namex.services.synonyms import DesignationPositionCodes
+from namex.services.synonyms import DesignationPositionCodes, LanguageCodes
 
 from .name_analysis_director import NameAnalysisDirector
 from . import ProcedureResult
@@ -88,8 +88,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         elif XproUnprotectedNameEntityTypes(entity_type):
             entity_type_code = XproUnprotectedNameEntityTypes(entity_type)
 
-        any_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.ANY, 'english')
-        end_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.END, 'english')
+        any_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.ANY, LanguageCodes.ENG)
+        end_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.END, LanguageCodes.ENG)
 
         self._designation_any_list_correct = any_list
         self._designation_end_list_correct = end_list

--- a/api/namex/services/name_request/auto_analyse/unprotected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/unprotected_name_analysis.py
@@ -69,8 +69,8 @@ class UnprotectedNameAnalysisService(NameAnalysisDirector):
     def _set_misplaced_designation_in_input_name(self):
         syn_svc = self.synonym_service
         original_name = self.get_original_name()
-        correct_designation_end = self._designation_end_list_user
-        correct_designation_any = self._designation_any_list_user
+        correct_designation_end = self._designation_end_list_correct
+        correct_designation_any = self._designation_any_list_correct
         self._misplaced_designation_any_list = syn_svc.get_misplaced_any_designations(original_name, correct_designation_any)
         self._misplaced_designation_end_list = syn_svc.get_misplaced_end_designations(original_name, correct_designation_end)
 
@@ -100,8 +100,8 @@ class UnprotectedNameAnalysisService(NameAnalysisDirector):
         any_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.ANY, 'english')
         end_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.END, 'english')
 
-        self._designation_any_list_user.extend(any_list)
-        self._designation_end_list_user.extend(end_list)
+        self._designation_any_list_correct.extend(any_list)
+        self._designation_end_list_correct.extend(end_list)
 
     def _set_entity_type_any_designation(self):
         syn_svc = self.synonym_service
@@ -135,7 +135,7 @@ class UnprotectedNameAnalysisService(NameAnalysisDirector):
         self._set_misplaced_designation_in_input_name()
 
         # Set all designations based on entity type typed by user
-        self._all_designations_user = self._designation_any_list_user + self._designation_end_list_user
+        self._all_designations_user = self._designation_any_list_correct + self._designation_end_list_correct
         # Set all designations based on company name typed by user
         #self._all_designations = self._designation_any_list + self._designation_end_list
 

--- a/api/namex/services/name_request/auto_analyse/unprotected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/unprotected_name_analysis.py
@@ -8,7 +8,7 @@ from . import ProcedureResult
 from namex.constants import \
     BCProtectedNameEntityTypes, BCUnprotectedNameEntityTypes, XproUnprotectedNameEntityTypes
 
-from namex.services.synonyms import DesignationPositionCodes
+from namex.services.synonyms import DesignationPositionCodes, LanguageCodes
 
 from namex.services.word_classification.token_classifier \
     import TokenClassifier
@@ -97,8 +97,8 @@ class UnprotectedNameAnalysisService(NameAnalysisDirector):
         elif XproUnprotectedNameEntityTypes.has_value(entity_type):
             entity_type_code = XproUnprotectedNameEntityTypes(entity_type)
 
-        any_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.ANY, 'english')
-        end_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.END, 'english')
+        any_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.ANY, LanguageCodes.ENG)
+        end_list = syn_svc.get_designations(entity_type_code, DesignationPositionCodes.END, LanguageCodes.ENG)
 
         self._designation_any_list_correct.extend(any_list)
         self._designation_end_list_correct.extend(end_list)

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -282,8 +282,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     '''
     Override the abstract / base class method
-    list_name: original name tokenized
-    entity_type_user: Entity type typed u user in UI
+    list_name: original name tokenized by designation. For instance, designation composed of many words is tokenized as one.
+    entity_type_user: Entity type typed by user. 'CR' by default
     all_designations: All Designations found in name (either misplaced or not)
     all_designations_user: All designations for the entity type typed by the user. 
     @return ProcedureResult
@@ -312,23 +312,23 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     '''
         Override the abstract / base class method
-        misplaced_designation_any, misplaced_designation_end, misplaced_designation_all
+        Just <end> designation can be misplaced in other position, it can be at the beginning, middle or before end in the name
+        Note: <any> designation can be anywhere in the name, so to be misplaced is not possible.
         @return ProcedureResult
         '''
 
-    def check_designation_misplaced(self, list_name, misplaced_designation_any, misplaced_designation_end,
-                                    misplaced_designation_all):
+    def check_designation_misplaced(self, list_name, misplaced_designation_end):
         result = ProcedureResult()
         result.is_valid = True
 
-        if misplaced_designation_all:
+        if misplaced_designation_end:
             result.is_valid = False
             result.result_code = AnalysisIssueCodes.DESIGNATION_MISPLACED
             result.values = {
                 'list_name': list_name,
-                'misplaced_any_designation': misplaced_designation_any,
+                'misplaced_any_designation': None,
                 'misplaced_end_designation': misplaced_designation_end,
-                'misplaced_all_designation': misplaced_designation_all
+                'misplaced_all_designation': misplaced_designation_end
             }
 
         return result

--- a/api/namex/services/synonyms/__init__.py
+++ b/api/namex/services/synonyms/__init__.py
@@ -15,3 +15,8 @@ class DesignationPositionCodes(Enum):
     START = 'start'
     END = 'end'
     ANY = 'any'
+
+
+class LanguageCodes(Enum):
+    ENG = 'english'
+    FR = 'french'

--- a/api/namex/services/synonyms/__init__.py
+++ b/api/namex/services/synonyms/__init__.py
@@ -18,5 +18,5 @@ class DesignationPositionCodes(Enum):
 
 
 class LanguageCodes(Enum):
-    ENG = 'english'
-    FR = 'french'
+    ENG = 'ENGLISH'
+    FR = 'FRENCH'

--- a/api/namex/services/synonyms/mixins/designation.py
+++ b/api/namex/services/synonyms/mixins/designation.py
@@ -12,10 +12,10 @@ from .. import DesignationPositionCodes, LanguageCodes
 
 class SynonymDesignationMixin(SynonymServiceMixin):
     def get_designated_end_all_words(self):
-        return self.get_designations(None, DesignationPositionCodes.END, 'english')
+        return self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
 
     def get_designated_any_all_words(self):
-        return self.get_designations(None, DesignationPositionCodes.ANY, 'english')
+        return self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
 
     def get_misplaced_end_designations(self, name, designation_end_entity_type):
         # en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, 'english')
@@ -64,7 +64,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_designation_end_in_name(self, name):
-        en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, 'english')
+        en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
         designation_end_rgx = '(' + '|'.join(map(str, en_designation_end_all_list)) + ')'
         designation_end_regex = r'{0}(?=(\s{0})*$)'.format(designation_end_rgx)
 
@@ -88,7 +88,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_incorrect_designation_end_in_name(self, name):
-        en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, 'english')
+        en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
         designation_end_rgx = '|'.join(map(str, en_designation_end_all_list))
         designation_end_regex = r'({})(?=(?:.*\s\w+$))'.format(designation_end_rgx)
 
@@ -103,7 +103,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_designation_any_in_name(self, name):
-        en_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, 'english')
+        en_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
         designation_any_rgx = '(' + '|'.join(map(str, en_designation_any_all_list)) + ')'
         designation_any_regex = r'{}(?=\s|$)'.format(designation_any_rgx)
 

--- a/api/namex/services/synonyms/mixins/designation.py
+++ b/api/namex/services/synonyms/mixins/designation.py
@@ -7,7 +7,7 @@ from namex.constants import \
 from namex.services.name_request.auto_analyse.name_analysis_utils import get_flat_list
 
 from . import SynonymServiceMixin
-from .. import DesignationPositionCodes
+from .. import DesignationPositionCodes, LanguageCodes
 
 
 class SynonymDesignationMixin(SynonymServiceMixin):
@@ -113,8 +113,6 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         return found_designation_any
 
     def get_all_end_designations(self):
-        # TODO: Fix RLC we don't have that entity type, code changed to RLC from something else...
-        # 'RLC': self._model.get_en_RLC_entity_type_end_designation()
         entity_types = [
             XproUnprotectedNameEntityTypes.XPRO_LIMITED_LIABILITY_COMPANY,
             BCUnprotectedNameEntityTypes.BC_LIMITED_LIABILITY_PARTNERSHIP,
@@ -125,11 +123,10 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         entity_end_designation_dict = {}
 
         for entity_type in entity_types:
-            # TODO: Use an enum for languages too!
             entity_end_designation_dict[entity_type.value] = self.get_designations(
                 entity_type,
                 DesignationPositionCodes.END,
-                'english'
+                LanguageCodes.ENG
             )
 
         return entity_end_designation_dict
@@ -142,11 +139,10 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         entity_any_designation_dict = {}
 
         for entity_type in entity_types:
-            # TODO: Use an enum for languages too!
             entity_any_designation_dict[entity_type.value] = self.get_designations(
                 entity_type,
                 DesignationPositionCodes.ANY,
-                'english'
+                LanguageCodes.ENG
             )
 
         return entity_any_designation_dict

--- a/api/namex/services/synonyms/mixins/designation.py
+++ b/api/namex/services/synonyms/mixins/designation.py
@@ -58,10 +58,15 @@ class SynonymDesignationMixin(SynonymServiceMixin):
 
         return entity_type_any_designation_name
 
+    '''
+    Get designations with <end> position for any entity type. This omits the general designation with <end> position:
+    English Designations_end Stop
+    '''
+
     def get_designation_end_in_name(self, name):
         en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, 'english')
         designation_end_rgx = '(' + '|'.join(map(str, en_designation_end_all_list)) + ')'
-        designation_end_regex = r'' + designation_end_rgx + '(?=(\s' + designation_end_rgx + ')*$)'
+        designation_end_regex = r'{0}(?=(\s{0})*$)'.format(designation_end_rgx)
 
         # Returns list of tuples
         found_designation_end = re.findall(designation_end_regex, name.lower())
@@ -76,51 +81,36 @@ class SynonymDesignationMixin(SynonymServiceMixin):
 
         return designation_end_list
 
-    def get_designation_all_in_name(self, name):
-        all_designations_end_all_list = self.get_designations(None, DesignationPositionCodes.END, 'english')
-        all_designations_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, 'english')
+    '''
+    Get designations with <end> position for any entity type which have incorrect position different to <end>.
+    Designations in <end> position which are at the beginning, middle or before <end> position, these designations
+    have to be shown as misplaced.
+    '''
 
-        all_designations = list(set(all_designations_end_all_list + all_designations_any_all_list))
-
-        all_designations.sort(key=len, reverse=True)
-
-        all_designations_rgx = '(' + '|'.join(map(str, all_designations)) + ')'
-        all_designations_regex = r'' + all_designations_rgx + '(?=\\s|$)'
+    def get_incorrect_designation_end_in_name(self, name):
+        en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, 'english')
+        designation_end_rgx = '|'.join(map(str, en_designation_end_all_list))
+        designation_end_regex = r'({})(?=(?:.*\s\w+$))'.format(designation_end_rgx)
 
         # Returns list of tuples
-        found_all_designations = re.findall(all_designations_regex, name.lower())
+        found_incorrect_designation_end = re.findall(designation_end_regex, name.lower())
 
-        return found_all_designations
+        return found_incorrect_designation_end
+
+    '''
+    Get designations with <any> position for any entity type. This omits the general designation with <any> position:
+    English Designations_any Stop
+    '''
 
     def get_designation_any_in_name(self, name):
         en_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, 'english')
         designation_any_rgx = '(' + '|'.join(map(str, en_designation_any_all_list)) + ')'
-        designation_any_regex = designation_any_rgx + '(?=\\s)'
+        designation_any_regex = r'{}(?=\s|$)'.format(designation_any_rgx)
 
         # Returns list of tuples
         found_designation_any = re.findall(designation_any_regex, name.lower())
 
         return found_designation_any
-
-    def get_misplaced_any_designations(self, name, designation_any_entity_type):
-        # en_designation_any_all_list = self.get_designations(entity_type, DesignationPositionCodes.ANY, 'english')
-        if not designation_any_entity_type:
-            return list()
-        designation_end_rgx = '(' + '|'.join(map(str, designation_any_entity_type)) + ')'
-        designation_end_regex = r'' + designation_end_rgx + '(?=(\s' + designation_end_rgx + ')*$)'
-
-        # Returns list of tuples
-        found_designation_end = re.findall(designation_end_regex, name.lower())
-
-        # Getting list of lists where the first list contains designations of type "anywhere" and the second list contains designations of type "end".
-        # [['association],['limited partnership']
-        misplaced_designation_end_list = [list(elem) for elem in found_designation_end]
-        if any(isinstance(el, list) for el in misplaced_designation_end_list):
-            misplaced_designation_end_list = get_flat_list(misplaced_designation_end_list)
-        misplaced_designation_end_list = list(filter(None, misplaced_designation_end_list))
-        misplaced_designation_end_list = list(dict.fromkeys(misplaced_designation_end_list))
-
-        return misplaced_designation_end_list
 
     def get_all_end_designations(self):
         # TODO: Fix RLC we don't have that entity type, code changed to RLC from something else...
@@ -128,11 +118,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         entity_types = [
             XproUnprotectedNameEntityTypes.XPRO_LIMITED_LIABILITY_COMPANY,
             BCUnprotectedNameEntityTypes.BC_LIMITED_LIABILITY_PARTNERSHIP,
-            # TODO: Arturo, if these are commented out, why? Document...
-            # BCProtectedNameEntityTypes.BC_COMMUNITY_CONTRIBUTION_COMPANY,
             BCProtectedNameEntityTypes.BC_UNLIMITED_LIABILITY_COMPANY,
-            # TODO: Arturo, if these are commented out, why? Document...
-            # BCProtectedNameEntityTypes.BC_BENEFIT_COMPANY,
             BCProtectedNameEntityTypes.BC_CORPORATION
         ]
 
@@ -150,10 +136,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
 
     def get_all_any_designations(self):
         entity_types = [
-            # TODO: Arturo, if these are commented out, why? Document...
-            # BCProtectedNameEntityTypes.BC_COOPERATIVE,
-            # BCProtectedNameEntityTypes.BC_COMMUNITY_CONTRIBUTION_COMPANY,
-            # XproUnprotectedNameEntityTypes.XPRO_COOPERATIVE
+
         ]
 
         entity_any_designation_dict = {}
@@ -162,8 +145,8 @@ class SynonymDesignationMixin(SynonymServiceMixin):
             # TODO: Use an enum for languages too!
             entity_any_designation_dict[entity_type.value] = self.get_designations(
                 entity_type,
-               DesignationPositionCodes.ANY,
-               'english'
+                DesignationPositionCodes.ANY,
+                'english'
             )
 
         return entity_any_designation_dict

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -188,7 +188,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         text = self.regex_punctuation(text)
         text = self.regex_together_one_letter(text)
         text = self.regex_strip_out_numbers_middle_end(text, ordinal_suffixes, numbers)
-        text = self.regex_numbers_standalone(text, stand_alone_words)
+        text = self.regex_numbers_standalone(text, ordinal_suffixes, numbers, stand_alone_words)
         text = self.regex_remove_extra_spaces(text)
 
         return text
@@ -266,9 +266,9 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
                       re.IGNORECASE)
         return " ".join(text.split())
 
-    def regex_numbers_standalone(self, text, stand_alone_words):
+    def regex_numbers_standalone(self, text, ordinal_suffixes, numbers, stand_alone_words):
         text = re.sub(
-            r'\b(?=(\d+(?:\s+\d+)*))\1(?!\s+(?:{})\b)\s*'.format(stand_alone_words),
+            r'\b(?=(\d+(?:{0})?(?:\s+\d+(?:{0})?)*|(?:{1})(?:\s+(?:{1}))*))\1(?!\s+(?:{2})\b)\s*'.format(ordinal_suffixes, numbers, stand_alone_words),
             '',
             text,
             0,

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -3,6 +3,7 @@ from sqlalchemy import func
 
 from namex.models import Synonym
 from namex.criteria.synonym.query_criteria import SynonymQueryCriteria
+from . import LanguageCodes
 
 from .mixins.designation import SynonymDesignationMixin
 from .mixins.model import SynonymModelMixin
@@ -112,7 +113,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         return flattened
 
     def get_designations(self, entity_type_code, position_code, lang):
-        lang = lang if isinstance(lang, str) else 'english'
+        lang = lang if isinstance(lang, str) else LanguageCodes.ENG
         model = self.get_model()
 
         filters = []
@@ -127,7 +128,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         else:
             filters.append(func.lower(model.category).op('~')(r'\y{}\y'.format('designation[s]?[_-]')))
 
-        filters.append(func.lower(model.category).op('~')(r'\y{}\y'.format(lang.lower())))
+        filters.append(func.lower(model.category).op('~')(r'\y{}\y'.format(lang.value.lower())))
 
         results = self.find_word_synonyms(None, filters)
         flattened = list(set(map(str.strip, (list(filter(None, self.flatten_synonyms_text(results)))))))

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -32,8 +32,8 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         return flattened_arr
 
     '''
-        Designations, distinctives and descriptives return stems_text
-        '''
+    Designations, distinctives and descriptives return stems_text
+    '''
 
     def find_word_synonyms(self, word, filters):
         model = self.get_model()
@@ -130,7 +130,9 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         filters.append(func.lower(model.category).op('~')(r'\y{}\y'.format(lang.lower())))
 
         results = self.find_word_synonyms(None, filters)
-        flattened = list(map(str.strip, (list(filter(None, self.flatten_synonyms_text(results))))))
+        flattened = list(set(map(str.strip, (list(filter(None, self.flatten_synonyms_text(results)))))))
+        flattened.sort(key=len, reverse=True)
+
         return flattened
 
     # TODO: Move this out of utils, it uses a model utils shouldn't use class methods
@@ -162,7 +164,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
          Remove cardinal and ordinal numbers from string in the middle and end: (?<=[A-Za-z]\b )([ 0-9]*(ST|[RN]D|TH)?\b)
     10.- Replace with non-space:
          Remove numbers at the beginning or keep them as long as the last string and following string is 
-         any BC|HOLDINGS|VENTURES: (^(?:\d+(?:{ordinal_suffixes})?\s+)+(?=[^\d]+$)|(?:({numbers})\s+)(?!.*?(?:{stand_alone_words}$))
+         any BC|HOLDINGS|VENTURES.
     	 Set single letters together (initials):(?<=\b[A-Za-z]\b) +(?=[a-zA-Z]\b)
     11.- Remove extra spaces to have just one space: \s+
     '''

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -171,6 +171,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         designation_all_regex = '|'.join(designation_all)
         prefixes = '|'.join(prefix_list)
         number_list = number_list = sorted(number_list, key=len, reverse=True)
+        print(number_list)
         numbers = '|'.join(number_list)
         ordinal_suffixes = 'ST|[RN]D|TH'
         stand_alone_words = 'HOLDINGS$|BC$|VENTURES$|SOLUTION$|ENTERPRISE$|INDUSTRIES$'
@@ -184,7 +185,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         text = self.regex_keep_together_abv(text, exceptions_ws)
         text = self.regex_punctuation(text)
         text = self.regex_together_one_letter(text)
-        text = self.regex_strip_out_numbers_middle_end(text)
+        text = self.regex_strip_out_numbers_middle_end(text, ordinal_suffixes, numbers)
         text = self.regex_numbers_standalone(text, ordinal_suffixes, numbers, stand_alone_words)
         text = self.regex_remove_extra_spaces(text)
 

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -269,7 +269,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     def regex_numbers_standalone(self, text, ordinal_suffixes, numbers, stand_alone_words):
         text = re.sub(
-            r'\b(?=(\d+(?:{0})?(?:\s+\d+(?:{0})?)*|(?:{1})(?:\s+(?:{1}))*))\1(?!\s+(?:{2})\b)\s*'.format(ordinal_suffixes, numbers, stand_alone_words),
+            r'\b(?=(\d+(?:{0})?(?:\s+\d+(?:\b{0}\b)?)*|(?:\b({1})\b)(?:\s+(?:\b({1})\b))*))\1(?!\s+(?:{2})\b)\s*'.format(ordinal_suffixes, numbers, stand_alone_words),
             '',
             text,
             0,

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -192,7 +192,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         return text
 
     def regex_remove_designations(self, text, internet_domains, designation_all_regex):
-        text = re.sub(r'{}|(?<=\d),(?=\d)|(?<=[A-Za-z])+[&-](?=[A-Za-z]\b)|\b({})\b.?'.format(internet_domains, designation_all_regex),
+        text = re.sub(r'\b({})\b|(?<=\d),(?=\d)|(?<=[A-Za-z])+[&-](?=[A-Za-z]\b)|\b({})\b.?'.format(internet_domains, designation_all_regex),
                       '',
                       text,
                       0,

--- a/api/namex/services/synonyms/synonym.py
+++ b/api/namex/services/synonyms/synonym.py
@@ -161,7 +161,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
     9.- Replace with non-space the following:
          Remove cardinal and ordinal numbers from string in the middle and end: (?<=[A-Za-z]\b )([ 0-9]*(ST|[RN]D|TH)?\b)
     10.- Replace with non-space:
-         Remove numbers and numbers in words at the beginning or keep them as long as the last string is 
+         Remove numbers at the beginning or keep them as long as the last string and following string is 
          any BC|HOLDINGS|VENTURES: (^(?:\d+(?:{ordinal_suffixes})?\s+)+(?=[^\d]+$)|(?:({numbers})\s+)(?!.*?(?:{stand_alone_words}$))
     	 Set single letters together (initials):(?<=\b[A-Za-z]\b) +(?=[a-zA-Z]\b)
     11.- Remove extra spaces to have just one space: \s+
@@ -186,7 +186,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         text = self.regex_punctuation(text)
         text = self.regex_together_one_letter(text)
         text = self.regex_strip_out_numbers_middle_end(text, ordinal_suffixes, numbers)
-        text = self.regex_numbers_standalone(text, ordinal_suffixes, numbers, stand_alone_words)
+        text = self.regex_numbers_standalone(text, stand_alone_words)
         text = self.regex_remove_extra_spaces(text)
 
         return text
@@ -264,9 +264,9 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
                       re.IGNORECASE)
         return " ".join(text.split())
 
-    def regex_numbers_standalone(self, text, ordinal_suffixes, numbers, stand_alone_words):
+    def regex_numbers_standalone(self, text, stand_alone_words):
         text = re.sub(
-            r'(^(?:\d+(?:{})?\s*)+(?=[^\d]*$)|\b(?:{})\b)(?!.*?(?:{}$))|(?<=\b[A-Za-z]\b) +(?=[a-zA-Z]\b)'.format(ordinal_suffixes, numbers, stand_alone_words),
+            r'\b(?=(\d+(?:\s+\d+)*))\1(?!\s+(?:{})\b)\s*'.format(stand_alone_words),
             '',
             text,
             0,

--- a/api/tests/python/namex_services/name_request/test_name_analysis_utils.py
+++ b/api/tests/python/namex_services/name_request/test_name_analysis_utils.py
@@ -8,7 +8,10 @@ from namex.services.name_request.auto_analyse.name_analysis_utils import remove_
                              ("CENTRAL CARE CORPORATION/CORPORATION CENTRALE DE SOINS", "CENTRAL CARE CORPORATION"),
                              ("20/20 CAFE & BAKERY", "20/20 CAFE & BAKERY"),
                              ("ABC ENGINEERING/CENTRAL CARE CORP.", "ABC ENGINEERING"),
-                             ("RE/MAX WALNUT DEVELOPERS", "RE/MAX WALNUT DEVELOPERS")
+                             ("RE/MAX WALNUT DEVELOPERS", "RE/MAX WALNUT DEVELOPERS"),
+                             ('ARMSTRONG 20/20 VISION', 'ARMSTRONG 20/20 VISION'),
+                             ('ARMSTRONG VISION 20/20', 'ARMSTRONG VISION 20/20'),
+                             ("ARMSTRONG VISION/2020 ENTERPRISE", "ARMSTRONG VISION")
                          ]
                          )
 def test_remove_french(name, expected):
@@ -17,10 +20,13 @@ def test_remove_french(name, expected):
 
 @pytest.mark.parametrize("name_list, dist_list, desc_list, dist_expected, desc_expected",
                          [
-                             (['PACIFIC', 'BLUE', 'ENTERPRISE'], ['PACIFIC', 'BLUE', 'ENTERPRISE'], ['PACIFIC', 'ENTERPRISE'],
+                             (['PACIFIC', 'BLUE', 'ENTERPRISE'], ['PACIFIC', 'BLUE', 'ENTERPRISE'],
+                              ['PACIFIC', 'ENTERPRISE'],
                               [['PACIFIC', 'BLUE']], [['ENTERPRISE']]),
-                             (['PACIFIC', 'BLUE', 'COAST', 'ENTERPRISE'], ['PACIFIC', 'BLUE', 'COAST', 'ENTERPRISE'], ['PACIFIC', 'COAST', 'ENTERPRISE'],
-                              [['PACIFIC', 'BLUE'], ['PACIFIC', 'BLUE', 'COAST']], [['COAST', 'ENTERPRISE'], ['ENTERPRISE']])
+                             (['PACIFIC', 'BLUE', 'COAST', 'ENTERPRISE'], ['PACIFIC', 'BLUE', 'COAST', 'ENTERPRISE'],
+                              ['PACIFIC', 'COAST', 'ENTERPRISE'],
+                              [['PACIFIC', 'BLUE'], ['PACIFIC', 'BLUE', 'COAST']],
+                              [['COAST', 'ENTERPRISE'], ['ENTERPRISE']])
                          ]
                          )
 def test_list_distinctive_descriptive(name_list, dist_list, desc_list, dist_expected, desc_expected):

--- a/api/tests/python/namex_services/synonyms/__init__.py
+++ b/api/tests/python/namex_services/synonyms/__init__.py
@@ -20,7 +20,8 @@ prefix_list = ['un', 're', 'in', 'dis', 'en', 'non', 'in', 'over', 'mis', 'sub',
                'trans', 'super', 'semi', 'anti', 'mid', 'under', 'ante', 'bene', 'circum', 'co', 'com', 'con',
                'col', 'dia', 'ex', 'homo', 'hyper', 'mal', 'micro', 'multi', 'para', 'poly', 'post', 'pro', 'retro',
                'tele', 'therm', 'trans', 'uni']
-number_list = ['one', 'two', 'three', 'first', 'second', 'third']
+number_list = ['nine hundred', 'one hundred', 'eleventh', 'eleven', 'second', 'three', 'first', 'third', 'eight',
+               'five', 'nine', 'one', 'two']
 exceptions_ws = ['activ8', 'h20']
 
 designation_all_regex = "(" + '|'.join(all_designations) + ")"

--- a/api/tests/python/namex_services/synonyms/test_synonym.py
+++ b/api/tests/python/namex_services/synonyms/test_synonym.py
@@ -169,14 +169,10 @@ def test_regex_strip_out_numbers_middle_end(name, expected):
 
 @pytest.mark.parametrize("name, expected",
                          [
-                             ("ONE TWO THREE HOLDINGS", "ONE TWO THREE HOLDINGS"),
                              ("123 HOLDINGS", "123 HOLDINGS"),
-                             ("FIRST SECOND HOLDINGS", "FIRST SECOND HOLDINGS"),
-                             ("1ST 2ND HOLDINGS", "1ST 2ND HOLDINGS"),
-                             ("ONE TWO THREE CANADA", "CANADA"),
                              ("123 CANADA", "CANADA"),
-                             ("FIRST SECOND THIRD CANADA", "CANADA"),
-                             ("1ST 2ND 3RD CANADA", "CANADA")
+                             ("123 CATHEDRAL VENTURES","CATHEDRAL VENTURES"),
+                             ("123 VENTURES", "123 VENTURES")
                          ])
 def test_regex_numbers_standalone(name, expected):
-    assert syn_svc.regex_numbers_standalone(name, ordinal_suffixes, numbers, stand_alone_words) == expected
+    assert syn_svc.regex_numbers_standalone(name, stand_alone_words) == expected

--- a/api/tests/python/namex_services/synonyms/test_synonym.py
+++ b/api/tests/python/namex_services/synonyms/test_synonym.py
@@ -169,10 +169,17 @@ def test_regex_strip_out_numbers_middle_end(name, expected):
 
 @pytest.mark.parametrize("name, expected",
                          [
+                             ("ONE TWO THREE HOLDINGS", "ONE TWO THREE HOLDINGS"),
                              ("123 HOLDINGS", "123 HOLDINGS"),
+                             ("FIRST SECOND HOLDINGS", "FIRST SECOND HOLDINGS"),
+                             ("1ST 2ND HOLDINGS", "1ST 2ND HOLDINGS"),
+                             ("ONE TWO THREE CANADA", "CANADA"),
                              ("123 CANADA", "CANADA"),
+                             ("FIRST SECOND THIRD CANADA", "CANADA"),
+                             ("1ST 2ND 3RD CANADA", "CANADA"),
                              ("123 CATHEDRAL VENTURES","CATHEDRAL VENTURES"),
-                             ("123 VENTURES", "123 VENTURES")
+                             ("123 VENTURES", "123 VENTURES"),
+                             ("ONE ARMSTRONG PLUMBING AND HEATING", "ARMSTRONG PLUMBING AND HEATING")
                          ])
 def test_regex_numbers_standalone(name, expected):
-    assert syn_svc.regex_numbers_standalone(name, stand_alone_words) == expected
+    assert syn_svc.regex_numbers_standalone(name, ordinal_suffixes, numbers, stand_alone_words) == expected

--- a/api/tests/python/namex_services/synonyms/test_synonym.py
+++ b/api/tests/python/namex_services/synonyms/test_synonym.py
@@ -140,7 +140,28 @@ def test_regex_together_one_letter(name, expected):
 
 
 '''
-9.- Replace with non-space:
+9.- Replace with non-space the following:
+         Remove cardinal and ordinal numbers from string in the middle and end: (?<=[A-Za-z]\b )([ 0-9]*(ST|[RN]D|TH)?\b)
+'''
+
+
+@pytest.mark.parametrize("name, expected",
+                         [
+                             ("ARMSTRONG 111 PLUMBING", "ARMSTRONG PLUMBING"),
+                             ("ARMSTRONG PLUMBING 111", "ARMSTRONG PLUMBING"),
+                             ("ARMSTRONG 111 PLUMBING 111", "ARMSTRONG PLUMBING"),
+                             ("123 HOLDINGS 2020", "123 HOLDINGS"),
+                             ("ARMSTRONG 20 20 VISION", "ARMSTRONG VISION"),
+                             ("ARMSTRONG VISION 20 20", "ARMSTRONG VISION"),
+                             ("ARMSTRONG ONE HUNDRED ELEVEN PLUMBING","ARMSTRONG PLUMBING"),
+                             ("ARMSTRONG PLUMBING ONE HUNDRED ELEVENTH", "ARMSTRONG PLUMBING")
+                         ])
+def test_regex_strip_out_numbers_middle_end(name, expected):
+    assert syn_svc.regex_strip_out_numbers_middle_end(name,ordinal_suffixes, numbers) == expected
+
+
+'''
+10.- Replace with non-space:
     Remove numbers and numbers in words at the beginning or keep them as long as the last string is 
     any BC|HOLDINGS|VENTURES:    
 '''


### PR DESCRIPTION
*ANALYZE NAME-Strip Out All Numbers for Conflict Matching #3141*

*Description of changes:*
All numbers must be stripped out for conflict matching accept when the name is using a stand-alone.Right now numbers are being stripped out of the beginning but not the end and not the middle.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
