### PR TITLE
3532 sort designations by language

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_issues.py
+++ b/api/namex/resources/auto_analyse/analysis_issues.py
@@ -204,7 +204,7 @@ class AnalysisResponseIssue:
                                 next_char = original_tokens[0]
 
                             token_is_designation = (current_original_token + next_char) in all_designations
-                            if token_is_designation:
+                            if original_tokens and token_is_designation:
                                 original_tokens.popleft()
                                 unprocessed_name_string = unprocessed_name_string[1:].strip()
 

--- a/api/namex/resources/auto_analyse/analysis_issues.py
+++ b/api/namex/resources/auto_analyse/analysis_issues.py
@@ -13,6 +13,8 @@ from .response_objects.name_action import NameAction, NameActions, WordPositions
 from .response_objects.consenting_body import ConsentingBody
 from .response_objects.conflict import Conflict
 
+from namex.utils.common import remove_periods_designation
+
 
 class AnalysisResponseIssue:
     issue_type = "Issue"  # Maybe get rid of this guy
@@ -26,9 +28,24 @@ class AnalysisResponseIssue:
     '''
     def __init__(self, analysis_response, setup_config):
         self.analysis_response = analysis_response
+        self.name_tokens = analysis_response.name_tokens
         self.entity_type = analysis_response.entity_type
         self.setup_config = []
         self.set_issue_setups(setup_config)
+
+    # TODO: Maybe move this to utils? Do as part of code clean up and refactor task
+    @classmethod
+    def _lc_list_items(cls, str_list, convert=False):
+        if not str_list or type(str_list) is not list:
+            return []  # This method should always return a list
+
+        try:
+            converted_list = list(map(lambda d: d.lower() if isinstance(d, str) else '', str_list)) \
+                if convert else list(map(lambda d: d.lower(), str_list))
+        except Exception as err:
+            print('List is not a list of strings ' + repr(err))
+
+        return converted_list
 
     def create_issue(self, procedure_result):
         return self.issue
@@ -77,32 +94,36 @@ class AnalysisResponseIssue:
     # [J, &, L, &, L, Engineering]
     # and return name tokens:
     # [JLL, Engineering]
-    def get_next_token_if_composite(self, name_original_tokens, name_processed_tokens):
+    def get_next_token_if_composite(self, str_name, name_original_tokens, name_processed_tokens):
         token_string = ''
+        processed_name_string = ''
 
         original_tokens = deque(name_original_tokens)
         processed_tokens = deque(name_processed_tokens)
 
         if len(processed_tokens) == 0:
-            return False, 0
+            return False, 0, 0, None
 
         processed_token = processed_tokens.popleft()
         current_processed_token = processed_token
 
+        processed_token_count = 0
         composite_idx_offset = 0
         current_original_token = original_tokens.popleft()
 
         if current_processed_token == current_original_token:
-            return False, 0
+            return False, 0, 0, current_original_token
 
         if current_processed_token.find(current_original_token) == -1:
-            return False, 0
+            return False, 0, 0, current_original_token
 
         while len(original_tokens) >= 0:
             if token_string == processed_token:
                 break
 
-            composite_idx_offset += 1
+            processed_token_count += 1
+
+            processed_name_string += current_original_token
 
             token_substr_idx = current_processed_token.find(current_original_token)
             token_is_next_chunk = token_substr_idx == 0
@@ -110,18 +131,34 @@ class AnalysisResponseIssue:
                 current_processed_token = current_processed_token[len(current_original_token):]
                 token_string += current_original_token
 
+            next_char = False
+            # this_char = str_name[len(original_name_string) - 1]
+            if len(str_name) > len(processed_name_string):
+                next_char = str_name[len(processed_name_string)]
+
+            if next_char and next_char == ' ':
+                processed_name_string += ' '
+
+            if next_char and next_char == ' ' or not next_char:
+                composite_idx_offset += 1
+
             if len(original_tokens) > 0:
                 current_original_token = original_tokens.popleft()
 
-        if composite_idx_offset:
-            return processed_token, composite_idx_offset
+        if processed_token_count:
+            return processed_token, processed_token_count, composite_idx_offset, processed_name_string
 
-        return False, 0
+        return False, 0, 0, current_processed_token
 
-    def adjust_word_index(self, name_original_tokens, name_tokens, word_idx):
-        token_string = ''
+    def adjust_word_index(self, original_name_str, name_original_tokens, name_tokens, word_idx, offset_designations=True):
+        all_designations = self.analysis_response.analysis_service.get_all_designations()
+        # all_designations_user = self.analysis_response.analysis_service.get_all_designations_user()
+
         original_tokens = deque(name_original_tokens)
         processed_tokens = deque(name_tokens)
+        processed_token_idx = 0
+
+        target_word = name_tokens[word_idx]
 
         word_idx_offset = 0
         composite_token_offset = 0
@@ -129,45 +166,78 @@ class AnalysisResponseIssue:
         previous_original_token = None
         current_original_token = None
 
+        unprocessed_name_string = original_name_str.lower()
+
         while len(original_tokens) > 0:
             # Check to see if we're dealing with a composite, if so, get the offset amount
-            composite_token, composite_idx_offset = self.get_next_token_if_composite(original_tokens, processed_tokens)
+            composite_token, composite_tokens_processed, composite_idx_offset, processed_name_string = \
+                self.get_next_token_if_composite(unprocessed_name_string, original_tokens, processed_tokens)
 
+            if processed_name_string:
+                # Only replace the first match!
+                unprocessed_name_string = unprocessed_name_string.replace(processed_name_string, '', 1).strip()
+
+            # Handle composite tokens
             if composite_token:
-                composite_token_offset += composite_idx_offset - 1
                 current_original_token = composite_token
-                for x in range(0, composite_idx_offset):
+
+                if composite_idx_offset > 0:
+                    composite_token_offset += composite_idx_offset - 1
+
+                for x in range(0, composite_tokens_processed):
                     if len(original_tokens) > 0:
                         original_tokens.popleft()
 
-            # Pop the left-most token off the list
+            # Handle normal word tokens
             else:
                 if len(original_tokens) > 0:
+                    # Pop the left-most token off the list
                     current_original_token = original_tokens.popleft()
-
-                    # Check for repeated tokens
-                    is_repeat_token = False
-                    if current_original_token == previous_original_token:
-                        is_repeat_token = True
-
-                    if is_repeat_token:
-                        word_idx_offset += 1
 
                     # If there are no processed tokens left to deal with, skip this step (handles designations, etc.)
                     # We don't need to increment the word_idx_offset anymore unless there's a repeated token
                     if len(processed_tokens) > 0:
-                        if current_original_token not in name_tokens:
-                            word_idx_offset += 1
-                            continue
+                        if offset_designations:
+                            # Does the current word have any punctuation associated with?
+                            next_char = ''
+                            if len(unprocessed_name_string) > 0 and len(original_tokens) > 0 and unprocessed_name_string[0] == original_tokens[0]:
+                                next_char = original_tokens[0]
 
-            if previous_original_token != current_original_token and len(processed_tokens) > 0:
+                            token_is_designation = (current_original_token + next_char) in all_designations
+                            if token_is_designation:
+                                original_tokens.popleft()
+                                unprocessed_name_string = unprocessed_name_string[1:].strip()
+
+                            # Skip designations
+                            if token_is_designation or current_original_token not in name_tokens:
+                                word_idx_offset += 1
+                                continue
+                        else:
+                            if current_original_token not in name_tokens:
+                                word_idx_offset += 1
+                                continue
+
+            # Check for repeated tokens - this has been moved to get_next_token_if_composite
+            # if current_original_token == previous_original_token:
+                # word_idx_offset += 1
+
+            # We only need to run this until we encounter the specified word
+            if current_original_token == target_word and word_idx == processed_token_idx:
+                original_tokens.clear()  # Clear the rest of the items to break out of the loop, we're done!
+                continue
+
+            # if previous_original_token != current_original_token and len(processed_tokens) > 0:
+            if len(processed_tokens) > 0:
+                processed_token_idx += 1
                 processed_tokens.popleft()
 
             previous_original_token = current_original_token
 
         offset_idx = word_idx + word_idx_offset + composite_token_offset
 
-        return offset_idx
+        print('Adjusted word index for word [' + target_word + '] from [' + str(word_idx) + '] -> [' + str(offset_idx) + ']')
+
+        return offset_idx, word_idx, word_idx_offset, composite_token_offset
 
 
 class CheckIsValid(AnalysisResponseIssue):
@@ -252,8 +322,8 @@ class ContainsUnclassifiableWordIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        list_none = procedure_result.values['list_none']
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)  # procedure_result.values['list_name']
+        list_none = self._lc_list_items(procedure_result.values['list_none'])
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -272,13 +342,18 @@ class ContainsUnclassifiableWordIssue(AnalysisResponseIssue):
         #  If there's a duplicate of an unclassified word, just grabbing the index won't do!
         issue.name_actions = []
         for word in list_none:
-            none_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+            offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                self.analysis_response.name_as_submitted,
+                self.analysis_response.name_original_tokens,
+                self.analysis_response.name_tokens,
+                list_name.index(word)
+            )
 
             issue.name_actions.append(
                 NameAction(
                     type=NameActions.HIGHLIGHT,
                     word=word,
-                    index=none_word_idx
+                    index=offset_idx
                 )
             )
 
@@ -314,8 +389,7 @@ class AddDistinctiveWordIssue(AnalysisResponseIssue):
             name_actions=[]
         )
 
-        # list_original = procedure_result.values['list_original']
-        list_name = procedure_result.values['list_name']
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)
 
         issue.name_actions = [
             NameAction(
@@ -345,9 +419,8 @@ class AddDescriptiveWordIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        # list_original = procedure_result.values['list_original']
-        list_name = procedure_result.values['list_name']
-        list_dist = procedure_result.values['list_dist']
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)  # procedure_result.values['list_name']
+        list_dist = self._lc_list_items(procedure_result.values['list_dist'])
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -366,7 +439,12 @@ class AddDescriptiveWordIssue(AnalysisResponseIssue):
         # TODO: Why was this like this before?
         # dist_word_idx = list_name.index(last_dist_word) # if list_dist.__len__() > 0 else 0
         dist_word_idx = list_name.index(last_dist_word) if list_dist.__len__() > 0 else 0
-        dist_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, dist_word_idx)
+        offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+            self.analysis_response.name_as_submitted,
+            self.analysis_response.name_original_tokens,
+            self.analysis_response.name_tokens,
+            dist_word_idx
+        )
 
         issue.name_actions = [
             NameAction(
@@ -374,7 +452,7 @@ class AddDescriptiveWordIssue(AnalysisResponseIssue):
                 position=WordPositions.END,
                 message="Add a Descriptive Word Here",
                 word=last_dist_word,
-                index=dist_word_idx
+                index=offset_idx
             )
         ]
 
@@ -432,8 +510,8 @@ class ContainsWordsToAvoidIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        list_avoid = procedure_result.values['list_avoid']
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)  # procedure_result.values['list_name']
+        list_avoid = self._lc_list_items(procedure_result.values['list_avoid'])
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -451,13 +529,18 @@ class ContainsWordsToAvoidIssue(AnalysisResponseIssue):
         # TODO: If there's a duplicate of a word to avoid, just grabbing the index might not do!
         issue.name_actions = []
         for word in list_avoid:
-            avoid_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+            offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                self.analysis_response.name_as_submitted,
+                self.analysis_response.name_original_tokens,
+                self.analysis_response.name_tokens, 
+                list_name.index(word)
+            )
 
             issue.name_actions.append(
                 NameAction(
                     type=NameActions.STRIKE,
                     word=word,
-                    index=avoid_word_idx
+                    index=offset_idx
                 )
             )
 
@@ -473,24 +556,18 @@ class ContainsWordsToAvoidIssue(AnalysisResponseIssue):
         return issue
 
 
-# TODO: Is this even a thing?
-'''
-@:deprecated
-'''
-
-
 class WordSpecialUse(AnalysisResponseIssue):
     issue_type = AnalysisIssueCodes.WORD_SPECIAL_USE
     status_text = "Further Action Required"
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        list_special = procedure_result.values['list_special']
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)  # procedure_result.values['list_name']
+        list_special = self._lc_list_items(procedure_result.values['list_special'])
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
-            line1="The word(s) "+ self._join_list_words(list_special) + " must go to examination ",
+            line1="The word(s) " + self._join_list_words(list_special) + " must go to examination ",
             line2=None,
             consenting_body=None,
             designations=None,
@@ -504,13 +581,18 @@ class WordSpecialUse(AnalysisResponseIssue):
         # TODO: If there's a duplicate of a word to avoid, just grabbing the index might not do!
         issue.name_actions = []
         for word in list_special:
-            list_special_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+            offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                self.analysis_response.name_as_submitted,
+                self.analysis_response.name_original_tokens,
+                self.analysis_response.name_tokens, 
+                list_name.index(word)
+            )
 
             issue.name_actions.append(
                 NameAction(
                     type=NameActions.HIGHLIGHT,
                     word=word,
-                    index=list_special_idx
+                    index=offset_idx
                 )
             )
 
@@ -532,8 +614,8 @@ class NameRequiresConsentIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        list_consent = procedure_result.values['list_consent']
+        list_name = self.analysis_response.name_tokens  # procedure_result.values['list_name']
+        list_consent = self._lc_list_items(procedure_result.values['list_consent'])
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -553,13 +635,18 @@ class NameRequiresConsentIssue(AnalysisResponseIssue):
 
         issue.name_actions = []
         for word in list_consent:
-            consent_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+            offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                self.analysis_response.name_as_submitted,
+                self.analysis_response.name_original_tokens,
+                self.analysis_response.name_tokens, 
+                list_name.index(word.lower())
+            )
 
             issue.name_actions.append(
                 NameAction(
                     type=NameActions.HIGHLIGHT,
                     word=word,
-                    index=consent_word_idx
+                    index=offset_idx
                 )
             )
 
@@ -587,10 +674,20 @@ class CorporateNameConflictIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        list_dist = procedure_result.values['list_dist']
-        list_desc = procedure_result.values['list_desc']
-        list_conflicts = procedure_result.values['list_conflicts']
+        name_as_submitted = self.analysis_response.name_as_submitted
+        list_original = self._lc_list_items(self.analysis_response.name_original_tokens)
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)
+
+        all_designations = self._lc_list_items(self.analysis_response.analysis_service.get_all_designations())
+        all_combined_designations = all_designations + remove_periods_designation(all_designations)
+
+        list_name_as_submitted = self._lc_list_items(self.analysis_response.name_as_submitted_tokenized)
+        # Filter out designations from the tokens
+        list_tokens = [item for item in list_name_as_submitted if item not in all_combined_designations]
+
+        list_dist = procedure_result.values['list_dist']  # Don't lower case this one it's a list wrapped list
+        list_desc = procedure_result.values['list_desc']  # Don't lower case this one it's a list wrapped list
+        list_conflicts = procedure_result.values['list_conflicts']  # Don't lower case this one it's a dict
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -631,53 +728,78 @@ class CorporateNameConflictIssue(AnalysisResponseIssue):
         list_remove = []  # These are passed down to the Template
 
         if is_exact_match:
-            # Loop over the list_name words, we need to decide to do with each word
-            for word in list_name:
-                name_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+            # Loop over the token words, we need to decide to do with each word
+            for token_idx, word in enumerate(list_tokens):
+                offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                    name_as_submitted,
+                    list_original,
+                    list_tokens,
+                    token_idx
+                )
 
-                # Highlight the descriptives
-                # <class 'list'>: ['mountain', 'view']
-                if word in list_dist_words:
+                # Highlight the conflict words
+                if list_tokens.index(word) != list_tokens.index(list_tokens[-1]):
                     issue.name_actions.append(NameAction(
                         word=word,
-                        index=name_word_idx,
+                        index=offset_idx,
+                        endIndex=offset_idx,
                         type=NameActions.HIGHLIGHT
                     ))
 
-                # Strike out the last descriptive word
-                if word in list_desc_words and name_word_idx == list_name.__len__() - 1:
-                    # <class 'list'>: ['growers', 'view']
+                # Strike out the last matching word
+                if list_tokens.index(word) == list_tokens.index(list_tokens[-1]):
                     list_remove.append(word)
                     issue.name_actions.append(NameAction(
                         word=word,
-                        index=name_word_idx,
+                        index=offset_idx,
+                        endIndex=offset_idx,
                         type=NameActions.STRIKE
                     ))
 
         if not is_exact_match:
             # Loop over the list_name words, we need to decide to do with each word
-            for word in list_name:
-                name_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+            for token_idx, word in enumerate(list_tokens):
+                offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                    name_as_submitted,
+                    list_original,
+                    list_tokens,
+                    token_idx
+                )
 
-                # Highlight the descriptives
-                # <class 'list'>: ['mountain', 'view']
-                if word in list_dist_words:
-                    issue.name_actions.append(NameAction(
-                        word=word,
-                        index=name_word_idx,
-                        type=NameActions.HIGHLIGHT
-                    ))
+                # This code has duplicate blocks because it allows us to tweak the response for composite token matches separately from normal words if necessary
+                if composite_token_offset and composite_token_offset > 0:
+                    # <class 'list'>: ['mountain', 'view']
+                    # Highlight the conflict words
+                    if word in current_conflict_keys and current_conflict_keys.index(word) != current_conflict_keys.index(current_conflict_keys[-1]):
+                        issue.name_actions.append(NameAction(
+                            word=word,
+                            index=offset_idx,
+                            type=NameActions.HIGHLIGHT
+                        ))
 
-                # Strike out the last descriptive word
-                '''
-                if word in list_desc_words and name_word_idx == list_name.__len__() - 1:
-                    # <class 'list'>: ['growers', 'view']
-                    issue.name_actions.append(NameAction(
-                        word=word,
-                        index=name_word_idx,
-                        type=NameActions.STRIKE
-                    ))
-                '''
+                    # Strike out the last matching word
+                    if word in current_conflict_keys and current_conflict_keys.index(word) == current_conflict_keys.index(current_conflict_keys[-1]):
+                        issue.name_actions.append(NameAction(
+                            word=word,
+                            index=offset_idx,
+                            type=NameActions.STRIKE
+                        ))
+                else:
+                    # Highlight the conflict words
+                    if word in current_conflict_keys and current_conflict_keys.index(word) != current_conflict_keys.index(current_conflict_keys[-1]):
+                        issue.name_actions.append(NameAction(
+                            word=word,
+                            index=offset_idx,
+                            type=NameActions.HIGHLIGHT
+                        ))
+
+                    # Strike out the last matching word
+                    if word in current_conflict_keys and current_conflict_keys.index(word) == current_conflict_keys.index(current_conflict_keys[-1]):
+                        issue.name_actions.append(NameAction(
+                            word=word,
+                            index=offset_idx,
+                            type=NameActions.STRIKE
+                        ))
 
         issue.conflicts = []
 
@@ -712,8 +834,8 @@ class DesignationNonExistentIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        correct_designations = procedure_result.values['correct_designations']
+        list_name = self._lc_list_items(self.analysis_response.name_tokens)  # procedure_result.values['list_name']
+        correct_designations = self._lc_list_items(procedure_result.values['correct_designations'])
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -750,18 +872,14 @@ class DesignationMismatchIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
+        list_name = self.analysis_response.name_tokens
+        list_name_incl_designation = self.analysis_response.name_original_tokens
+
         incorrect_designations = procedure_result.values['incorrect_designations']
         correct_designations = procedure_result.values['correct_designations']
-        # TODO: Implement the misplaced designations cases!
-        # TODO: I think we can remove this, misplaced has been moved out into its own procedure!
-        # misplaced_any_designation = procedure_result.values['misplaced_any_designation']
-        # misplaced_end_designation = procedure_result.values['misplaced_end_designation']
 
-        # TODO: If case comes back in upper case for the incorrect designations we won't have a match...
-        # Convert all strings to lower-case before comparing
-        incorrect_designations_lc = list(map(lambda d: d.lower() if isinstance(d, str) else '', incorrect_designations))
-        list_name_lc = list(map(lambda d: d.lower(), list_name))
+        incorrect_designations_lc = self._lc_list_items(incorrect_designations, True)
+        list_name_incl_designation_lc = self._lc_list_items(list_name_incl_designation)
 
         entity_type_description = get_entity_type_description(self.entity_type)
 
@@ -779,15 +897,20 @@ class DesignationMismatchIssue(AnalysisResponseIssue):
         )
 
         # Loop over the list_name words, we need to decide to do with each word
-        for word in list_name_lc:
-            name_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+        for word in list_name_incl_designation_lc:
+            offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                self.analysis_response.name_as_submitted,
+                self.analysis_response.name_original_tokens,
+                list_name_incl_designation_lc,
+                list_name_incl_designation.index(word),
+                False
+            )
 
-            # Highlight the descriptives
-            # <class 'list'>: ['mountain', 'view']
+            # Highlight the issues
             if word in incorrect_designations_lc:
                 issue.name_actions.append(NameAction(
                     word=word,
-                    index=name_word_idx,
+                    index=offset_idx,
                     type=NameActions.HIGHLIGHT
                 ))
 
@@ -815,13 +938,16 @@ class DesignationMisplacedIssue(AnalysisResponseIssue):
     issue = None
 
     def create_issue(self, procedure_result):
-        list_name = procedure_result.values['list_name']
-        misplaced_any_designation = procedure_result.values['misplaced_any_designation']
+        list_name_incl_designation = self.analysis_response.name_original_tokens
+
+        # TODO: This was in here but not handled, why?
+        # misplaced_any_designation = procedure_result.values['misplaced_any_designation']
         misplaced_end_designation = procedure_result.values['misplaced_end_designation']
         misplaced_all_designation = procedure_result.values['misplaced_all_designation']
 
-        list_name_lc = list(map(lambda d: d.lower(), list_name))
-        misplaced_all_designation_lc = list(map(lambda d: d.lower() if isinstance(d, str) else '', misplaced_all_designation))
+        misplaced_all_designation_lc = self._lc_list_items(misplaced_all_designation, True)
+        misplaced_all_designation_lc = misplaced_all_designation_lc + remove_periods_designation(misplaced_all_designation_lc)
+        list_name_incl_designation_lc = self._lc_list_items(list_name_incl_designation)
 
         issue = NameAnalysisIssue(
             issue_type=self.issue_type,
@@ -839,15 +965,20 @@ class DesignationMisplacedIssue(AnalysisResponseIssue):
 
 
         # Loop over the list_name words, we need to decide to do with each word
-        for word in list_name_lc:
-            name_word_idx = self.adjust_word_index(self.analysis_response.name_original_tokens, self.analysis_response.name_tokens, list_name.index(word))
+        for word in list_name_incl_designation_lc:
+            offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(
+                self.analysis_response.name_as_submitted,
+                self.analysis_response.name_original_tokens,
+                list_name_incl_designation_lc,
+                list_name_incl_designation.index(word),
+                False
+            )
 
-            # Highlight the descriptives
-            # <class 'list'>: ['mountain', 'view']
+            # Highlight the issues
             if word in misplaced_all_designation_lc:
                 issue.name_actions.append(NameAction(
                     word=word,
-                    index=name_word_idx,
+                    index=offset_idx,
                     type=NameActions.HIGHLIGHT
                 ))
 

--- a/api/namex/resources/auto_analyse/analysis_response.py
+++ b/api/namex/resources/auto_analyse/analysis_response.py
@@ -81,6 +81,10 @@ class AnalysisResponse:
         return self.analysis_service.name_as_submitted
 
     @property
+    def name_as_submitted_tokenized(self):
+        return self.analysis_service.name_as_submitted_tokenized
+
+    @property
     def entity_type(self):
         return self._entity_type
 

--- a/api/namex/resources/auto_analyse/response_objects/name_action.py
+++ b/api/namex/resources/auto_analyse/response_objects/name_action.py
@@ -43,8 +43,12 @@ class NameAction(Serializable):
         if kwargs.get('index') and (isinstance(kwargs.get('index'), int) is False or kwargs.get('index', 0) < 0):
             raise TypeError('Invalid index, index must be a positive integer or zero')
 
+        if kwargs.get('endIndex') and (isinstance(kwargs.get('endIndex'), int) is False or kwargs.get('endIndex', 0) < 0):
+            raise TypeError('Invalid endIndex, endIndex must be a positive integer or zero')
+
         self.type = kwargs.get('type').value if kwargs.get('type') else None
         self.position = kwargs.get('position').value if kwargs.get('position') else None
         self.message = kwargs.get('message', None)
         self.word = kwargs.get('word', None)
         self.index = kwargs.get('index', None)
+        self.endIndex = kwargs.get('endIndex', None)

--- a/api/namex/services/name_processing/mixins/get_synonym_lists.py
+++ b/api/namex/services/name_processing/mixins/get_synonym_lists.py
@@ -5,15 +5,15 @@ class GetSynonymListsMixin(object):
     _stop_words = []
     # TODO: Arturo _number_words is declared in multiple files
     _number_words = []
-    _designated_end_words = []
-    _designated_any_words = []
-    _designated_all_words = []
+    #_designated_end_words = []
+    #_designated_any_words = []
+    #_designated_all_words = []
 
-    _eng_designated_end_words = []
-    _eng_designated_any_words = []
+    #_eng_designated_end_words = []
+    #_eng_designated_end_words = []
 
-    _fr_designated_end_words = []
-    _fr_designated_any_words = []
+    #_fr_designated_any_words = []
+    #_fr_designated_any_words = []
 
     def get_prefixes(self):
         return self._prefixes
@@ -30,25 +30,25 @@ class GetSynonymListsMixin(object):
     def get_number_words(self):
         return self._number_words
 
-    def get_designated_end_words(self):
-        return self._designated_end_words
-
-    def get_designated_any_words(self):
-        return self._designated_any_words
-
-    def get_designated_all_words(self):
-        return self._designated_all_words
-
-    def get_eng_designated_end_words(self):
-        return self._eng_designated_end_words
-
-    def get_eng_designated_any_words(self):
-        return self._eng_designated_any_words
-
-    def get_fr_designated_end_words(self):
-        return self._fr_designated_end_words
-
-    def get_fr_designated_any_words(self):
-        return self._fr_designated_any_words
+    # def get_designated_end_words(self):
+    #     return self._designated_end_words
+    #
+    # def get_designated_any_words(self):
+    #     return self._designated_any_words
+    #
+    # def get_designated_all_words(self):
+    #     return self._designated_all_words
+    #
+    # def get_eng_designated_end_words(self):
+    #     return self._eng_designated_end_words
+    #
+    # def get_eng_designated_any_words(self):
+    #     return self._eng_designated_any_words
+    #
+    # def get_fr_designated_end_words(self):
+    #     return self._fr_designated_end_words
+    #
+    # def get_fr_designated_any_words(self):
+    #     return self._fr_designated_any_words
 
 

--- a/api/namex/services/name_processing/mixins/get_synonym_lists.py
+++ b/api/namex/services/name_processing/mixins/get_synonym_lists.py
@@ -10,9 +10,9 @@ class GetSynonymListsMixin(object):
     _designated_all_words = []
 
     _eng_designated_end_words = []
-    _eng_designated_end_words = []
+    _eng_designated_any_words = []
 
-    _fr_designated_any_words = []
+    _fr_designated_end_words = []
     _fr_designated_any_words = []
 
     def get_prefixes(self):

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -128,7 +128,9 @@ class NameProcessingService(GetSynonymListsMixin):
         ).data
 
         self.name_first_part = remove_french(name)
-        self.name_original_tokens = name.lower().split()
+        # self.name_original_tokens = name.lower().split()
+        self.name_original_tokens = [x for x in [x.strip() for x in re.split('(\W)', name.lower())] if x]
+
         self._process_name()
 
     def set_name_tokenized(self, name):

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -220,10 +220,7 @@ class NameProcessingService(GetSynonymListsMixin):
                 # These properties are mixed in via GetSynonymListsMixin
                 # See the class constructor
                 self._stop_words,
-                # self._designated_any_words,
-                # self._designated_end_words,
                 self._designated_all_words,
-                # self._fr_designation_end_list,
                 self._prefixes,
                 self._number_words
             )

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -129,7 +129,7 @@ class NameProcessingService(GetSynonymListsMixin):
 
         self.name_first_part = remove_french(name)
         # self.name_original_tokens = name.lower().split()
-        self.name_original_tokens = [x for x in [x.strip() for x in re.split('(\W)', name.lower())] if x]
+        self.name_original_tokens = [x for x in [x.strip() for x in re.split('([ &/-])', name.lower())] if x]
 
         self._process_name()
 

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -9,8 +9,8 @@ class GetDesignationsListsMixin(object):
     _fr_designated_any_words = []
 
     # Designation_any_list_user and designation_end_list_user based on entity type typed by user:
-    _designation_any_list_correct = []
-    _designation_end_list_correct = []
+    #_designation_any_list_correct = []
+    #_designation_end_list_correct = []
 
     _eng_designation_any_list_correct = []
     _eng_designation_end_list_correct = []

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -1,4 +1,5 @@
 class GetDesignationsListsMixin(object):
+    # designated_end/any_words contain all the end/any designations for all Entity Types
     _designated_end_words = []
     _designated_any_words = []
 
@@ -9,8 +10,8 @@ class GetDesignationsListsMixin(object):
     _fr_designated_any_words = []
 
     # Designation_any_list_user and designation_end_list_user based on entity type typed by user:
-    designation_any_list_correct = []
-    designation_end_list_correct = []
+    _designation_any_list_correct = []
+    _designation_end_list_correct = []
 
     _eng_designation_any_list_correct = []
     _eng_designation_end_list_correct = []
@@ -29,6 +30,8 @@ class GetDesignationsListsMixin(object):
 
     # Designation_any_list and designation_end_list based on company name typed by user
     _all_designations = []
+    _designation_any_list = []
+    _designation_end_list =[]
 
     # Wrong any_list and end_list based on company name typed by user
     _misplaced_designation_any_list = []
@@ -96,9 +99,6 @@ class GetDesignationsListsMixin(object):
     def get_entity_type_end_designation(self):
         return self._entity_type_end_designation
 
-    # def get_all_entity_types(self):
-    #    return self._all_entity_types
-
     def get_all_designations_user(self):
         return self._all_designations_user
 
@@ -107,3 +107,9 @@ class GetDesignationsListsMixin(object):
 
     def get_all_designations(self):
         return self._all_designations
+
+    def get_designation_any_list(self):
+        return self._designation_any_list
+
+    def get_designation_end_list(self):
+        return self._designation_end_list

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -18,6 +18,9 @@ class GetDesignationsListsMixin(object):
     _fr_designation_any_list_correct = []
     _fr_designation_end_list_correct = []
 
+    _eng_designation_all_list_correct = []
+    _fr_designation_all_list_correct = []
+
     _all_designations_user = []
     _all_designations_user_no_periods = []
 

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -9,8 +9,8 @@ class GetDesignationsListsMixin(object):
     _fr_designated_any_words = []
 
     # Designation_any_list_user and designation_end_list_user based on entity type typed by user:
-    #_designation_any_list_correct = []
-    #_designation_end_list_correct = []
+    designation_any_list_correct = []
+    designation_end_list_correct = []
 
     _eng_designation_any_list_correct = []
     _eng_designation_end_list_correct = []

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -68,7 +68,7 @@ def remove_french(text):
 
 
 def remove_stop_words(original_name_list, stop_words):
-    words = ' '.join([word for x, word in enumerate(original_name_list) if word not in stop_words])
+    words = ' '.join([word for x, word in enumerate(original_name_list) if word and word not in stop_words])
 
     return words
 

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -171,11 +171,15 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # self._set_misplaced_designation_in_input_name()
 
         # Set all designations based on entity type typed by user,'CR' by default
-        self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
-        self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
+        #self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
+        #self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
 
-        self._all_designations_user = self._designation_any_list_correct + self._designation_end_list_correct
-        self._all_designations_user.sort(key=len, reverse=True)
+        self._eng_designation_all_list_correct = self._eng_designation_any_list_correct + self._eng_designation_end_list_correct
+        self._eng_designation_all_list_correct.sort(key=len, reverse=True)
+        self._fr_designation_all_list_correct = self._fr_designation_any_list_correct + self._fr_designation_end_list_correct
+        self._fr_designation_all_list_correct.sort(key=len, reverse=True)
+
+        self._all_designations_user = self._eng_designation_all_list_correct + self._fr_designation_all_list_correct
 
         self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)
         self._all_designations_user_no_periods.sort(key=len, reverse=True)

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -96,25 +96,30 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         self._eng_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.ANY.value,
                                                                           lang=LanguageCodes.ENG.value).data
-        self._eng_designation_any_list_correct.sort(key=len, reverse=True)
+        #self._eng_designation_any_list_correct.sort(key=len, reverse=True)
 
         self._eng_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.END.value,
                                                                           lang=LanguageCodes.ENG.value).data
-        self._eng_designation_end_list_correct.sort(key=len, reverse=True)
+        #self._eng_designation_end_list_correct.sort(key=len, reverse=True)
 
         self._fr_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                          position_code=DesignationPositionCodes.ANY.value,
                                                                          lang=LanguageCodes.FR.value).data
-        self._fr_designation_any_list_correct.sort(key=len, reverse=True)
+        #self._fr_designation_any_list_correct.sort(key=len, reverse=True)
 
         self._fr_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                          position_code=DesignationPositionCodes.END.value,
                                                                          lang=LanguageCodes.FR.value).data
-        self._fr_designation_end_list_correct.sort(key=len, reverse=True)
+        #self._fr_designation_end_list_correct.sort(key=len, reverse=True)
 
-        self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
-        self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
+        self._eng_designation_all_list_correct = self._eng_designation_any_list_correct + self._eng_designation_end_list_correct
+        self._eng_designation_all_list_correct.sort(key=len, reverse=True)
+        self._fr_designation_all_list_correct = self._fr_designation_any_list_correct + self._fr_designation_end_list_correct
+        self._fr_designation_all_list_correct.sort(key=len, reverse=True)
+
+        #self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
+        #self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
 
     '''
     Set the corresponding entity type for designations <any> found in name

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -96,22 +96,25 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         self._eng_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.ANY.value,
                                                                           lang=LanguageCodes.ENG.value).data
