### PR TITLE
3246 designations enters without periods

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_issues.py
+++ b/api/namex/resources/auto_analyse/analysis_issues.py
@@ -684,6 +684,7 @@ class DesignationMisplacedIssue(AnalysisResponseIssue):
         misplaced_all_designation = procedure_result.values['misplaced_all_designation']
 
         list_name_lc = list(map(lambda d: d.lower(), list_name))
+        misplaced_all_designation_lc = list(map(lambda d: d.lower() if isinstance(d, str) else '', misplaced_all_designation))
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -706,7 +707,7 @@ class DesignationMisplacedIssue(AnalysisResponseIssue):
 
             # Highlight the descriptives
             # <class 'list'>: ['mountain', 'view']
-            if word in misplaced_all_designation:
+            if word in misplaced_all_designation_lc:
                 issue.name_actions.append(NameAction(
                     word=word,
                     index=name_word_idx,

--- a/api/namex/resources/auto_analyse/analysis_issues.py
+++ b/api/namex/resources/auto_analyse/analysis_issues.py
@@ -233,7 +233,7 @@ class AddDescriptiveWordIssue(AnalysisResponseIssue):
         last_dist_word = list_dist.pop() if list_dist.__len__() > 0 else None
         # TODO: Why was this like this before?
         # dist_word_idx = list_name.index(last_dist_word) # if list_dist.__len__() > 0 else 0
-        dist_word_idx = list_name.index(last_dist_word) if list_dist.__len__() > 0 else 0
+        dist_word_idx = list_name.index(last_dist_word)
         issue.name_actions = [
             NameAction(
                 type=NameActions.BRACKETS,

--- a/api/namex/resources/auto_analyse/analysis_options.py
+++ b/api/namex/resources/auto_analyse/analysis_options.py
@@ -34,7 +34,7 @@ class AddDescriptiveSetup(Setup):
 
 
 def add_descriptive_setup():
-    return AddDistinctiveSetup(
+    return AddDescriptiveSetup(
         type="add_descriptive",
         header=Template("Add Descriptive"),
         line1=Template(

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -118,7 +118,7 @@ class NameProcessingService(GetSynonymListsMixin):
         self.name_as_submitted_tokenized = regex.findall(name.lower())
 
     def _clean_name_words(self, text, stop_words=[], designation_any=[], designation_end=[], designation_all=[],
-                          fr_designation_end_list=[], prefix_list=[], number_list=[]):
+                          prefix_list=[], number_list=[]):
         if not text or not stop_words or not designation_any or not designation_end or not prefix_list and not number_list:
             warnings.warn("Parameters in clean_name_words function are not set.", Warning)
 
@@ -178,7 +178,6 @@ class NameProcessingService(GetSynonymListsMixin):
                 self._designated_any_words,
                 self._designated_end_words,
                 self._designated_all_words,
-                self._fr_designation_end_list,
                 self._prefixes,
                 self._number_words
             )

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -117,9 +117,8 @@ class NameProcessingService(GetSynonymListsMixin):
         regex = re.compile(r'(?<!\w)({}|[a-z-A-Z]+)(?!\w)'.format(designation_alternators))
         self.name_as_submitted_tokenized = regex.findall(name.lower())
 
-    def _clean_name_words(self, text, stop_words=[], designation_any=[], designation_end=[], designation_all=[],
-                          prefix_list=[], number_list=[]):
-        if not text or not stop_words or not designation_any or not designation_end or not prefix_list and not number_list:
+    def _clean_name_words(self, text, stop_words=[], designation_all=[], prefix_list=[], number_list=[]):
+        if not text or not stop_words or not prefix_list and not number_list:
             warnings.warn("Parameters in clean_name_words function are not set.", Warning)
 
         syn_svc = self.synonym_service
@@ -175,8 +174,8 @@ class NameProcessingService(GetSynonymListsMixin):
                 # These properties are mixed in via GetSynonymListsMixin
                 # See the class constructor
                 self._stop_words,
-                self._designated_any_words,
-                self._designated_end_words,
+                # self._designated_any_words,
+                # self._designated_end_words,
                 self._designated_all_words,
                 self._prefixes,
                 self._number_words

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -28,6 +28,10 @@ class NameProcessingService(GetSynonymListsMixin):
         return self._name_as_submitted
 
     @property
+    def name_first_part(self):
+        return self._name_first_part
+
+    @property
     def name_as_submitted_tokenized(self):
         return self._name_as_submitted_tokenized
 
@@ -38,6 +42,10 @@ class NameProcessingService(GetSynonymListsMixin):
     @name_as_submitted.setter
     def name_as_submitted(self, val):
         self._name_as_submitted = val
+
+    @name_first_part.setter
+    def name_first_part(self, val):
+        self._name_first_part = val
 
     @name_as_submitted_tokenized.setter
     def name_as_submitted_tokenized(self, val):
@@ -83,6 +91,7 @@ class NameProcessingService(GetSynonymListsMixin):
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.name_as_submitted = None
+        self._name_first_part = None
         self.name_as_submitted_tokenized = None
         self.name_original_tokens = None
         self.processed_name = None
@@ -94,8 +103,10 @@ class NameProcessingService(GetSynonymListsMixin):
     '''
     Set and process a submitted name string using the process_name class method.
     '''
+
     def set_name(self, name):
         self.name_as_submitted = name  # Store the user's submitted name string
+        self.name_first_part = remove_french(name)
         self.name_original_tokens = name.lower().split()
         self._process_name()
 
@@ -106,7 +117,8 @@ class NameProcessingService(GetSynonymListsMixin):
         regex = re.compile(r'(?<!\w)({}|[a-z-A-Z]+)(?!\w)'.format(designation_alternators))
         self.name_as_submitted_tokenized = regex.findall(name.lower())
 
-    def _clean_name_words(self, text, stop_words=[], designation_any=[], designation_end=[], designation_all=[], fr_designation_end_list=[], prefix_list=[], number_list=[]):
+    def _clean_name_words(self, text, stop_words=[], designation_any=[], designation_end=[], designation_all=[],
+                          fr_designation_end_list=[], prefix_list=[], number_list=[]):
         if not text or not stop_words or not designation_any or not designation_end or not prefix_list and not number_list:
             warnings.warn("Parameters in clean_name_words function are not set.", Warning)
 
@@ -151,6 +163,7 @@ class NameProcessingService(GetSynonymListsMixin):
     Split a name string into classifiable tokens. Called whenever set_name is invoked.
     @:param string:name
     '''
+
     def _process_name(self):
         try:
             # Prepare any data that we need to pre-process the name

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -141,7 +141,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
         '''
 
     @abc.abstractmethod
-    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user):
+    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user, all_designation_user_no_periods):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -6,6 +6,7 @@ class GetDesignationsListsMixin(object):
     _designation_any_list_correct = []
     _designation_end_list_correct = []
     _all_designations_user = []
+    _all_designations_user_no_periods = []
 
     # All designations for entity type typed bu user
     designations_entity_type_user = []
@@ -59,6 +60,9 @@ class GetDesignationsListsMixin(object):
 
     def get_all_designations_user(self):
         return self._all_designations_user
+
+    def get_all_designations_user_no_periods(self):
+        return self._all_designations_user_no_periods
 
     def get_all_designations(self):
         return self._all_designations

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -232,13 +232,13 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             list_dist, list_desc, list_none = self.word_classification_tokens
 
             analysis = []
-            if list_none and list_none.__len__() > 0:
-                self._list_dist_words, self._list_desc_words = TokenClassifier.handle_unclassified_words(
-                    list_dist,
-                    list_desc,
-                    list_none,
-                    list_name
-                )
+            # if list_none and list_none.__len__() > 0:
+            #     self._list_dist_words, self._list_desc_words = TokenClassifier.handle_unclassified_words(
+            #         list_dist,
+            #         list_desc,
+            #         list_none,
+            #         list_name
+            #     )
 
             check_words_to_avoid = builder.check_words_to_avoid(list_name, self.processed_name)
             if not check_words_to_avoid.is_valid:

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -192,7 +192,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         wc_svc = self.word_classification_service
 
         np_svc.set_name(name)
-        np_svc.set_name_tokenized(name)
+        np_svc.set_name_tokenized(np_svc.name_first_part)
 
         # TODO: Get rid of this when done refactoring!
         self._list_name_words = np_svc.name_tokens

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -59,7 +59,7 @@ Rules:  1) Before and after slash has to be at least two words to removed string
 
 
 def remove_french(text):
-    text = re.sub(r'(^[A-Z]+(?:[^A-Z\n]+[A-Z]+)+[^A-Z\n]*)/(\w+(?:[^A-Z\n]+[A-Z]+)+[^A-Z\n]*$)+',
+    text = re.sub(r'(^[A-Z]+(?:[^A-Z\n]+[A-Z]+)+[^A-Z\n]*)/(\s*\w+(?:[^A-Z\n]+[A-Z]+)+[^A-Z\n]*$)+',
                   r'\1 ',
                   text,
                   0,
@@ -73,8 +73,9 @@ def remove_stop_words(original_name_list, stop_words):
     return words
 
 
-def list_distinctive_descriptive_same(name_list):
-    queue = collections.deque(name_list)
+def list_distinctive_descriptive_same(name_list, none_list):
+    queue = [element for element in name_list if element not in none_list]
+
     dist_list = []
     desc_list = []
 
@@ -84,7 +85,7 @@ def list_distinctive_descriptive_same(name_list):
     dist_list.reverse()
 
     for dist in dist_list:
-        desc_list.append([i for i in name_list if i not in dist])
+        desc_list.append([i for i in name_list if i not in dist and i not in none_list])
 
     return dist_list, desc_list
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -132,7 +132,7 @@ def validate_distinctive_descriptive_lists(list_name, list_dist, list_desc):
 def list_distinctive_descriptive(name_list, dist_list, desc_list):
     queue_dist = collections.deque(dist_list)
 
-    if dist_list == name_list:
+    if len(name_list) > 0 and dist_list == name_list:
         queue_dist.pop()
 
     dist_list_tmp, dist_list_all, desc_list_tmp, desc_list_all = [], [], [], []

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -73,8 +73,8 @@ def remove_stop_words(original_name_list, stop_words):
     return words
 
 
-def list_distinctive_descriptive_same(name_list, none_list):
-    queue = [element for element in name_list if element not in none_list]
+def list_distinctive_descriptive_same(name_list):
+    queue = collections.deque(name_list)
 
     dist_list = []
     desc_list = []
@@ -85,7 +85,7 @@ def list_distinctive_descriptive_same(name_list, none_list):
     dist_list.reverse()
 
     for dist in dist_list:
-        desc_list.append([i for i in name_list if i not in dist and i not in none_list])
+        desc_list.append([i for i in name_list if i not in dist])
 
     return dist_list, desc_list
 

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -50,14 +50,23 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
 
     def _set_designations_by_input_name(self):
         syn_svc = self.synonym_service
-        original_name = self.get_original_name()
+        np_svc = self.name_processing_service
+
+        # original_name = self.get_original_name()
+        # Get the first section of name when exists slash. For instance, ARMSTRONG PLUMBING LTD./ ARMSTRONG PLUMBING LIMITEE
+        # Just take ARMSTRONG PLUMBING LTD. and perform analysis of designations.
+        name_first_part = np_svc.name_first_part
 
         # These are used when getting the entity type in _set_entity_type_any_designation, _set_entity_type_end_designation
         # for <any> and <end> designations which are properly placed:
-        self._designation_any_list = syn_svc.get_designation_any_in_name(name=original_name).data
-        self._designation_end_list = syn_svc.get_designation_end_in_name(name=original_name).data
+        # self._designation_any_list = syn_svc.get_designation_any_in_name(name=original_name).data
+        # self._designation_end_list = syn_svc.get_designation_end_in_name(name=original_name).data
 
-        self._all_designations = syn_svc.get_designation_all_in_name(name=original_name).data
+        self._designation_any_list = syn_svc.get_designation_any_in_name(name=name_first_part).data
+        self._designation_end_list = syn_svc.get_designation_end_in_name(name=name_first_part).data
+
+        # self._all_designations = syn_svc.get_designation_all_in_name(name=original_name).data
+        self._all_designations = syn_svc.get_designation_all_in_name(name=name_first_part).data
 
     '''
     Set designations in position <end> found any other place in the company name, these designations are misplaced.
@@ -70,7 +79,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
 
         designation_end_misplaced_list = syn_svc.get_incorrect_designation_end_in_name(tokenized_name=tokenized_name,
                                                                                        designation_end_list=correct_designation_end_list).data
-        self._misplaced_designation_end_list = designation_end_misplaced_list
+        self._misplaced_designation_end_list = list(map(lambda x: x.upper(), designation_end_misplaced_list))
 
     def _set_designations_by_entity_type_user(self):
         syn_svc = self.synonym_service

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -164,13 +164,15 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
     def do_analysis(self):
         builder = self.builder
 
-        list_name = self.name_tokens
+        # list_name = self.name_tokens
         # list_dist, list_desc, list_none = self.word_classification_tokens
+
+        list_name = [element for element in self.name_tokens if element not in builder.get_list_none()]
 
         results = []
 
         # Return any combination of these checks
-        check_conflicts = builder.search_conflicts(builder.get_list_dist(), builder.get_list_desc(), self.name_tokens,
+        check_conflicts = builder.search_conflicts(builder.get_list_dist(), builder.get_list_desc(), list_name,
                                                    self.processed_name)
 
         if not check_conflicts.is_valid:

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -6,7 +6,7 @@ from namex.constants import \
 
 from .name_analysis_director import NameAnalysisDirector
 
-from namex.utils.common import parse_dict_of_lists
+from namex.utils.common import parse_dict_of_lists, remove_periods_designation
 
 '''
 The ProtectedNameAnalysisService returns an analysis response using the strategies in analysis_strategies.py
@@ -66,7 +66,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
     def _set_designations_incorrect_position_by_input_name(self):
         syn_svc = self.synonym_service
         tokenized_name = self.get_original_name_tokenized()
-        correct_designation_end_list = self._designation_end_list_correct
+        correct_designation_end_list = remove_periods_designation(self._designation_end_list_correct)
 
         designation_end_misplaced_list = syn_svc.get_incorrect_designation_end_in_name(tokenized_name=tokenized_name,
                                                                                        designation_end_list=correct_designation_end_list).data
@@ -150,6 +150,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
 
         # Set all designations based on entity type typed by user,'CR' by default
         self._all_designations_user = self._designation_any_list_correct + self._designation_end_list_correct
+        self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)
 
         # Set all designations based on company name typed by user
         # self._all_designations = self._designation_any_list + self._designation_end_list
@@ -198,7 +199,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
                 self.get_original_name_tokenized(),
                 self.entity_type,
                 self.get_all_designations(),
-                self.get_all_designations_user()
+                self.get_all_designations_user(),
+                self.get_all_designations_user_no_periods()
             )
 
             if not check_designation_mismatch.is_valid:

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -173,15 +173,13 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
     def do_analysis(self):
         builder = self.builder
 
-        # list_name = self.name_tokens
+        list_name = self.name_tokens
         # list_dist, list_desc, list_none = self.word_classification_tokens
-
-        list_name = [element for element in self.name_tokens if element not in builder.get_list_none()]
 
         results = []
 
         # Return any combination of these checks
-        check_conflicts = builder.search_conflicts(builder.get_list_dist(), builder.get_list_desc(), list_name,
+        check_conflicts = builder.search_conflicts(self._list_dist_words, self._list_desc_words, list_name,
                                                    self.processed_name)
 
         if not check_conflicts.is_valid:

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -36,10 +36,15 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         # _, _, list_incorrect_classification = validate_distinctive_descriptive_lists(list_name, list_dist, list_desc)
 
         # Validate possible combinations using available distinctive and descriptive list:
-        if list_dist == list_desc:
-            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(list_name)
+        self._list_none_words= list_none
+        if len(list_dist) > 0 and list_dist == list_desc:
+            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(list_name,
+                                                                                             list_none)
         else:
-            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive(list_name, list_dist, list_desc)
+            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive(list_name,
+                                                                                        list_dist,
+                                                                                        list_desc
+                                                                                        )
 
         # # First, check to make sure the name doesn't have too many words
         # if len(list_name) > MAX_LIMIT:
@@ -67,7 +72,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         #     results.append(result)
 
         # Now that too many words and unclassified words are handled, handle distinctive and descriptive issues
-        #result = None
+        # result = None
 
         # list_name contains the clean name. For instance, the name 'ONE TWO THREE CANADA' is just 'CANADA'. Then,
         # the original name should be passed to get the correct index when reporting issues to front end.
@@ -252,7 +257,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                                                                                             w_desc, list_name, name)
         most_similar_names.extend(
             list({k for k, v in
-                  sorted(dict_highest_counter.items(), key=lambda item: (-item[1], len(item[0])))[0:MAX_MATCHES_LIMIT]}))
+                  sorted(dict_highest_counter.items(), key=lambda item: (-item[1], len(item[0])))[
+                  0:MAX_MATCHES_LIMIT]}))
 
         for element in most_similar_names:
             response.update({element: dict_highest_detail.get(element, {})})
