### PR TITLE
3429 show both english french designation for all designation

### DIFF
--- a/api/namex/services/name_processing/__init__.py
+++ b/api/namex/services/name_processing/__init__.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class LanguageCodes(Enum):
+    ENG = 'ENGLISH'
+    FR = 'FRENCH'

--- a/api/namex/services/name_processing/mixins/get_synonym_lists.py
+++ b/api/namex/services/name_processing/mixins/get_synonym_lists.py
@@ -8,7 +8,12 @@ class GetSynonymListsMixin(object):
     _designated_end_words = []
     _designated_any_words = []
     _designated_all_words = []
-    _fr_designation_end_list = []
+
+    _eng_designated_end_words = []
+    _eng_designated_end_words = []
+
+    _fr_designated_any_words = []
+    _fr_designated_any_words = []
 
     def get_prefixes(self):
         return self._prefixes
@@ -31,5 +36,19 @@ class GetSynonymListsMixin(object):
     def get_designated_any_words(self):
         return self._designated_any_words
 
+    def get_designated_all_words(self):
+        return self._designated_all_words
+
+    def get_eng_designated_end_words(self):
+        return self._eng_designated_end_words
+
+    def get_eng_designated_any_words(self):
+        return self._eng_designated_any_words
+
     def get_fr_designated_end_words(self):
-        return self._fr_designation_end_list
+        return self._fr_designated_end_words
+
+    def get_fr_designated_any_words(self):
+        return self._fr_designated_any_words
+
+

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -1,6 +1,7 @@
 import re
 import warnings
 
+from . import LanguageCodes
 from ..name_request.auto_analyse.name_analysis_utils import remove_french, remove_stop_words
 
 # from namex.services.synonyms.synonym import SynonymService
@@ -173,14 +174,19 @@ class NameProcessingService(GetSynonymListsMixin):
         self._stop_words = syn_svc.get_stop_words().data
         self._prefixes = syn_svc.get_prefixes().data
         self._number_words = syn_svc.get_number_words().data
-        self._designated_end_words = syn_svc.get_designated_end_all_words().data
-        self._designated_any_words = syn_svc.get_designated_any_all_words().data
 
-        self._designated_all_words = list(set(self._designated_any_words +
-                                              self._designated_end_words))
+        self._eng_designated_end_words = syn_svc.get_designated_end_all_words(lang=LanguageCodes.ENG.value).data
+        self._eng_designated_any_words = syn_svc.get_designated_any_all_words(lang=LanguageCodes.ENG.value).data
+
+        self._fr_designated_end_words = syn_svc.get_designated_end_all_words(lang=LanguageCodes.FR.value).data
+        self._fr_designated_any_words = syn_svc.get_designated_any_all_words(lang=LanguageCodes.FR.value).data
+
+        self._designated_end_words = self._eng_designated_end_words + self._fr_designated_end_words
+        self._designated_any_words = self._eng_designated_any_words + self._fr_designated_any_words
+
+        self._designated_all_words = list(set(self._designated_any_words + self._designated_end_words))
         self._designated_all_words.sort(key=len, reverse=True)
