### PR TITLE
Removing variable all_designation_user_no_periods storing designation…

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_issues.py
+++ b/api/namex/resources/auto_analyse/analysis_issues.py
@@ -13,7 +13,7 @@ from .response_objects.name_action import NameAction, NameActions, WordPositions
 from .response_objects.consenting_body import ConsentingBody
 from .response_objects.conflict import Conflict
 
-from namex.utils.common import remove_periods_designation
+#from namex.utils.common import remove_periods_designation
 
 
 class AnalysisResponseIssue:
@@ -679,11 +679,11 @@ class CorporateNameConflictIssue(AnalysisResponseIssue):
         list_name = self._lc_list_items(self.analysis_response.name_tokens)
 
         all_designations = self._lc_list_items(self.analysis_response.analysis_service.get_all_designations())
-        all_combined_designations = all_designations + remove_periods_designation(all_designations)
+        #all_combined_designations = all_designations + remove_periods_designation(all_designations)
 
         list_name_as_submitted = self._lc_list_items(self.analysis_response.name_as_submitted_tokenized)
         # Filter out designations from the tokens
-        list_tokens = [item for item in list_name_as_submitted if item not in all_combined_designations]
+        list_tokens = [item for item in list_name_as_submitted if item not in all_designations]
 
         list_dist = procedure_result.values['list_dist']  # Don't lower case this one it's a list wrapped list
         list_desc = procedure_result.values['list_desc']  # Don't lower case this one it's a list wrapped list
@@ -946,7 +946,7 @@ class DesignationMisplacedIssue(AnalysisResponseIssue):
         misplaced_all_designation = procedure_result.values['misplaced_all_designation']
 
         misplaced_all_designation_lc = self._lc_list_items(misplaced_all_designation, True)
-        misplaced_all_designation_lc = misplaced_all_designation_lc + remove_periods_designation(misplaced_all_designation_lc)
+        #misplaced_all_designation_lc = misplaced_all_designation_lc + remove_periods_designation(misplaced_all_designation_lc)
         list_name_incl_designation_lc = self._lc_list_items(list_name_incl_designation)
 
         issue = NameAnalysisIssue(

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -141,7 +141,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
         '''
 
     @abc.abstractmethod
-    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user, all_designation_user_no_periods):
+    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -19,7 +19,7 @@ class GetDesignationsListsMixin(object):
     _fr_designation_end_list_correct = []
 
     _all_designations_user = []
-    _all_designations_user_no_periods = []
+    #_all_designations_user_no_periods = []
 
     # All designations for entity type typed bu user
     designations_entity_type_user = []
@@ -99,8 +99,8 @@ class GetDesignationsListsMixin(object):
     def get_all_designations_user(self):
         return self._all_designations_user
 
-    def get_all_designations_user_no_periods(self):
-        return self._all_designations_user_no_periods
+    #def get_all_designations_user_no_periods(self):
+    #    return self._all_designations_user_no_periods
 
     def get_all_designations(self):
         return self._all_designations

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -6,7 +6,7 @@ from namex.constants import \
 
 from .name_analysis_director import NameAnalysisDirector
 
-from namex.utils.common import parse_dict_of_lists, remove_periods_designation
+from namex.utils.common import parse_dict_of_lists
 
 '''
 The ProtectedNameAnalysisService returns an analysis response using the strategies in analysis_strategies.py
@@ -75,7 +75,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
     def _set_designations_incorrect_position_by_input_name(self):
         syn_svc = self.synonym_service
         tokenized_name = self.get_original_name_tokenized()
-        correct_designation_end_list = remove_periods_designation(self._designation_end_list_correct)
+        #correct_designation_end_list = remove_periods_designation(self._designation_end_list_correct)
+        correct_designation_end_list = self._designation_end_list_correct
 
         designation_end_misplaced_list = syn_svc.get_incorrect_designation_end_in_name(tokenized_name=tokenized_name,
                                                                                        designation_end_list=correct_designation_end_list).data
@@ -174,8 +175,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
         self._all_designations_user = self._designation_any_list_correct + self._designation_end_list_correct
         self._all_designations_user.sort(key=len, reverse=True)
 
-        self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)
-        self._all_designations_user_no_periods.sort(key=len, reverse=True)
+        #self._all_designations_user_no_periods = remove_periods_designation(self._all_designations_user)
+        #self._all_designations_user_no_periods.sort(key=len, reverse=True)
 
         # Set all designations based on company name typed by user
         # self._all_designations = self._designation_any_list + self._designation_end_list
@@ -224,8 +225,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector):
                 self.get_original_name_tokenized(),
                 self.entity_type,
                 self.get_all_designations(),
-                self.get_all_designations_user(),
-                self.get_all_designations_user_no_periods()
+                self.get_all_designations_user()
+                #self.get_all_designations_user_no_periods()
             )
 
             if not check_designation_mismatch.is_valid:

--- a/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
+++ b/api/namex/services/name_request/name_analysis_builder_v2/name_analysis_builder.py
@@ -374,16 +374,14 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user,
-                                   all_designation_user_no_periods):
+    def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user):
         result = ProcedureResult()
         result.is_valid = True
 
         mismatch_entity_designation_list = []
         for idx, token in enumerate(list_name):
-            if any(token in designation for designation in all_designations):
-                if token not in all_designation_user_no_periods:
-                    mismatch_entity_designation_list.append(token.upper())
+            if token in all_designations and token not in all_designations_user:
+                mismatch_entity_designation_list.append(token.upper())
 
         if mismatch_entity_designation_list:
             result.is_valid = False


### PR DESCRIPTION
#3476, Handle Missing Period on Designation Mismatch and Move Designation:*

*Description of changes:*
-Removing variable (_all_designations_user_no_periods) storing designations without periods. Now LTD OR LLC are not longer considered designations because they have no period included. Just LTD. , L.L.C. are valid designations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
