### PR TITLE
Switch issue sort order to first misplaced, then mismatch.

### DIFF
--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -322,8 +322,8 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
                 AnalysisIssueCodes.CORPORATE_CONFLICT,
                 AnalysisIssueCodes.DESIGNATION_NON_EXISTENT,
-                AnalysisIssueCodes.DESIGNATION_MISMATCH,
-                AnalysisIssueCodes.DESIGNATION_MISPLACED
+                AnalysisIssueCodes.DESIGNATION_MISPLACED,
+                AnalysisIssueCodes.DESIGNATION_MISMATCH
             ]
 
             analysis = analysis + self.do_analysis()


### PR DESCRIPTION
*#3768, Switch Response Order for Designations:*

*Description of changes:*
Switch response order from 
analysis_issues_sort_order = [
                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
                AnalysisIssueCodes.WORDS_TO_AVOID,
                AnalysisIssueCodes.TOO_MANY_WORDS,
                AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
                AnalysisIssueCodes.WORD_SPECIAL_USE,
                AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
                AnalysisIssueCodes.CORPORATE_CONFLICT,
                AnalysisIssueCodes.DESIGNATION_NON_EXISTENT,
                AnalysisIssueCodes.DESIGNATION_MISMATCH,
                AnalysisIssueCodes.DESIGNATION_MISPLACED
            ]
to DESIGNATION_MISMATCH before DESIGNATION_MISPLACED:
analysis_issues_sort_order = [
                AnalysisIssueCodes.ADD_DISTINCTIVE_WORD,
                AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
                AnalysisIssueCodes.WORDS_TO_AVOID,
                AnalysisIssueCodes.TOO_MANY_WORDS,
                AnalysisIssueCodes.CONTAINS_UNCLASSIFIABLE_WORD,
                AnalysisIssueCodes.WORD_SPECIAL_USE,
                AnalysisIssueCodes.NAME_REQUIRES_CONSENT,
                AnalysisIssueCodes.CORPORATE_CONFLICT,
                AnalysisIssueCodes.DESIGNATION_NON_EXISTENT,
                AnalysisIssueCodes.DESIGNATION_MISPLACED,
                AnalysisIssueCodes.DESIGNATION_MISMATCH,
            ]


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
