### PR TITLE
3158 remove checks from well formed name

### DIFF
--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -177,3 +177,21 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
     @abc.abstractmethod
     def get_details_most_similar(self, list_response, dist_substitution_dict, desc_substitution_dict):
         return ProcedureResult(is_valid=True)
+
+    '''
+    This method IS abstract and MUST BE IMPLEMENTED in extending Builder classes
+    @return ProcedureResult
+    '''
+    @abc.abstractmethod
+    def check_word_limit(self, list_name):
+        return ProcedureResult(is_valid=True)
+
+    '''
+    This method IS abstract and MUST BE IMPLEMENTED in extending Builder classes
+    @return ProcedureResult
+    '''
+
+    @abc.abstractmethod
+    def check_unclassified_words(self, list_name, list_none):
+        return ProcedureResult(is_valid=True)
+

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -266,6 +266,21 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
             analysis = analysis + results
 
+            analysis_issues_sort_order = [
+                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
+                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
+                AnalysisIssueCodes.TOO_MANY_WORDS,
+                AnalysisIssueCodes.WORDS_TO_AVOID,
+                AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
+                AnalysisIssueCodes.WORD_SPECIAL_USE,
+                AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
+                AnalysisIssueCodes.CORPORATE_CONFLICT,
+                AnalysisIssueCodes.DESIGNATION_MISMATCH,
+                AnalysisIssueCodes.DESIGNATION_MISPLACED
+            ]
+
+            analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)
+
             # If the error coming back is that a name is not well formed
             # OR if the error coming back has words to avoid...
             # eg. result.result_code = AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD
@@ -273,10 +288,10 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             # word in the result.
 
             issues_that_must_be_fixed = [
-                AnalysisIssueCodes.WORDS_TO_AVOID,
-                AnalysisIssueCodes.TOO_MANY_WORDS,
                 AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
-                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD
+                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
+                AnalysisIssueCodes.WORDS_TO_AVOID,
+                AnalysisIssueCodes.TOO_MANY_WORDS
             ]
 
             issue_must_be_fixed = False
@@ -311,18 +326,18 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
                 analysis = list(map(remove_words_to_avoid, analysis))
 
-            analysis_issues_sort_order = [
-                AnalysisIssueCodes.WORDS_TO_AVOID,
-                AnalysisIssueCodes.TOO_MANY_WORDS,
-                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
-                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
-                AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
-                AnalysisIssueCodes.WORD_SPECIAL_USE,
-                AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
-                AnalysisIssueCodes.CORPORATE_CONFLICT,
-                AnalysisIssueCodes.DESIGNATION_MISMATCH,
-                AnalysisIssueCodes.DESIGNATION_MISPLACED
-            ]
+            # analysis_issues_sort_order = [
+            #     AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
+            #     AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
+            #     AnalysisIssueCodes.WORDS_TO_AVOID,
+            #     AnalysisIssueCodes.TOO_MANY_WORDS,
+            #     AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
+            #     AnalysisIssueCodes.WORD_SPECIAL_USE,
+            #     AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
+            #     AnalysisIssueCodes.CORPORATE_CONFLICT,
+            #     AnalysisIssueCodes.DESIGNATION_MISMATCH,
+            #     AnalysisIssueCodes.DESIGNATION_MISPLACED
+            # ]
 
             analysis = analysis + self.do_analysis()
             analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -67,9 +67,9 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     def builder(self, builder):
         self._builder = builder
 
-#    @property
-#    def model(self):
-#        return Synonym
+    #    @property
+    #    def model(self):
+    #        return Synonym
 
     @property
     def entity_type(self):