@@ -350,7 +356,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user, all_designation_user_no_periods):
+    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user,
+                                   all_designation_user_no_periods):
         result = ProcedureResult()
         result.is_valid = True
 

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -36,11 +36,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         # _, _, list_incorrect_classification = validate_distinctive_descriptive_lists(list_name, list_dist, list_desc)
 
         # Validate possible combinations using available distinctive and descriptive list:
-        self._list_none_words = list_none
+        # self._list_none_words = list_none
         list_name = [element for element in list_name if element not in list_none]
         if len(list_dist) > 0 and list_dist == list_desc:
-            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(list_name,
-                                                                                             list_none)
+            self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(list_name)
         else:
             self._list_dist_words, self._list_desc_words = list_distinctive_descriptive(list_name,
                                                                                         list_dist,

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -350,14 +350,14 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user):
+    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user, all_designation_user_no_periods):
         result = ProcedureResult()
         result.is_valid = True
 
         mismatch_entity_designation_list = []
         for idx, token in enumerate(list_name):
             if any(token in designation for designation in all_designations):
-                if token not in all_designations_user:
+                if token not in all_designation_user_no_periods:
                     mismatch_entity_designation_list.append(token.upper())
 
         if mismatch_entity_designation_list:

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -37,6 +37,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         # Validate possible combinations using available distinctive and descriptive list:
         self._list_none_words= list_none
