### PR TITLE
3387 slashes and prefixes issues

### DIFF
--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -117,7 +117,13 @@ class NameProcessingService(GetSynonymListsMixin):
     '''
 
     def set_name(self, name):
+        syn_svc = SynonymService()
         self.name_as_submitted = name  # Store the user's submitted name string
+        self._prefixes = syn_svc.get_prefixes().data
+        name = syn_svc.get_regex_prefixes(
+            text=name,
+            prefix_list=self._prefixes
+        ).data
         self.name_first_part = remove_french(name)
         self.name_original_tokens = name.lower().split()
         self._process_name()
@@ -137,6 +143,10 @@ class NameProcessingService(GetSynonymListsMixin):
         vwc_svc = self.virtual_word_condition_service
 
         words = remove_stop_words(self.name_original_tokens, stop_words)
+        words = syn_svc.get_regex_prefixes(
+            text=words,
+            prefix_list=prefix_list
+        ).data
         words = remove_french(words)
 
         exceptions_ws = syn_svc.get_exception_regex(text=words).data

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -119,12 +119,14 @@ class NameProcessingService(GetSynonymListsMixin):
     def set_name(self, name):
         syn_svc = SynonymService()
         self.name_as_submitted = name  # Store the user's submitted name string
+
         self._prefixes = syn_svc.get_prefixes().data
         prefixes = '|'.join(self._prefixes)
         name = syn_svc.get_regex_prefixes(
             text=name,
-            prefixes=prefixes
+            prefixes_str=prefixes
         ).data
+
         self.name_first_part = remove_french(name)
         self.name_original_tokens = name.lower().split()
         self._process_name()
@@ -144,10 +146,11 @@ class NameProcessingService(GetSynonymListsMixin):
         vwc_svc = self.virtual_word_condition_service
 
         words = remove_stop_words(self.name_original_tokens, stop_words)
+
         prefixes = '|'.join(prefix_list)
         words = syn_svc.get_regex_prefixes(
             text=words,
-            prefixes=prefixes
+            prefixes_str=prefixes
         ).data
         words = remove_french(words)
 
@@ -198,7 +201,6 @@ class NameProcessingService(GetSynonymListsMixin):
 
         self._designated_all_words = list(set(self._designated_any_words + self._designated_end_words))
         self._designated_all_words.sort(key=len, reverse=True)
-
 
     '''
     Split a name string into classifiable tokens. Called whenever set_name is invoked.

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -120,9 +120,10 @@ class NameProcessingService(GetSynonymListsMixin):
         syn_svc = SynonymService()
         self.name_as_submitted = name  # Store the user's submitted name string
         self._prefixes = syn_svc.get_prefixes().data
+        prefixes = '|'.join(self._prefixes)
         name = syn_svc.get_regex_prefixes(
             text=name,
-            prefix_list=self._prefixes
+            prefixes=prefixes
         ).data
         self.name_first_part = remove_french(name)
         self.name_original_tokens = name.lower().split()
@@ -143,9 +144,10 @@ class NameProcessingService(GetSynonymListsMixin):
         vwc_svc = self.virtual_word_condition_service
 
         words = remove_stop_words(self.name_original_tokens, stop_words)
+        prefixes = '|'.join(prefix_list)
         words = syn_svc.get_regex_prefixes(
             text=words,
-            prefix_list=prefix_list
+            prefixes=prefixes
         ).data
         words = remove_french(words)
 

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -154,7 +154,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def check_unclassified_words(self, list_name, list_none):
         result = None
-
         if list_none.__len__() > 0:
             unclassified_words_list_response = []
             for idx, token in enumerate(list_name):
@@ -163,6 +162,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             result = ProcedureResult()
             result.is_valid = False
             result.result_code = AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD
