### PR TITLE
Set show_examination_button to False to show the button just when the…re is one issue, but not show when there are multiple issues.

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_issues.py
+++ b/api/namex/resources/auto_analyse/analysis_issues.py
@@ -572,7 +572,7 @@ class WordSpecialUse(AnalysisResponseIssue):
             consenting_body=None,
             designations=None,
             show_reserve_button=False,
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]


### PR DESCRIPTION
*#3385, Special Restricted Words Result Panel:*

*Description of changes:*
-Change show_examination_button from True to False to stop showing examination button when there are just one issue.

Test case:
 VANCITY PLUMBING 
 VANCITY PLUMGING LTD.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
