### PR TITLE
3975 issue type designation more than one

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_options.py
+++ b/api/namex/resources/auto_analyse/analysis_options.py
@@ -208,3 +208,16 @@ def change_entity_type_setup():
         line2=Template(""),
         label=Template("Change $entity_type to $correct_designations")
     )
+
+
+class TwoDesignationsSetup(Setup):
+    pass
+
+
+def two_designations_order_setup():
+    return TwoDesignationsSetup(
+        type="two_designations",
+        header=Template("Keep just one designation"),
+        line1=Template("You have selected more than one designation."),
+        line2=Template("")
+    )

--- a/api/namex/resources/auto_analyse/analysis_options.py
+++ b/api/namex/resources/auto_analyse/analysis_options.py
@@ -218,6 +218,6 @@ def two_designations_order_setup():
     return TwoDesignationsSetup(
         type="two_designations",
         header=Template("Keep just one designation"),
-        line1=Template("You have selected more than one designation."),
+        line1=Template("Please select one of the designations listed here:"),
         line2=Template("")
     )

--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
@@ -12,7 +12,7 @@ from .issues import \
     BcCorporateNameConflictIssue as CorporateNameConflictIssue, \
     BcIncorrectCategoryIssue as IncorrectCategoryIssue, \
     BcWordSpecialUseIssue as WordSpecialUseIssue, \
-    BcEndDesignationMoreThanOnceIssue as EndDesignationMoreThanOnceIssue,\
+    BcEndDesignationMoreThanOnceIssue as EndDesignationMoreThanOnceIssue, \
     BcDesignationMisplacedIssue as DesignationMisplacedIssue, \
     BcDesignationNonExistentIssue as DesignationNonExistentIssue
 
@@ -31,7 +31,7 @@ from ...analysis_options import \
     replace_designation_setup, \
     change_entity_type_setup, \
     change_designation_order_setup, \
-    add_designation_setup
+    add_designation_setup, two_designations_order_setup
 
 
 # Execute analysis returns a response strategy code
@@ -259,7 +259,7 @@ class BcAnalysisResponse(AnalysisResponse):
         return issue
 
     def build_end_designation_more_than_once_issue(self, procedure_result, issue_count, issue_idx):
-        option1 = change_designation_order_setup()
+        option1 = two_designations_order_setup()
         # Tweak the header
         option1.header = "Option 1"
 
@@ -272,7 +272,6 @@ class BcAnalysisResponse(AnalysisResponse):
         self.executed_procedures.append(procedure_result.result_code)
 
         return issue
-
 
     def build_designation_misplaced_issue(self, procedure_result, issue_count, issue_idx):
         option1 = change_designation_order_setup()

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -140,7 +140,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
     '''
 
     @abc.abstractmethod
-    def check_end_designation_more_than_once(self, list_name, designation_end_list, misplaced_designation_end):
+    def check_end_designation_more_than_once(self, list_name, all_designation_end_list, correct_designations_user, misplaced_designation_end):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -89,6 +89,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
             check_designation_more_than_one = builder.check_end_designation_more_than_once(
                 self.get_original_name_tokenized(),
                 self.get_designation_end_list(),
+                self.get_all_designations_user(),
                 self.get_misplaced_designation_end()
             )
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -394,10 +394,11 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_end_designation_more_than_once(self, list_name, designation_end_list, misplaced_designation_end):
+    def check_end_designation_more_than_once(self, list_name, all_designation_end_list, correct_designations_user, misplaced_designation_end):
         result = ProcedureResult()
         result.is_valid = True
 
+        designation_end_list = [designation for designation in all_designation_end_list if designation in correct_designations_user]
         correct_end_designations = designation_end_list + list(
             set(misplaced_designation_end) - set(designation_end_list))
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_one_word_with_hyphen_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_one_word_with_hyphen_request.py
@@ -60,7 +60,13 @@ def test_designation_mismatch_one_word_with_hyphen_request_response(client, jwt,
             'location': 'BC',
             'entity_type': 'CR',
             'request_action': 'NEW'
-        }
+        },
+        {
+            'name': 'ARMSTRONG PLUMBING L.L.C. INC.',
+            'location': 'BC',
+            'entity_type': 'CR',
+            'request_action': 'NEW'
+        },
     ]
 
     for entry in test_params:

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_end_designation_more_than_once.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_end_designation_more_than_once.py
@@ -84,6 +84,12 @@ def test_end_designation_more_than_once_request_response(client, jwt, app):
             'entity_type': 'CR',
             'request_action': 'NEW'
         },
+        {
+            'name': 'ARMSTRONG PLUMBING L.L.C. INC.',
+            'location': 'BC',
+            'entity_type': 'CR',
+            'request_action': 'NEW'
+        },
 
     ]
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_end_designation_more_than_once.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_end_designation_more_than_once.py
@@ -83,14 +83,7 @@ def test_end_designation_more_than_once_request_response(client, jwt, app):
             'location': 'BC',
             'entity_type': 'CR',
             'request_action': 'NEW'
-        },
-        {
-            'name': 'ARMSTRONG PLUMBING L.L.C. INC.',
-            'location': 'BC',
-            'entity_type': 'CR',
-            'request_action': 'NEW'
-        },
-
+        }
     ]
 
     for entry in test_params:

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -214,7 +214,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
     @classmethod
     def regex_remove_designations(cls, text, internet_domains, designation_all_regex):
-        text = re.sub(r'\b({0})\b|(?<=\d),(?=\d)|(?<!\w)({1})(?!\w)(?=.*$)'.format(
+        text = re.sub(r'\b({0})\b|(?<=\d),(?=\d)|(?<!\w)({1})(?![A-Za-z0-9_.])(?=.*$)'.format(
             internet_domains,
             designation_all_regex),
             '',


### PR DESCRIPTION
*#3975, Issue type designation more than one:*

*Description of changes:*

- Add a type to setup (type="two_designations")
- Only include the issue type when all designations are valid for the entity type
- Update test cases for issue type designation more than one.
- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