-        # TODO: Handle french designations
-        self._fr_designation_end_list = []
+
 
     '''
     Split a name string into classifiable tokens. Called whenever set_name is invoked.

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -93,8 +93,8 @@ class GetDesignationsListsMixin(object):
     def get_entity_type_end_designation(self):
         return self._entity_type_end_designation
 
-    def get_all_entity_type(self):
-        return self._all_entity_type
+    # def get_all_entity_types(self):
+    #    return self._all_entity_types
 
     def get_all_designations_user(self):
         return self._all_designations_user

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -2,9 +2,22 @@ class GetDesignationsListsMixin(object):
     _designated_end_words = []
     _designated_any_words = []
 
+    _eng_designated_end_words = []
+    _eng_designated_any_words = []
+
+    _fr_designated_end_words = []
+    _fr_designated_any_words = []
+
     # Designation_any_list_user and designation_end_list_user based on entity type typed by user:
     _designation_any_list_correct = []
     _designation_end_list_correct = []
+
+    _eng_designation_any_list_correct = []
+    _eng_designation_end_list_correct = []
+
+    _fr_designation_any_list_correct = []
+    _fr_designation_end_list_correct = []
+
     _all_designations_user = []
     _all_designations_user_no_periods = []
 
@@ -12,8 +25,6 @@ class GetDesignationsListsMixin(object):
     designations_entity_type_user = []
 
     # Designation_any_list and designation_end_list based on company name typed by user
-    # _designation_any_list = []
-    # _designation_end_list = []
     _all_designations = []
 
     # Wrong any_list and end_list based on company name typed by user
@@ -37,8 +48,35 @@ class GetDesignationsListsMixin(object):
     def get_designated_any_words(self):
         return self._designated_any_words
 
-    # def get_misplaced_designation_in_input_name(self):
-    #    return self._misplaced_designation
+    def get_eng_designated_end_words(self):
+        return self._eng_designated_end_words
+
+    def get_eng_designated_any_words(self):
+        return self._eng_designated_any_words
+
+    def get_fr_designated_end_words(self):
+        return self._fr_designated_end_words
+
+    def get_fr_designated_any_words(self):
+        return self._fr_designated_any_words
+
+    def get_designation_any_list_correct(self):
+        return self._designation_any_list_correct
+
+    def get_designation_end_list_correct(self):
+        return self._designation_end_list_correct
+
+    def get_eng_designation_any_list_correct(self):
+        return self._eng_designation_any_list_correct
+
+    def get_eng_designation_end_list_correct(self):
+        return self._eng_designation_end_list_correct
+
+    def get_fr_designation_any_list_correct(self):
+        return self._fr_designation_any_list_correct
+
+    def get_fr_designation_end_list_correct(self):
+        return self._fr_designation_end_list_correct
 
     def get_misplaced_designation_any(self):
         return self._misplaced_designation_any_list
@@ -55,8 +93,8 @@ class GetDesignationsListsMixin(object):
     def get_entity_type_end_designation(self):
         return self._entity_type_end_designation
 
-    def get_all_entity_types(self):
-        return self._all_entity_types
+    def get_all_entity_type(self):
+        return self._all_entity_type
 
     def get_all_designations_user(self):
         return self._all_designations_user

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -168,8 +168,14 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # self._set_misplaced_designation_in_input_name()
 
         # Set all designations based on entity type typed by user,'CR' by default
+        self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
+        self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
+
         self._all_designations_user = self._designation_any_list_correct + self._designation_end_list_correct
+        self._all_designations_user.sort(key=len, reverse=True)
+
         self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)
+        self._all_designations_user_no_periods.sort(key=len, reverse=True)
 
         # Set all designations based on company name typed by user
         # self._all_designations = self._designation_any_list + self._designation_end_list

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -93,15 +93,25 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         elif XproUnprotectedNameEntityTypes(entity_type):
             entity_type_code = XproUnprotectedNameEntityTypes(entity_type)
 
-        any_list = syn_svc.get_designations(entity_type_code=entity_type_code.value,
-                                            position_code=DesignationPositionCodes.ANY.value,
-                                            lang=LanguageCodes.ENG.value).data
-        end_list = syn_svc.get_designations(entity_type_code=entity_type_code.value,
-                                            position_code=DesignationPositionCodes.END.value,
-                                            lang=LanguageCodes.ENG.value).data
+        self._eng_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
+                                                                          position_code=DesignationPositionCodes.ANY.value,
+                                                                          lang=LanguageCodes.ENG.value).data
+        self._eng_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
+                                                                          position_code=DesignationPositionCodes.END.value,
+                                                                          lang=LanguageCodes.ENG.value).data
 
-        self._designation_any_list_correct = any_list
-        self._designation_end_list_correct = end_list
+        self._fr_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
+                                                                         position_code=DesignationPositionCodes.ANY.value,
+                                                                         lang=LanguageCodes.FR.value).data
+        self._fr_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
+                                                                         position_code=DesignationPositionCodes.END.value,
+                                                                         lang=LanguageCodes.FR.value).data
+
+        self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
+        self._designation_any_list_correct.sort(key=len, reverse=True)
+
+        self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
+        self._designation_end_list_correct.sort(key=len, reverse=True)
 
     '''
     Set the corresponding entity type for designations <any> found in name