+        self._eng_designation_any_list_correct.sort(key=len, reverse=True)
+
         self._eng_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.END.value,
                                                                           lang=LanguageCodes.ENG.value).data
+        self._eng_designation_end_list_correct.sort(key=len, reverse=True)
 
         self._fr_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                          position_code=DesignationPositionCodes.ANY.value,
                                                                          lang=LanguageCodes.FR.value).data
+        self._fr_designation_any_list_correct.sort(key=len, reverse=True)
+
         self._fr_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                          position_code=DesignationPositionCodes.END.value,
                                                                          lang=LanguageCodes.FR.value).data
+        self._fr_designation_end_list_correct.sort(key=len, reverse=True)
 
         self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
-        self._designation_any_list_correct.sort(key=len, reverse=True)
-
         self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
-        self._designation_end_list_correct.sort(key=len, reverse=True)
 
     '''
     Set the corresponding entity type for designations <any> found in name

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -57,15 +57,9 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # Just take ARMSTRONG PLUMBING LTD. and perform analysis of designations.
         name_first_part = np_svc.name_first_part
 
-        # These are used when getting the entity type in _set_entity_type_any_designation, _set_entity_type_end_designation
-        # for <any> and <end> designations which are properly placed:
-        # self._designation_any_list = syn_svc.get_designation_any_in_name(name=original_name).data
-        # self._designation_end_list = syn_svc.get_designation_end_in_name(name=original_name).data
-
         self._designation_any_list = syn_svc.get_designation_any_in_name(name=name_first_part).data
         self._designation_end_list = syn_svc.get_designation_end_in_name(name=name_first_part).data
 
-        # self._all_designations = syn_svc.get_designation_all_in_name(name=original_name).data
         self._all_designations = syn_svc.get_designation_all_in_name(name=name_first_part).data
 
     '''
