### PR TITLE
3281 v2 not handling restricted words number

### DIFF
--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -156,7 +156,7 @@ class NameProcessingService(GetSynonymListsMixin):
     def exception_virtual_word_condition(self, text, vwc_svc):
         exceptions_ws = []
         for word in re.sub(r'[^a-zA-Z0-9 -\']+', ' ', text, 0, re.IGNORECASE).split():
-            if vwc_svc.get_word(word):
+            if vwc_svc.get_word(word) and bool(re.search(r'\d', word)):
                 exceptions_ws.append(word)
 
         if not exceptions_ws:

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -10,6 +10,8 @@ from .mixins.get_synonym_lists import GetSynonymListsMixin
 
 from swagger_client import SynonymsApi as SynonymService
 
+from ..virtual_word_condition.virtual_word_condition import VirtualWordConditionService
+
 '''
 Service for pre-processing of a user submitted name request name string.
 Setting the name using NameProcessingService.set_name will clean the name and set the following properties:
@@ -87,9 +89,18 @@ class NameProcessingService(GetSynonymListsMixin):
     def synonym_service(self, svc):
         self._synonym_service = svc
 
+    @property
+    def virtual_word_condition_service(self):
+        return self._virtual_word_condition_service
+
+    @virtual_word_condition_service.setter
+    def virtual_word_condition_service(self, svc):
+        self._virtual_word_condition_service = svc
+
     def __init__(self):
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
+        self.virtual_word_condition_service = VirtualWordConditionService()
         self.name_as_submitted = None
         self._name_first_part = None
         self.name_as_submitted_tokenized = None
@@ -122,11 +133,13 @@ class NameProcessingService(GetSynonymListsMixin):
             warnings.warn("Parameters in clean_name_words function are not set.", Warning)
 
         syn_svc = self.synonym_service
+        vwc_svc = self.virtual_word_condition_service
 
         words = remove_stop_words(self.name_original_tokens, stop_words)
         words = remove_french(words)
 
         exceptions_ws = syn_svc.get_exception_regex(text=words).data
+        exceptions_ws.extend(self.exception_virtual_word_condition(words, vwc_svc))
 
         tokens = syn_svc.get_transform_text(
             text=words,
@@ -139,6 +152,17 @@ class NameProcessingService(GetSynonymListsMixin):
         tokens = tokens.split()
 
         return [x.lower() for x in tokens if x]
+
+    def exception_virtual_word_condition(self, text, vwc_svc):
+        exceptions_ws = []
+        for word in re.sub(r'[^a-zA-Z0-9 -\']+', ' ', text, 0, re.IGNORECASE).split():
+            if vwc_svc.get_word(word):
+                exceptions_ws.append(word)
+
+        if not exceptions_ws:
+            exceptions_ws.append('null')
+
+        return exceptions_ws
 
     def _prepare_data(self):
         syn_svc = self.synonym_service

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -312,12 +312,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         for words_consent in all_words_consent_list:
             for name_sin_plural in name_singular_plural_list:
                 if re.search(r'\b{}\b'.format(re.escape(words_consent.lower())), name_sin_plural.lower()):
-                    word_consent_tokenized = words_consent.lower().split()
-                    name_sin_plur_tokenized = name_sin_plural.split()
-                    for word in word_consent_tokenized:
-                        if word.lower() in name_sin_plural:
-                            idx = name_sin_plur_tokenized.index(word.lower())
-                            words_consent_dict[idx] = word
+                    words_consent_dict.update(self.get_position_word_consent(words_consent, name_sin_plural))
 
         words_consent_list_response = []
         for key in sorted(words_consent_dict):
@@ -332,6 +327,17 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             }
 
         return result
+
+    def get_position_word_consent(self, words_consent, name_sin_plural):
+        word_consent_tokenized = words_consent.lower().split()
+        name_sin_plur_tokenized = name_sin_plural.split()
+        words_consent_dict = {}
+        for word in word_consent_tokenized:
+            if word.lower() in name_sin_plural:
+                idx = name_sin_plur_tokenized.index(word.lower())
+                words_consent_dict[idx] = word
+
+        return words_consent_dict
 
     def check_designation_existence(self, list_name, all_designations, all_designations_user):
         result = ProcedureResult()

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -10,7 +10,7 @@ from ..auto_analyse.name_analysis_utils import validate_distinctive_descriptive_
 from namex.models.request import Request
 from ..auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
 
-from namex.utils.common import parse_dict_of_lists
+from namex.utils.common import parse_dict_of_lists, get_plural_singular_name
 
 '''
 Sample builder