@@ -118,6 +118,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     name_as_submitted_tokenized tokenize the original name and when there is a compound designation made of more than one
     word, the term is counted as token. For instance, designations such as limited liability company is counted as one token.
     '''
+
     @property
     def name_as_submitted_tokenized(self):
         np_svc = self.name_processing_service
@@ -126,6 +127,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     '''
     Just an alias for name_as_submitted
     '''
+
     @property
     def original_name(self):
         return self.name_as_submitted
@@ -184,6 +186,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     @:prop processed_name The cleaned name
     @:prop name_tokens Word tokens generated from the cleaned name
     '''
+
     def set_name(self, name):
         np_svc = self.name_processing_service
         wc_svc = self.word_classification_service
@@ -203,6 +206,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     Prepare any data required by the analysis builder.
     prepare_data is an abstract method and must be implemented in extending classes.
     '''
+
     def prepare_data(self):
         # Query for whatever data we need to load up here
         self.configure_builder()
@@ -218,6 +222,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     - If you don't want to check to see if a name is well formed first, override check_name_is_well_formed in the supplied builder.
     @:return ProcedureResult[]
     '''
+
     def execute_analysis(self):
         try:
             # Execute analysis using the supplied builder
@@ -240,6 +245,15 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 analysis.append(check_words_to_avoid)
                 return analysis
 
+            results = []
+            check_word_limit = builder.check_word_limit(list_name)
+            if check_word_limit:
+                results.append(check_word_limit)
+
+            check_word_unclassified = builder.check_unclassified_words(list_name, list_none)
+            if check_word_unclassified:
+                results.append(check_word_unclassified)
+
             check_name_is_well_formed = builder.check_name_is_well_formed(
                 self.token_classifier.distinctive_word_tokens,
                 self.token_classifier.descriptive_word_tokens,
@@ -247,8 +261,10 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 self.name_tokens,
                 self.name_original_tokens
             )
+            if check_name_is_well_formed:
+                results.append(check_name_is_well_formed)
 
-            analysis = analysis + check_name_is_well_formed
+            analysis = analysis + results
 
             # If the error coming back is that a name is not well formed
             # OR if the error coming back has words to avoid...
@@ -282,7 +298,8 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
             has_words_to_avoid = self._has_analysis_issue_type(analysis, AnalysisIssueCodes.WORDS_TO_AVOID)
             if has_words_to_avoid:
-                matched_words_to_avoid = self._get_analysis_issue_type_issues(analysis, AnalysisIssueCodes.WORDS_TO_AVOID)
+                matched_words_to_avoid = self._get_analysis_issue_type_issues(analysis,
+                                                                              AnalysisIssueCodes.WORDS_TO_AVOID)
                 for procedure_result in matched_words_to_avoid:
                     list_avoid = list_avoid + procedure_result.values.get('list_avoid', [])
 