@@ -96,31 +90,30 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         self._eng_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.ANY.value,
                                                                           lang=LanguageCodes.ENG.value).data
-        #self._eng_designation_any_list_correct.sort(key=len, reverse=True)
 
         self._eng_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.END.value,
                                                                           lang=LanguageCodes.ENG.value).data
-        #self._eng_designation_end_list_correct.sort(key=len, reverse=True)
 
         self._fr_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                          position_code=DesignationPositionCodes.ANY.value,
                                                                          lang=LanguageCodes.FR.value).data
-        #self._fr_designation_any_list_correct.sort(key=len, reverse=True)
 
         self._fr_designation_end_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                          position_code=DesignationPositionCodes.END.value,
                                                                          lang=LanguageCodes.FR.value).data
-        #self._fr_designation_end_list_correct.sort(key=len, reverse=True)
 
         self._eng_designation_all_list_correct = self._eng_designation_any_list_correct + self._eng_designation_end_list_correct
         self._eng_designation_all_list_correct.sort(key=len, reverse=True)
+
         self._fr_designation_all_list_correct = self._fr_designation_any_list_correct + self._fr_designation_end_list_correct
         self._fr_designation_all_list_correct.sort(key=len, reverse=True)
 
-        #self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
-        #self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
+        self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
+        self._designation_any_list_correct.sort(key=len, reverse=True)
 