--- a/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
@@ -64,12 +64,18 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_designation_end_in_name(self, name):
-        en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
-        designation_end_rgx = '(' + '|'.join(map(str, en_designation_end_all_list)) + ')'
+        designation_end_all_eng_list = self.get_designations(None, DesignationPositionCodes.END,
+                                                             LanguageCodes.ENG.value)
+        designation_end_all_fr_list = self.get_designations(None, DesignationPositionCodes.END,
+                                                            LanguageCodes.FR.value)
+
+        designation_end_all_list = designation_end_all_eng_list + designation_end_all_fr_list
+        designation_end_all_list.sort(key=len, reverse=True)
+        designation_end_rgx = '(' + '|'.join(map(str, designation_end_all_list)) + ')'
         designation_end_regex = r'{0}(?=(\s{0})*$)'.format(designation_end_rgx)
 
         # Returns list of tuples
-        designation_end_list = re.findall(designation_end_regex, name.lower())
+        designation_end_list = [x for d in re.findall(designation_end_regex, name.lower()) for x in d if x]
 
         return designation_end_list
 
@@ -96,8 +102,15 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_designation_any_in_name(self, name):
-        en_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
-        designation_any_rgx = '(' + '|'.join(map(str, en_designation_any_all_list)) + ')'
+        designation_any_all_eng_list = self.get_designations(None, DesignationPositionCodes.ANY,
+                                                             LanguageCodes.ENG.value)
+        designation_any_all_fr_list = self.get_designations(None, DesignationPositionCodes.ANY,
+                                                            LanguageCodes.FR.value)
+
+        designation_any_all_list = designation_any_all_eng_list + designation_any_all_fr_list
+        designation_any_all_list.sort(key=len, reverse=True)
+
+        designation_any_rgx = '(' + '|'.join(map(str, designation_any_all_list)) + ')'
         designation_any_regex = r'(?<!\w)({0})(?!\w)(?=\s|$)'.format(designation_any_rgx)
 
         # Returns list of tuples

--- a/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
@@ -12,10 +12,10 @@ from .. import DesignationPositionCodes, LanguageCodes
 
 class SynonymDesignationMixin(SynonymServiceMixin):
     def get_designated_end_all_words(self):
-        return self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
+        return self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG.value)
 
     def get_designated_any_all_words(self):
-        return self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
+        return self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG.value)
 
     def get_misplaced_end_designations(self, name, designation_end_entity_type):
         # en_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
@@ -64,12 +64,12 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_designation_end_in_name(self, name):
-        designation_end_all_eng_list = self.get_designations(None, DesignationPositionCodes.END,
+        eng_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END,
                                                              LanguageCodes.ENG.value)