+        list_name = [element for element in list_name if element not in list_none]
         if len(list_dist) > 0 and list_dist == list_desc:
             self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(list_name,
                                                                                              list_none)

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -36,7 +36,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         # _, _, list_incorrect_classification = validate_distinctive_descriptive_lists(list_name, list_dist, list_desc)
 
         # Validate possible combinations using available distinctive and descriptive list:
-        self._list_none_words= list_none
+        self._list_none_words = list_none
         list_name = [element for element in list_name if element not in list_none]
         if len(list_dist) > 0 and list_dist == list_desc:
             self._list_dist_words, self._list_desc_words = list_distinctive_descriptive_same(list_name,
@@ -364,9 +364,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         mismatch_entity_designation_list = []
         for idx, token in enumerate(list_name):
-            if any(token in designation for designation in all_designations):
-                if token not in all_designation_user_no_periods:
-                    mismatch_entity_designation_list.append(token.upper())
+            if token in all_designations and token not in all_designation_user_no_periods:
+                mismatch_entity_designation_list.append(token.upper())
 
         if mismatch_entity_designation_list:
             result.is_valid = False

--- a/api/namex/utils/common.py
+++ b/api/namex/utils/common.py
@@ -1,3 +1,5 @@
+import re
+
 _parse_csv_line = lambda x: (x.split(','))
 
 
@@ -19,3 +21,14 @@ def parse_dict_of_lists(results):
     for item in results:
         output[item.key] = item.list
     return output
+
+
+def remove_periods_designation(results):
+    designation_list = []
+    for item in results:
+        text = re.sub(r'[\.]', '', item, 0, re.IGNORECASE)
+        designation_list.append(item)
+        if text != item:
+            designation_list.append(text)
+
+    return designation_list

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -10,7 +10,6 @@ from .mixins.model import SynonymModelMixin
 
 from synonyms.utils.service_utils import get_entity_type_code, get_designation_position_code
 
-
 """
 - Services implement business logic, and NON generic queries. 
 - Services don't have generic model query methods like find, find_one, or find_by_criteria.
@@ -194,8 +193,9 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     @classmethod
     def regex_remove_designations(cls, text, internet_domains, designation_all_regex):
-        text = re.sub(r'\b({})\b|(?<=\d),(?=\d)|(?<=[A-Za-z])+[&-](?=[A-Za-z]\b)|\b({})\b.?'.format(internet_domains,
-                                                                                                    designation_all_regex),
+        text = re.sub(r'\b({0})\b|(?<=\d),(?=\d)|(?<=[A-Za-z])+[&-](?=[A-Za-z]\b)|(?<!\w)({1})(?!\w)(?=.*\s\w+$)'.format(
+            internet_domains,
+            designation_all_regex),
                       '',
                       text,
                       0,

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -193,7 +193,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     @classmethod
     def regex_remove_designations(cls, text, internet_domains, designation_all_regex):
-        text = re.sub(r'\b({0})\b|(?<=\d),(?=\d)|(?<=[A-Za-z])+[&-](?=[A-Za-z]\b)|(?<!\w)({1})(?!\w)(?=.*\s\w+$)'.format(
+        text = re.sub(r'\b({0})\b|(?<=\d),(?=\d)|(?<=[A-Za-z])+[&-](?=[A-Za-z]\b)|(?<!\w)({1})(?!\w)(?=.*$)'.format(
             internet_domains,
             designation_all_regex),
                       '',

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -180,7 +180,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
         text = self.regex_remove_designations(text, internet_domains, designation_all_regex)
         text = self.regex_numbers_lot(text)
-        text = self.regex_repeated_strings(text)
+        # text = self.regex_repeated_strings(text)
         text = self.regex_separated_ordinals(text, ordinal_suffixes)
         text = self.regex_keep_together_abv(text, exceptions_ws)
         text = self.regex_punctuation(text)
@@ -259,8 +259,8 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     @classmethod
     def regex_together_one_letter(cls, text):
-        text = re.sub(r'(?<=\b[A-Za-z]\b) +(?=[a-zA-Z]\b)|^\s+|\s+$',
-                      '',
+        text = re.sub(r'(\b[A-Za-z]{1,2}\b)\s+(?=[a-zA-Z]{1,2}\b)|\s+$',
+                      r'\1',
                       text,
                       0,
                       re.IGNORECASE)


### PR DESCRIPTION
*#3246, Designation Enters without the Periods Cause Bad Behaviour:*

*Description of changes:*
-Fix regex related to designations and names with two letters.
-Created a new function to remove periods from designations and add designations with no period to the list if not included.
-Upper case for misplaced designation
-Handling slash in names (excluding french name)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