+        self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
+        self._designation_end_list_correct.sort(key=len, reverse=True)
     '''
     Set the corresponding entity type for designations <any> found in name
     '''
@@ -176,9 +169,6 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # self._set_misplaced_designation_in_input_name()
 
         # Set all designations based on entity type typed by user,'CR' by default
-        #self._designation_any_list_correct = self._eng_designation_any_list_correct + self._fr_designation_any_list_correct
-        #self._designation_end_list_correct = self._eng_designation_end_list_correct + self._fr_designation_end_list_correct
-
         self._eng_designation_all_list_correct = self._eng_designation_any_list_correct + self._eng_designation_end_list_correct
         self._eng_designation_all_list_correct.sort(key=len, reverse=True)
         self._fr_designation_all_list_correct = self._fr_designation_any_list_correct + self._fr_designation_end_list_correct
@@ -188,9 +178,6 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
 
         self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)
         self._all_designations_user_no_periods.sort(key=len, reverse=True)
-
-        # Set all designations based on company name typed by user
-        # self._all_designations = self._designation_any_list + self._designation_end_list
 
     '''
     do_analysis is an abstract method inherited from NameAnalysisDirector must be implemented.

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -123,10 +123,10 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # entity_any_designation_dict = self._entity_any_designation_dict
         designation_any_list = self._designation_any_list
 
-        all_end_designations = syn_svc.get_all_end_designations().data
+        all_any_designations = syn_svc.get_all_any_designations().data
 
         self._entity_type_any_designation = syn_svc.get_entity_type_any_designation(
-            entity_any_designation_dict=parse_dict_of_lists(all_end_designations),
+            entity_any_designation_dict=parse_dict_of_lists(all_any_designations),
             all_designation_any_end_list=designation_any_list
         ).data
 
@@ -139,10 +139,10 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # entity_end_designation_dict = self._entity_end_designation_dict
         designation_end_list = self._designation_end_list
 
-        all_any_designations = syn_svc.get_all_any_designations().data
+        all_end_designations = syn_svc.get_all_end_designations().data
 
         self._entity_type_end_designation = syn_svc.get_entity_type_end_designation(
-            entity_end_designation_dict=parse_dict_of_lists(all_any_designations),
+            entity_end_designation_dict=parse_dict_of_lists(all_end_designations),
             all_designation_any_end_list=designation_end_list
         ).data
 
@@ -169,11 +169,6 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         # self._set_misplaced_designation_in_input_name()
 
         # Set all designations based on entity type typed by user,'CR' by default
-        self._eng_designation_all_list_correct = self._eng_designation_any_list_correct + self._eng_designation_end_list_correct
-        self._eng_designation_all_list_correct.sort(key=len, reverse=True)
-        self._fr_designation_all_list_correct = self._fr_designation_any_list_correct + self._fr_designation_end_list_correct
-        self._fr_designation_all_list_correct.sort(key=len, reverse=True)
-
         self._all_designations_user = self._eng_designation_all_list_correct + self._fr_designation_all_list_correct
 
         self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)

--- a/solr-synonyms-api/synonyms/endpoints/synonyms.py
+++ b/solr-synonyms-api/synonyms/endpoints/synonyms.py
@@ -678,6 +678,33 @@ class _TransformText(Resource):
         }
 
 
+@api.route('/regex-prefixes', strict_slashes=False, methods=['GET'])
+class _RegexPrefixes(Resource):
+    @staticmethod
+    @cors.crossdomain(origin='*')
+    # @jwt.requires_auth
+    # @api.expect()
+    @api.response(200, 'SynonymsApi', response_string)
+    @marshal_with(response_string)
+    @api.doc(params={
+        'text': '',
+        'prefixes_str': ''
+    })
+    def get():
+        text = unquote_plus(request.args.get('text'))
+        prefixes_str = unquote_plus(request.args.get('prefixes_str'))
+
+        if not validate_request(request.args):
+            return
+
+        service = SynonymService()
+        result = service.regex_prefixes(text, prefixes_str)
+
+        return {
+            'data': result
+        }
+
+
 @api.route('/<col>/<term>', strict_slashes=False, methods=['GET'])
 class _Synonyms(Resource):
     @staticmethod

--- a/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/mixins/designation.py
@@ -115,6 +115,7 @@ class SynonymDesignationMixin(SynonymServiceMixin):
 
         # Returns list of tuples
         found_designation_any = re.findall(designation_any_regex, name.lower())
+        found_designation_any = list(set([x for designation in found_designation_any for x in designation]))
 
         return found_designation_any
 


### PR DESCRIPTION
*#3532, Sort designations by Language:*

*Description of changes:*
-Sort by Language, then by length
-Fixes related to designation variables in GetSynonymListsMixin that have to be in GetDesignationsListsMixin. In GetSynonymListsMixin we leave just prefixes, substitution, stop words
-Removed unused variables in _clean_name_words, we are sending all_designations instead of splitting in any/end (this was commented, just removing comments)
-Returning list instead of list of tuples in get_designation_any_in_name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