@@ -364,5 +381,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     do_analysis is an abstract method and must be implemented in extending classes.
     @:return ProcedureResult[]
     '''
+
     def do_analysis(self):
         raise NotImplementedError('do_analysis must be implemented in extending classes')

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -245,15 +245,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 analysis.append(check_words_to_avoid)
                 return analysis
 
-            results = []
-            check_word_limit = builder.check_word_limit(list_name)
-            if check_word_limit:
-                results.append(check_word_limit)
-
-            check_word_unclassified = builder.check_unclassified_words(list_name, list_none)
-            if check_word_unclassified:
-                results.append(check_word_unclassified)
-
             check_name_is_well_formed = builder.check_name_is_well_formed(
                 self.token_classifier.distinctive_word_tokens,
                 self.token_classifier.descriptive_word_tokens,
@@ -262,24 +253,19 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 self.name_original_tokens
             )
             if check_name_is_well_formed:
-                results.append(check_name_is_well_formed)
+                analysis.append(check_name_is_well_formed)
+                return analysis
 
-            analysis = analysis + results
+            check_word_limit = builder.check_word_limit(list_name)
+            if check_word_limit:
+                analysis.append(check_word_limit)
+                return analysis
 
-            analysis_issues_sort_order = [
-                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
-                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
-                AnalysisIssueCodes.TOO_MANY_WORDS,
-                AnalysisIssueCodes.WORDS_TO_AVOID,
-                AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
-                AnalysisIssueCodes.WORD_SPECIAL_USE,
-                AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
-                AnalysisIssueCodes.CORPORATE_CONFLICT,
-                AnalysisIssueCodes.DESIGNATION_MISMATCH,
-                AnalysisIssueCodes.DESIGNATION_MISPLACED
-            ]
+            check_word_unclassified = builder.check_unclassified_words(list_name, list_none)
+            if check_word_unclassified:
+                analysis.append(check_word_unclassified)
 
-            analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)
+            #analysis = analysis + results
 
             # If the error coming back is that a name is not well formed
             # OR if the error coming back has words to avoid...
@@ -326,18 +312,18 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
                 analysis = list(map(remove_words_to_avoid, analysis))
 
-            # analysis_issues_sort_order = [
-            #     AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
-            #     AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
-            #     AnalysisIssueCodes.WORDS_TO_AVOID,
-            #     AnalysisIssueCodes.TOO_MANY_WORDS,
-            #     AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
-            #     AnalysisIssueCodes.WORD_SPECIAL_USE,
-            #     AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
-            #     AnalysisIssueCodes.CORPORATE_CONFLICT,
-            #     AnalysisIssueCodes.DESIGNATION_MISMATCH,
-            #     AnalysisIssueCodes.DESIGNATION_MISPLACED
-            # ]
+            analysis_issues_sort_order = [
+                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
+                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
+                AnalysisIssueCodes.WORDS_TO_AVOID,
+                AnalysisIssueCodes.TOO_MANY_WORDS,
+                AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
+                AnalysisIssueCodes.WORD_SPECIAL_USE,
+                AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
+                AnalysisIssueCodes.CORPORATE_CONFLICT,
+                AnalysisIssueCodes.DESIGNATION_MISMATCH,
+                AnalysisIssueCodes.DESIGNATION_MISPLACED
+            ]
 
             analysis = analysis + self.do_analysis()
             analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -26,7 +26,9 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     '''
 
     def check_name_is_well_formed(self, list_dist, list_desc, list_none, list_name, list_original_name):
-        results = []
+        #results = []
+        result = ProcedureResult()
+        result.is_valid = True
         # TODO: We're doing two checks for name is well formed, that should probably not be the case
 
         # list_name = ['victoria', 'abc', 'view', 'book']
@@ -67,7 +69,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         #     results.append(result)
 
         # Now that too many words and unclassified words are handled, handle distinctive and descriptive issues
-        result = None
+        #result = None
 
         # list_name contains the clean name. For instance, the name 'ONE TWO THREE CANADA' is just 'CANADA'. Then,
         # the original name should be passed to get the correct index when reporting issues to front end.
@@ -117,10 +119,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     'list_dist': list_dist or []
                 }
 
-        if result:
-            results.append(result)
+        #if result:
+        #    results.append(result)
 
-        return results
+        return result
 
     '''
     Override the abstract / base class method.

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -139,7 +139,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 'length_name': length_name
             }
 
-            return result
+        return result
 
     '''
     Override the abstract / base class method.
@@ -163,7 +163,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 'list_none': unclassified_words_list_response
             }
 
-            return result
+        return result
 
     '''
     Override the abstract / base class method.

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -26,9 +26,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     '''
 
     def check_name_is_well_formed(self, list_dist, list_desc, list_none, list_name, list_original_name):
-        #results = []
-        result = ProcedureResult()
-        result.is_valid = True
+        result = None
         # TODO: We're doing two checks for name is well formed, that should probably not be the case
 
         # list_name = ['victoria', 'abc', 'view', 'book']
@@ -119,9 +117,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     'list_dist': list_dist or []
                 }
 
-        #if result:
-        #    results.append(result)
-
         return result
 
     '''
@@ -131,8 +126,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     '''
 
     def check_word_limit(self, list_name):