+
+            list_name = [x.upper() for x in list_name]
+            unclassified_words_list_response = [x.upper() for x in unclassified_words_list_response]
+
             result.values = {
                 'list_name': list_name or [],
                 'list_none': unclassified_words_list_response
@@ -326,6 +329,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         if words_consent_list_response:
             result.is_valid = False
             result.result_code = AnalysisIssueCodes.NAME_REQUIRES_CONSENT
+
+            list_name = [x.upper() for x in list_name]
+            words_consent_list_response = [x.upper() for x in words_consent_list_response]
+
             result.values = {
                 'list_name': list_name,
                 'list_consent': words_consent_list_response

--- a/solr-synonyms-api/synonyms/endpoints/synonyms.py
+++ b/solr-synonyms-api/synonyms/endpoints/synonyms.py
@@ -711,17 +711,17 @@ class _RegexPrefixes(Resource):
     @marshal_with(response_string)
     @api.doc(params={
         'text': '',
-        'prefix_list': ''
+        'prefixes_str': ''
     })
     def get():
         text = unquote_plus(request.args.get('text'))
-        prefix_list = literal_eval(request.args.get('prefix_list'))
+        prefixes_str = unquote_plus(request.args.get('prefixes_str'))
 
         if not validate_request(request.args):
             return
 
         service = SynonymService()
-        result = service.regex_prefixes(text, prefix_list)
+        result = service.regex_prefixes(text, prefixes_str)
 
         return {
             'data': result

--- a/solr-synonyms-api/synonyms/endpoints/synonyms.py
+++ b/solr-synonyms-api/synonyms/endpoints/synonyms.py
@@ -658,14 +658,14 @@ class _TransformText(Resource):
     @api.doc(params={
         'text': '',
         'designation_all': '',
-        # TODO: Deprecate prefix_list
-        'prefix_list': '',  # Deprecate first we don't want to break anything, don't delete this yet!
+        'prefix_list': '',
         'number_list': '',
         'exceptions_ws': '',
     })
     def get():
         text = unquote_plus(request.args.get('text'))
         designation_all = literal_eval(request.args.get('designation_all'))
+        prefix_list = literal_eval(request.args.get('prefix_list'))
         number_list = literal_eval(request.args.get('number_list'))
         exceptions_ws = literal_eval(request.args.get('exceptions_ws')) if request.args.get('exceptions_ws') else []
 
@@ -673,7 +673,7 @@ class _TransformText(Resource):
             return
 
         service = SynonymService()
-        result = service.regex_transform(text, designation_all, number_list, exceptions_ws)
+        result = service.regex_transform(text, designation_all, prefix_list, number_list, exceptions_ws)
 
         return {
             'data': result

--- a/solr-synonyms-api/synonyms/endpoints/synonyms.py
+++ b/solr-synonyms-api/synonyms/endpoints/synonyms.py
@@ -16,9 +16,7 @@ from synonyms.models import synonym
 
 from synonyms.services.synonyms import DesignationPositionCodes
 
-
 __all__ = ['api']
-
 
 api = Namespace('Synonyms', description='Synonyms Service - Used by Namex API and Name Processing Service')
 
@@ -701,3 +699,30 @@ class _Synonyms(Resource):
                 response_list.append(result.stems_text)
         print(response_list)
         return ('results', response_list), 200
+
+
+@api.route('/regex-prefixes', strict_slashes=False, methods=['GET'])
+class _RegexPrefixes(Resource):
+    @staticmethod
+    @cors.crossdomain(origin='*')
+    # @jwt.requires_auth
+    # @api.expect()
+    @api.response(200, 'SynonymsApi', response_list)
+    @marshal_with(response_list)
+    @api.doc(params={
+        'text': '',
+        'prefix_list': ''
+    })
+    def get():
+        text = unquote_plus(request.args.get('text'))
+        prefix_list = literal_eval(request.args.get('prefix_list'))
+
+        if not validate_request(request.args):
+            return
+
+        service = SynonymService()
+        results = service.regex_prefixes(text, prefix_list)
+
+        return {
+            'data': results
+        }

--- a/solr-synonyms-api/synonyms/endpoints/synonyms.py
+++ b/solr-synonyms-api/synonyms/endpoints/synonyms.py
@@ -707,8 +707,8 @@ class _RegexPrefixes(Resource):
     @cors.crossdomain(origin='*')
     # @jwt.requires_auth
     # @api.expect()
-    @api.response(200, 'SynonymsApi', response_list)
-    @marshal_with(response_list)
+    @api.response(200, 'SynonymsApi', response_string)
+    @marshal_with(response_string)
     @api.doc(params={
         'text': '',
         'prefix_list': ''
@@ -721,8 +721,8 @@ class _RegexPrefixes(Resource):
             return
 
         service = SynonymService()
-        results = service.regex_prefixes(text, prefix_list)
+        result = service.regex_prefixes(text, prefix_list)
 
         return {
-            'data': results
+            'data': result
         }

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -206,7 +206,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     @classmethod
     def regex_prefixes(cls, text, prefixes):
-        text = re.sub(r'\b({})([ &/.-])([A-Za-z]+)'.format(prefixes),
+        text = re.sub(r'\b({0})([ &/.-])([A-Za-z]+)'.format(prefixes),
                       r'\1\3',
                       text,
                       0,

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -171,14 +171,16 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
     10.- Remove extra spaces to have just one space: \s+
     '''
 
-    def regex_transform(self, text, designation_all, number_list, exceptions_ws):
+    def regex_transform(self, text, designation_all, prefix_list, number_list, exceptions_ws):
         designation_all_regex = '|'.join(designation_all)
+        prefixes = '|'.join(prefix_list)
         numbers = '|'.join(number_list)
         ordinal_suffixes = 'ST|[RN]D|TH'
         stand_alone_words = 'HOLDINGS$|BC$|VENTURES$|SOLUTION$|ENTERPRISE$|INDUSTRIES$'
         internet_domains = '.COM|.ORG|.NET|.EDU'
 
         text = self.regex_remove_designations(text, internet_domains, designation_all_regex)
+        text = self.regex_prefixes(text, prefixes)
         text = self.regex_numbers_lot(text)
         text = self.regex_repeated_strings(text)
         text = self.regex_separated_ordinals(text, ordinal_suffixes)


### PR DESCRIPTION
#3387, Slashes and Prefix Issues:*

*Description of changes:*
Words with prefix at the beginning separated by slash, hyphen or space are set together. Then, PRE/SCHOOL becomes PRESCHOOL.
This uses regex-prefixes endpoint in solr-synonyms-api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