@@ -67,7 +67,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         #     results.append(result)
 
         # Now that too many words and unclassified words are handled, handle distinctive and descriptive issues
-        #result = None
+        # result = None
 
         # list_name contains the clean name. For instance, the name 'ONE TWO THREE CANADA' is just 'CANADA'. Then,
         # the original name should be passed to get the correct index when reporting issues to front end.
@@ -252,7 +252,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                                                                                             w_desc, list_name, name)
         most_similar_names.extend(
             list({k for k, v in
-                  sorted(dict_highest_counter.items(), key=lambda item: (-item[1], len(item[0])))[0:MAX_MATCHES_LIMIT]}))
+                  sorted(dict_highest_counter.items(), key=lambda item: (-item[1], len(item[0])))[
+                  0:MAX_MATCHES_LIMIT]}))
 
         for element in most_similar_names:
             response.update({element: dict_highest_detail.get(element, {})})
@@ -305,17 +306,22 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         result.is_valid = True
 
         all_words_consent_list = self.word_condition_service.get_words_requiring_consent()
-        words_consent_list = []
+        words_consent_dict = {}
+        name_singular_plural_list = get_plural_singular_name(name)
 
         for words_consent in all_words_consent_list:
-            if re.search(r'\b{}\b'.format(re.escape(words_consent.lower())), name.lower()):
-                words_consent_list.append(words_consent.lower())
+            for name_sin_plural in name_singular_plural_list:
+                if re.search(r'\b{}\b'.format(re.escape(words_consent.lower())), name_sin_plural.lower()):
+                    word_consent_tokenized = words_consent.lower().split()
+                    name_sin_plur_tokenized = name_sin_plural.split()
+                    for word in word_consent_tokenized:
+                        if word.lower() in name_sin_plural:
+                            idx = name_sin_plur_tokenized.index(word.lower())
+                            words_consent_dict[idx] = word
 
         words_consent_list_response = []
-
-        for idx, token in enumerate(list_name):
-            if any(token in word for word in words_consent_list):
-                words_consent_list_response.append(token)
+        for key in sorted(words_consent_dict):
+            words_consent_list_response.append(list_name[key])
 
         if words_consent_list_response:
             result.is_valid = False
@@ -350,7 +356,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user, all_designation_user_no_periods):
+    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user,
+                                   all_designation_user_no_periods):
         result = ProcedureResult()
         result.is_valid = True
 

--- a/api/namex/services/virtual_word_condition/virtual_word_condition.py
+++ b/api/namex/services/virtual_word_condition/virtual_word_condition.py
@@ -1,3 +1,4 @@
+from sqlalchemy import func
 from sqlalchemy.sql.expression import false, true
 
 from namex.criteria.virtual_word_condition.query_criteria import VirtualWordConditionCriteria
@@ -64,3 +65,20 @@ class VirtualWordConditionService:
         results = model.find_by_criteria(criteria)
         flattened = list(map(str.strip, (list(filter(None, flatten_tuple_results(results))))))
         return flattened
+
+    def get_word(self, word):
+        model = self.get_model()
+
+        filters = [
+            func.lower(model.rc_words).op('~')(r'\y{}\y'.format(word.lower()))
+        ]
+
+        criteria = VirtualWordConditionCriteria(
+            fields=[model.rc_words],
+            filters=filters
+        )
+
+        if model.find_by_criteria(criteria):
+            return word
+
+        return None

--- a/api/namex/utils/common.py
+++ b/api/namex/utils/common.py
@@ -1,4 +1,6 @@
 import re
+from pattern.text.en import singularize
+from itertools import product
 
 _parse_csv_line = lambda x: (x.split(','))
 
@@ -32,3 +34,19 @@ def remove_periods_designation(results):
             designation_list.append(text)
 
     return designation_list
+
+
+def get_plural_singular_name(name):
+    d = {}
+    for word in name.split():
+        val = []
+        singular = singularize(word.lower())
+        val.extend([singular])
+        val.extend([word.lower()])
+        d[word] = (list(set(val)))
+
+    name_list = []
+    for combination in product(*d.values()):
+        name_list.append(' '.join(combination))
+
+    return name_list

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -20,4 +20,5 @@ toolz
 nltk==3.4.5
 werkzeug==0.16.1
 pysolr
+pattern
 git+https://github.com/bcgov/namex-synonyms-api-py-client.git#egg=swagger_client