-        result = ProcedureResult()
-        result.is_valid = True
+        result = None
 
         length_name = len(list_name)
         if length_name > MAX_LIMIT:
@@ -154,8 +148,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     '''
 
     def check_unclassified_words(self, list_name, list_none):
-        result = ProcedureResult()
-        result.is_valid = True
+        result = None
 
         if list_none.__len__() > 0:
             unclassified_words_list_response = []

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -41,30 +41,30 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         else:
             self._list_dist_words, self._list_desc_words = list_distinctive_descriptive(list_name, list_dist, list_desc)
 
-        # First, check to make sure the name doesn't have too many words
-        if len(list_name) > MAX_LIMIT:
-            result = ProcedureResult()
-            result.is_valid = False
-            result.result_code = AnalysisIssueCodes.TOO_MANY_WORDS
-
-            results.append(result)
-
-        # Next, we check for unclassified words
-        if list_none.__len__() > 0:
-            unclassified_words_list_response = []
-            for idx, token in enumerate(list_name):
-                if any(token in word for word in list_none):
-                    unclassified_words_list_response.append(token)
-
-            result = ProcedureResult()
-            result.is_valid = False
-            result.result_code = AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD
-            result.values = {
-                'list_name': list_name or [],
-                'list_none': unclassified_words_list_response
-            }
-
-            results.append(result)
+        # # First, check to make sure the name doesn't have too many words
+        # if len(list_name) > MAX_LIMIT:
+        #     result = ProcedureResult()
+        #     result.is_valid = False
+        #     result.result_code = AnalysisIssueCodes.TOO_MANY_WORDS
+        #
+        #     results.append(result)
+        #
+        # # Next, we check for unclassified words
+        # if list_none.__len__() > 0:
+        #     unclassified_words_list_response = []
+        #     for idx, token in enumerate(list_name):
+        #         if any(token in word for word in list_none):
+        #             unclassified_words_list_response.append(token)
+        #
+        #     result = ProcedureResult()
+        #     result.is_valid = False
+        #     result.result_code = AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD
+        #     result.values = {
+        #         'list_name': list_name or [],
+        #         'list_none': unclassified_words_list_response
+        #     }
+        #
+        #     results.append(result)
 
         # Now that too many words and unclassified words are handled, handle distinctive and descriptive issues
         result = None
@@ -121,6 +121,54 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             results.append(result)
 
         return results
+
+    '''
+    Override the abstract / base class method.
+
+    @return ProcedureResult
+    '''
+
+    def check_word_limit(self, list_name):
+        result = ProcedureResult()
+        result.is_valid = True
+
+        length_name = len(list_name)
+        if length_name > MAX_LIMIT:
+            result = ProcedureResult()
+            result.is_valid = False
+            result.result_code = AnalysisIssueCodes.TOO_MANY_WORDS
+
+            result.values = {
+                'list_name': list_name,
+                'length_name': length_name
+            }
+
+            return result
+
+    '''
+    Override the abstract / base class method.
+
+    @return ProcedureResult
+    '''
+
+    def check_unclassified_words(self, list_name, list_none):
+        result = ProcedureResult()
+        result.is_valid = True
+
+        if list_none.__len__() > 0:
+            unclassified_words_list_response = []
+            for idx, token in enumerate(list_name):
+                if any(token in word for word in list_none):
+                    unclassified_words_list_response.append(token)
+            result = ProcedureResult()
+            result.is_valid = False
+            result.result_code = AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD
+            result.values = {
+                'list_name': list_name or [],
+                'list_none': unclassified_words_list_response
+            }
+
+            return result
 
     '''
     Override the abstract / base class method.


### PR DESCRIPTION
*#3158, Remove checks from well formed name:*

*Description of changes:*

- Take out word limit and unclassified checking from well_formed
- If any stopper is present (Add distinctive, Add descriptive, words to avoid and too many words), then stop conducting further checks and return response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