-        designation_end_all_fr_list = self.get_designations(None, DesignationPositionCodes.END,
+        fr_designation_end_all_list = self.get_designations(None, DesignationPositionCodes.END,
                                                             LanguageCodes.FR.value)
 
-        designation_end_all_list = designation_end_all_eng_list + designation_end_all_fr_list
+        designation_end_all_list = eng_designation_end_all_list + fr_designation_end_all_list
         designation_end_all_list.sort(key=len, reverse=True)
         designation_end_rgx = '(' + '|'.join(map(str, designation_end_all_list)) + ')'
         designation_end_regex = r'{0}(?=(\s{0})*$)'.format(designation_end_rgx)
@@ -102,12 +102,12 @@ class SynonymDesignationMixin(SynonymServiceMixin):
     '''
 
     def get_designation_any_in_name(self, name):
-        designation_any_all_eng_list = self.get_designations(None, DesignationPositionCodes.ANY,
+        eng_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY,
                                                              LanguageCodes.ENG.value)
-        designation_any_all_fr_list = self.get_designations(None, DesignationPositionCodes.ANY,
+        fr_designation_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY,
                                                             LanguageCodes.FR.value)
 
-        designation_any_all_list = designation_any_all_eng_list + designation_any_all_fr_list
+        designation_any_all_list = eng_designation_any_all_list + fr_designation_any_all_list
         designation_any_all_list.sort(key=len, reverse=True)
 
         designation_any_rgx = '(' + '|'.join(map(str, designation_any_all_list)) + ')'
@@ -123,11 +123,20 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         '''
 
     def get_designation_all_in_name(self, name):
-        all_designations_end_all_list = self.get_designations(None, DesignationPositionCodes.END, LanguageCodes.ENG)
-        all_designations_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY, LanguageCodes.ENG)
+        eng_all_designations_end_all_list = self.get_designations(None, DesignationPositionCodes.END,
+                                                                  LanguageCodes.ENG.value)
+        eng_all_designations_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY,
+                                                                  LanguageCodes.ENG.value)
+
+        fr_all_designations_end_all_list = self.get_designations(None, DesignationPositionCodes.END,
+                                                                 LanguageCodes.FR.value)
+        fr_all_designations_any_all_list = self.get_designations(None, DesignationPositionCodes.ANY,
+                                                                 LanguageCodes.FR.value)
+
+        all_designations_end_all_list = eng_all_designations_end_all_list + fr_all_designations_end_all_list
+        all_designations_any_all_list = eng_all_designations_any_all_list + fr_all_designations_any_all_list
 
         all_designations = list(set(all_designations_end_all_list + all_designations_any_all_list))
-
         all_designations.sort(key=len, reverse=True)
 
         all_designations_rgx = '|'.join(map(str, all_designations))
@@ -154,6 +163,15 @@ class SynonymDesignationMixin(SynonymServiceMixin):
                 DesignationPositionCodes.END,
                 LanguageCodes.ENG
             )
+            eng_designation_end = self.get_designations(entity_type.value, DesignationPositionCodes.END,
+                                                        LanguageCodes.ENG.value)
+            fr_designation_end = self.get_designations(entity_type.value, DesignationPositionCodes.END,
+                                                       LanguageCodes.FR.value)
+
+            designation_end = eng_designation_end + fr_designation_end
+            designation_end.sort(key=len, reverse=True)
+
+            entity_end_designation_dict[entity_type.value] = designation_end
 
         return entity_end_designation_dict
 
@@ -164,11 +182,14 @@ class SynonymDesignationMixin(SynonymServiceMixin):
         entity_any_designation_dict = {}
 
         for entity_type in entity_types:
-            entity_any_designation_dict[entity_type.value] = self.get_designations(
-                entity_type,
-                DesignationPositionCodes.ANY,
-                LanguageCodes.ENG
-            )
+            eng_designation_any = self.get_designations(entity_type, DesignationPositionCodes.ANY,
+                                                        LanguageCodes.ENG.value)
+            fr_designation_any = self.get_designations(entity_type, DesignationPositionCodes.ANY,
+                                                       LanguageCodes.FR.value)
+            designation_any = eng_designation_any + fr_designation_any
+            designation_any.sort(key=len, reverse=True)
+
+            entity_any_designation_dict[entity_type.value] = designation_any
 
         return entity_any_designation_dict
 


### PR DESCRIPTION
*# 3429: Show both English and French for the EntityType in All Designation Response Lists:*

*Description of changes:*
-Add French designations to English designations in processing and response. For instance, remove designations in regex_transform now considers French/English designations and response related to possible designations to be used include French and English version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