--- a/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
@@ -98,7 +98,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     def get_designation_any_in_name(self, name):
         en_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
         designation_any_rgx = '(' + '|'.join(map(str, en_designation_any_all_list)) + ')'
-        designation_any_regex = r'\b({})\b(?=\s|$)'.format(designation_any_rgx)
+        designation_any_regex = r'(?<!\w)({0})(?!\w)(?=\s|$)'.format(designation_any_rgx)
 
         # Returns list of tuples
         found_designation_any = re.findall(designation_any_regex, name.lower())
@@ -118,7 +118,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         all_designations.sort(key=len, reverse=True)
 
         all_designations_rgx = '|'.join(map(str, all_designations))
-        all_designations_regex = r'\b({})\b(?=\s|$)'.format(all_designations_rgx)
+        all_designations_regex = r'(?<!\w)({0})(?!\w)(?=\s|$)'.format(all_designations_rgx)
 
         # Returns list of tuples
         found_all_designations = re.findall(all_designations_regex, name.lower())

--- a/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
@@ -98,7 +98,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     def get_designation_any_in_name(self, name):
         en_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
         designation_any_rgx = '(' + '|'.join(map(str, en_designation_any_all_list)) + ')'
-        designation_any_regex = r'{}(?=\s|$)'.format(designation_any_rgx)
+        designation_any_regex = r'\b({})\b(?=\s|$)'.format(designation_any_rgx)
 
         # Returns list of tuples
         found_designation_any = re.findall(designation_any_regex, name.lower())
@@ -118,7 +118,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         all_designations.sort(key=len, reverse=True)
 
         all_designations_rgx = '|'.join(map(str, all_designations))
-        all_designations_regex = r'({})(?=\s|$)'.format(all_designations_rgx)
+        all_designations_regex = r'\b({})\b(?=\s|$)'.format(all_designations_rgx)
 
         # Returns list of tuples
         found_all_designations = re.findall(all_designations_regex, name.lower())

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -299,7 +299,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         # Build exception list to avoid separation of numbers and letters when they are part of synonym table such as H20, 4MULA, ACTIV8
         exceptions_ws = []
         for word in re.sub(r'[^a-zA-Z0-9 -\']+', ' ', text, 0, re.IGNORECASE).split():
-            if self.get_substitutions(word):
+            if self.get_substitutions(word) and bool(re.search(r'\d', word)):
                 exceptions_ws.append(word)
 
         if not exceptions_ws:

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -180,7 +180,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
         text = self.regex_remove_designations(text, internet_domains, designation_all_regex)
         text = self.regex_numbers_lot(text)
-        # text = self.regex_repeated_strings(text)
+        text = self.regex_repeated_strings(text)
         text = self.regex_separated_ordinals(text, ordinal_suffixes)
         text = self.regex_keep_together_abv(text, exceptions_ws)
         text = self.regex_punctuation(text)

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -268,7 +268,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     @classmethod
     def regex_strip_out_numbers_middle_end(cls, text, ordinal_suffixes, numbers):
-        text = re.sub(r'(?<=[A-Za-z]\b\s)([ 0-9]+({})?|({})\b)'.format(ordinal_suffixes, numbers),
+        text = re.sub(r'(?<=[A-Za-z]\b\s)([ 0-9]+({})?\b|({})\b)'.format(ordinal_suffixes, numbers),
                       '',
                       text,
                       0,
@@ -278,7 +278,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
     @classmethod
     def regex_numbers_standalone(cls, text, ordinal_suffixes, numbers, stand_alone_words):
         text = re.sub(
-            r'\b(?=(\d+(?:{0})?(?:\s+\d+(?:\b{0}\b)?)*|(?:\b({1})\b)(?:\s+(?:\b({1})\b))*))\1(?!\s+(?:{2})\b)\s*'.format(
+            r'\b(?=(\d+(?:{0})?\b(?:\s+\d+(?:\b{0}\b)?)*|(?:\b({1})\b)(?:\s+(?:\b({1})\b))*))\1(?!\s+(?:{2})\b)\s*'.format(
                 ordinal_suffixes, numbers, stand_alone_words),
             '',
             text,


### PR DESCRIPTION
*#3281, Not Handling Restricted Words/Consent Words with Numbers:*

*Description of changes:*
-Keep together words containing letters and numbers such as 4H
-Apply singular/plural to every word in the name to match cases such as SUMMERS GAMES 
-Fixes in regex related to designations found during testing designations with dots and without.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
