### PR TITLE
3921 add search conflictsto well formed name

### DIFF
--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -277,7 +277,7 @@ request_type_mapping = [
     ('LP', EntityTypes.LIMITED_PARTNERSHIP.value, RequestAction.NEW.value),
     ('CLP', EntityTypes.LIMITED_PARTNERSHIP.value, RequestAction.CHG.value),
     ('XLP', EntityTypes.XPRO_LIMITED_PARTNERSHIP.value, RequestAction.NEW.value),
-    ('CXLP', EntityTypes.XPRO_LIMITED_PARTNERSHIP.value, RequestAction.CHG.value),
+    ('XCLP', EntityTypes.XPRO_LIMITED_PARTNERSHIP.value, RequestAction.CHG.value),
     ('SO', EntityTypes.SOCIETY.value, RequestAction.NEW.value),
     ('ASO', EntityTypes.SOCIETY.value, RequestAction.AML.value),
     ('CSO', EntityTypes.SOCIETY.value, RequestAction.CHG.value),

--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -315,9 +315,14 @@ request_type_mapping = [
     ('RFI', EntityTypes.FINANCIAL_INSTITUTION.value, RequestAction.REST.value),
     ('PA', EntityTypes.PRIVATE_ACT.value, RequestAction.NEW.value),
     ('PAR', EntityTypes.PARISH.value, RequestAction.NEW.value),
-    ('BC', EntityTypes.BENEFIT_COMPANY.value, RequestAction.NEW.value)
-]
-
+    ('BC', EntityTypes.BENEFIT_COMPANY.value, RequestAction.NEW.value),
+    ('BEAM', EntityTypes.BENEFIT_COMPANY.value, RequestAction.AML.value),
+    ('BEC', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CHG.value),
+    ('BECT', EntityTypes.BENEFIT_COMPANY.value, RequestAction.MVE.value),
+    ('BERE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.REST.value),
+    ('BECV', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value),
+    ('BECR', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value)
+    ]
 
 class NameState(Enum):
     NOT_EXAMINED = 'NE'

--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -3,7 +3,7 @@
 from . import db, ma
 from marshmallow import fields
 from sqlalchemy.orm import backref
-from namex.constants import NameState
+
 
 class Name(db.Model):
     __tablename__ = 'names'
@@ -37,6 +37,14 @@ class Name(db.Model):
     # required for name request name analysis
     _name_type_cd = db.Column('name_type_cd', db.String(10))
     _clean_name = db.Column('clean_name', db.String(1024), index=True)
+
+    NOT_EXAMINED = 'NE'
+    APPROVED = 'APPROVED'
+    REJECTED = 'REJECTED'
+    CONDITION = 'CONDITION'
+    # needed for name request reservation before completing the nr
+    RESERVED = 'RESERVED'
+    COND_RESERVE = 'COND-RESERVE'
 
 
     #Properties added for Name Request

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -273,7 +273,7 @@ class Request(db.Model):
     # START NEW NAME_REQUEST SERVICE METHODS, WE WILL REFACTOR THESE SHORTLY
     # START NEW NAME_REQUEST SERVICE METHODS, WE WILL REFACTOR THESE SHORTLY
     @classmethod
-    def get_general_query(cls):
+    def get_general_query(cls, change_filter=False):
         criteria = []
         basic_filters = [
             cls.id == Name.nrId,
@@ -324,6 +324,28 @@ class Request(db.Model):
                  EntityTypes.XPRO_COOPERATIVE.value,
                  LegacyEntityTypes.XPRO_COOPERATIVE.XCCP.value,
                  LegacyEntityTypes.XPRO_COOPERATIVE.XRCP.value,
+                 EntityTypes.BENEFIT_COMPANY.value
+                 ] if not change_filter else [EntityTypes.PRIVATE_ACT.value,
+                 EntityTypes.CORPORATION.value,
+                 LegacyEntityTypes.CORPORATION.CCR.value,
+                 LegacyEntityTypes.CORPORATION.RCR.value,
+                 EntityTypes.COOPERATIVE.value,
+                 LegacyEntityTypes.COOPERATIVE.CCP.value,
+                 LegacyEntityTypes.COOPERATIVE.RCP.value,
+                 EntityTypes.FINANCIAL_INSTITUTION.value,
+                 LegacyEntityTypes.FINANCIAL_INSTITUTION.CFI.value,
+                 LegacyEntityTypes.FINANCIAL_INSTITUTION.RFI.value,
+                 LegacyEntityTypes.SOCIETY.ASO.value,
+                 LegacyEntityTypes.SOCIETY.CSO.value,
+                 LegacyEntityTypes.SOCIETY.RSO.value,
+                 EntityTypes.UNLIMITED_LIABILITY_COMPANY.value,
+                 LegacyEntityTypes.UNLIMITED_LIABILITY_COMPANY.UC.value,
+                 LegacyEntityTypes.UNLIMITED_LIABILITY_COMPANY.CUL.value,
+                 LegacyEntityTypes.UNLIMITED_LIABILITY_COMPANY.RUL.value,
+                 EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value,
+                 LegacyEntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.CC.value,
+                 LegacyEntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.RCC.value,
+                 EntityTypes.PARISH.value,
                  EntityTypes.BENEFIT_COMPANY.value
                  ]),
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -388,7 +388,7 @@ class Request(db.Model):
         return flattened
 
     @classmethod
-    def get_query_distinctive_descriptive(cls, descriptive_element, criteria, distinctive=False):
+    def get_query_distinctive_descriptive(cls, descriptive_element, criteria, distinctive=False, check_name_is_well_formed=False):
         special_characters_element= Request.set_special_characters(descriptive_element)
         for e in criteria:
             if not distinctive:
@@ -400,7 +400,11 @@ class Request(db.Model):
                 e.filters[0].append(func.lower(Name.name).op('~')(r' \y{}\y'.format(substitutions)))
             else:
                 substitutions = '|'.join(map(str, special_characters_element))
-                e.filters[0].append(func.lower(Name.name).op('~')(r'^(no.?)*\s*\d*\s*\W*({})\W*\s*'.format(substitutions)))
+                if not check_name_is_well_formed:
+                    e.filters[0].append(func.lower(Name.name).op('~')(r'^(no.?)*\s*\d*\s*\W*({})\W*\s*'.format(substitutions)))
+                else:
+                    e.filters[0].append(
+                        func.lower(Name.name).op('~')(r'^\s*\W*({})\W*\s*'.format(substitutions)))
 
         if distinctive:
             return criteria

--- a/api/namex/resources/events.py
+++ b/api/namex/resources/events.py
@@ -84,12 +84,6 @@ class Events(Resource):
                 user_action = "Set to Historical by NRO(Migration)"
             if e_dict["stateCd"]==State.COMPLETED and (e_dict["action"] == "post" or e_dict["action"] == "update_from_nro"):
                 user_action = "Migrated by NRO"
-            if "english" in e_dict:
-                if e_dict["action"] == "post" and e_dict["stateCd"] == State.DRAFT:
-                    user_action ="Submitted to Examiners in Name Request"
-
-            if e_dict["action"] == "post" and e_dict["stateCd"] in [State.RESERVED, State.COND_RESERVE]:
-                user_action = "Submitted to Examiners in Name Request"
 
             e_dict_previous = e_dict
             e_dict["user_action"] = user_action

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -78,7 +78,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
     '''
 
     @abc.abstractmethod
-    def check_name_is_well_formed(self, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
+    def check_name_is_well_formed(self, skip_search_conflicts, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -78,7 +78,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
     '''
 
     @abc.abstractmethod
-    def check_name_is_well_formed(self, skip_search_conflicts, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
+    def check_name_is_well_formed(self, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -137,6 +137,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
+        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()
@@ -215,8 +216,8 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self._list_dist_words, self._list_desc_words = check_synonyms(syn_svc, self._list_dist_words,
                                                                       self._list_desc_words)
 
-        self._dict_name_words = get_classification_summary(self.name_tokens, self._list_dist_words, self._list_desc_words)
-
+        self._dict_name_words = get_classification_summary(self.name_tokens, self._list_dist_words,
+                                                           self._list_desc_words)
 
     '''
     This is the main execution call that wraps name analysis checks. 
@@ -241,14 +242,19 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 return analysis
 
             check_name_is_well_formed = builder.check_name_is_well_formed(
-                    self._dict_name_words,
-                    self._list_dist_words,
-                    self._list_desc_words,
-                    self.name_tokens,
-                    self.name_original_tokens
-                )
-            if not check_name_is_well_formed.is_valid:
+                self._dict_name_words,
+                self._list_dist_words,
+                self._list_desc_words,
+                self.name_tokens,
+                self.processed_name,
+                self.name_original_tokens
+            )
+            if check_name_is_well_formed.result_code in (
+            AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
+                    not check_name_is_well_formed.is_valid:
                 analysis.append(check_name_is_well_formed)
+            elif check_name_is_well_formed.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
+                self.skip_search_conflicts = True
 
             if analysis:
                 return analysis
@@ -324,6 +330,9 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             ]
 
             analysis = analysis + self.do_analysis()
+            if self.skip_search_conflicts:
+                analysis.append(check_name_is_well_formed)
+                
             analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)
 
             return analysis

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -257,7 +257,9 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 analysis.append(check_words_to_avoid)
                 return analysis
 
+            self.set_skip_search_conflicts(True)
             check_name_is_well_formed = builder.check_name_is_well_formed(
+                self.skip_search_conflicts,
                 self._dict_name_words,
                 self._list_dist_words,
                 self._list_desc_words,
@@ -266,11 +268,13 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 self.name_original_tokens
             )
             if check_name_is_well_formed.result_code in (
-            AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
+                    AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
                     not check_name_is_well_formed.is_valid:
                 analysis.append(check_name_is_well_formed)
             elif check_name_is_well_formed.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
-                self.skip_search_conflicts = True
+                self.set_skip_search_conflicts(True)
+            else:
+                self.set_skip_search_conflicts(False)
 
             if analysis:
                 return analysis
@@ -348,7 +352,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             analysis = analysis + self.do_analysis()
             if self.skip_search_conflicts:
                 analysis.append(check_name_is_well_formed)
-                
+
             analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)
 
             return analysis

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -98,6 +98,14 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self._token_classifier = token_classifier
 
     @property
+    def skip_search_conflicts(self):
+        return self._skip_search_conflicts
+
+    @skip_search_conflicts.setter
+    def skip_search_conflicts(self, skip_search_conflicts):
+        self._skip_search_conflicts = skip_search_conflicts
+
+    @property
     def word_classification_tokens(self):
         return \
             self.token_classifier.distinctive_word_tokens, \
@@ -137,7 +145,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
-        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()
@@ -147,6 +154,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self.token_classifier = None
 
         self.entity_type = None
+        self.skip_search_conflicts = False
 
     # Call this method from whatever is using this director
     def use_builder(self, builder):
@@ -159,6 +167,14 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     # Convenience method for extending implementations
     def set_entity_type(self, entity_type):
         self.entity_type = entity_type
+
+    # Convenience method for extending implementations
+    def get_skip_search_conflicts(self):
+        return self._skip_search_conflicts
+
+    # Convenience method for extending implementations
+    def set_skip_search_conflicts(self, skip_search_conflicts):
+        self.skip_search_conflicts = skip_search_conflicts
 
     # API for extending implementations
     def get_name_tokens(self):

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -145,7 +145,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
-        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -145,6 +145,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
+        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -259,7 +259,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
             self.set_skip_search_conflicts(True)
             check_name_is_well_formed = builder.check_name_is_well_formed(
-                self.skip_search_conflicts,
                 self._dict_name_words,
                 self._list_dist_words,
                 self._list_desc_words,

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -154,6 +154,6 @@ def get_classification_summary(list_name, list_dist_words, list_desc_words):
 def get_conflicts_same_classification(builder, name_tokens, processed_name, list_dist, list_desc):
     list_dist, list_desc = \
         list_distinctive_descriptive(name_tokens, list_dist, list_desc)
-    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name)
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name, True)
 
     return check_conflicts

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -50,6 +50,38 @@ def remove_stop_words(name, stop_words, exception_stop_word_designation):
     return " ".join(text.split())
 
 
+def list_distinctive_descriptive(name_list, dist_list, desc_list):
+    queue_dist = collections.deque(dist_list)
+    dist_list_tmp, dist_list_all, desc_list_tmp, desc_list_all = [], [], [], []
+
+    dist_list_tmp.append(list(queue_dist))
+
+    while len(queue_dist) > 1:
+        queue_dist.pop()
+        dist_list_tmp.append(list(queue_dist))
+
+    dist_list_tmp.reverse()
+
+    for dist in dist_list_tmp:
+        desc_list_tmp.append([i for i in name_list if i not in dist and i in desc_list])
+
+    # Validate generation of list of lists of distinctives and descriptives with the correct combinations:
+    for idx, element in enumerate(dist_list_tmp):
+        if dist_list_tmp[idx] + desc_list_tmp[idx] == name_list:
+            dist_list_all.append(dist_list_tmp[idx])
+            desc_list_all.append(desc_list_tmp[idx])
+
+    for idx, element in enumerate(dist_list_all):
+        if len(dist_list_all) > 1 and (len(dist_list_all[idx]) == 0 or len(desc_list_all[idx]) == 0):
+            del dist_list_all[idx]
+            del desc_list_all[idx]
+
+    if len(dist_list_all) == 0 and len(desc_list_all) == 0:
+        return [dist_list_all], [desc_list_all]
+
+    return dist_list_all, desc_list_all
+
+
 def get_all_substitutions(syn_svc, list_dist, list_desc, list_name):
     all_dist_substitutions_synonyms = syn_svc.get_all_substitutions_synonyms(
         words=list_dist,
@@ -117,3 +149,11 @@ def check_synonyms(syn_svc, list_dist_words, list_desc_words):
 def get_classification_summary(list_name, list_dist_words, list_desc_words):
     return {word: DataFrameFields.DISTINCTIVE.value if word in list_dist_words else DataFrameFields.DESCRIPTIVE.value \
         if word in list_desc_words else DataFrameFields.UNCLASSIFIED.value for word in list_name}
+
+
+def get_conflicts_same_classification(builder, name_tokens, processed_name, list_dist, list_desc):
+    list_dist, list_desc = \
+        list_distinctive_descriptive(name_tokens, list_dist, list_desc)
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name)
+
+    return check_conflicts

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -44,15 +44,16 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         results = []
 
         # Return any combination of these checks
-        check_conflicts = builder.search_conflicts(
-            self.get_list_dist(),
-            self.get_list_desc(),
-            self.name_tokens,
-            self.processed_name
-        )
+        if not self.skip_search_conflicts:
+            check_conflicts = builder.search_conflicts(
+                [self.get_list_dist()],
+                [self.get_list_desc()],
+                self.name_tokens,
+                self.processed_name
+            )
 
-        if not check_conflicts.is_valid:
-            results.append(check_conflicts)
+            if not check_conflicts.is_valid:
+                results.append(check_conflicts)
 
         # TODO: Use the list_name array, don't use a string in the method!
         # check_words_requiring_consent = builder.check_words_requiring_consent(list_name)  # This is correct

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -102,7 +102,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
         valid = False
-        self.director.skip_search_conflicts = True
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             for i, value in enumerate(name_dict.values()):
@@ -110,8 +109,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
-                                                                    list_name)
+                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
                 if check_conflicts.is_valid:
                     result = ProcedureResult()
                     result.is_valid = False
@@ -137,7 +135,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             else:
                 return check_conflicts
 
-        self.director.skip_search_conflicts = False
         return result
 
     '''

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -102,6 +102,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
         valid = False
+        self.director.skip_search_conflicts = True
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             for i, value in enumerate(name_dict.values()):
@@ -109,7 +110,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
+                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+                                                                    list_name)
                 if check_conflicts.is_valid:
                     result = ProcedureResult()
                     result.is_valid = False
@@ -135,6 +137,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             else:
                 return check_conflicts
 
+        self.director.skip_search_conflicts = False
         return result
 
     '''

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -25,7 +25,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult[] An array of procedure results
     '''
 
-    def check_name_is_well_formed(self, skip_search_conflict, name_dict, list_dist, list_desc, list_name,
+    def check_name_is_well_formed(self, name_dict, list_dist, list_desc, list_name,
                                   processed_name, list_original_name):
         result = ProcedureResult()
         result.is_valid = True

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -102,6 +102,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
         valid = False
+        self.director.skip_search_conflicts = True
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             for i, value in enumerate(name_dict.values()):
@@ -109,7 +110,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
+                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+                                                                    list_name)
                 if check_conflicts.is_valid:
                     result = ProcedureResult()
                     result.is_valid = False
@@ -135,6 +137,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             else:
                 return check_conflicts
 
+        self.director.skip_search_conflicts = False
         return result
 
     '''
@@ -269,8 +272,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         dist_substitution_list = self.get_subsitutions_distinctive(w_dist)
         desc_synonym_list = self.get_substitutions_descriptive(w_desc)
 
+        change_filter = True if self.director.skip_search_conflicts else False
+
         for dist in dist_substitution_list:
-            criteria = Request.get_general_query()
+            criteria = Request.get_general_query(change_filter)
             criteria = Request.get_query_distinctive_descriptive(dist, criteria, True)
             # Inject descriptive section into query, execute and add matches to list
             for desc in desc_synonym_list:
@@ -407,11 +412,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_end_designation_more_than_once(self, list_name, all_designation_end_list, correct_designations_user, misplaced_designation_end):
+    def check_end_designation_more_than_once(self, list_name, all_designation_end_list, correct_designations_user,
+                                             misplaced_designation_end):
         result = ProcedureResult()
         result.is_valid = True
 
-        designation_end_list = [designation for designation in all_designation_end_list if designation in correct_designations_user]
+        designation_end_list = [designation for designation in all_designation_end_list if
+                                designation in correct_designations_user]
         correct_end_designations = designation_end_list + list(
             set(misplaced_designation_end) - set(designation_end_list))
 

--- a/api/namex/services/nro/change_nr.py
+++ b/api/namex/services/nro/change_nr.py
@@ -144,49 +144,9 @@ def _update_request(oracle_cursor, nr, event_id, change_flags):
                               event_id=event_id,
                               req_inst_id=req_inst_id)
 
-        # create curosr for env
-        test_env = 'prod'
-        #create curosr for env
-        if test_env in app_config:
-            oracle_cursor.execute("""
-                    INSERT INTO request_instance(request_instance_id, request_id,priority_cd, request_type_cd,
-                    expiration_date, start_event_id, tilma_ind, xpro_jurisdiction,
-                    nuans_expiration_date, queue_position, additional_info, nature_business_info,
-                    user_note, nuans_num, tilma_transaction_id, assumed_nuans_num, assumed_nuans_name, assumed_nuans_expiration_date,
-                    last_nuans_update_role, admin_comment)
-                    VALUES (request_instance_seq.nextval, :request_id, :priority_cd, :request_type_cd, 
-                              :expiration_date, :event_id, :tilma_ind, :xpro_jurisdiction, 
-                              :nuans_expiration_date, :queue_position, :additional_info, :nature_business_info,
-                              :user_note, :nuans_num, :tilma_transaction_id, :assumed_nuans_num, 
-                              :assumed_nuans_name, :assumed_nuans_expiration_date, :last_nuans_updated_role, 
-                              :admin_comment)
-                    """,
-                                  request_id=nr.requestId,
-                                  priority_cd=row[2],
-                                  request_type_cd=nr.requestTypeCd,
-                                  expiration_date=nr.expirationDate,
-                                  event_id=event_id,
-                                  tilma_ind=row[7],
-                                  xpro_jurisdiction=nr.xproJurisdiction,
-                                  nuans_expiration_date=row[9],
-                                  queue_position=row[10],
-                                  additional_info=nr.additionalInfo,
-                                  nature_business_info=nr.natureBusinessInfo,
-                                  user_note=row[13],
-                                  nuans_num=row[14],
-                                  tilma_transaction_id=row[15],
-                                  assumed_nuans_num=row[16],
-                                  assumed_nuans_name=row[17],
-                                  assumed_nuans_expiration_date=row[18],
-                                  last_nuans_updated_role=row[19],
-                                  admin_comment=row[20]
-                                  )
-
-
-        else:
-
-            # create new request_instance record
-            oracle_cursor.execute("""
+        # create cursor for env
+        # create new request_instance record
+        oracle_cursor.execute("""
             INSERT INTO request_instance(request_instance_id, request_id,priority_cd, request_type_cd,
             expiration_date, start_event_id, tilma_ind, xpro_jurisdiction,
             nuans_expiration_date, queue_position, additional_info, nature_business_info,

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_distinctive_word_base_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_distinctive_word_base_request.py
@@ -35,10 +35,6 @@ def test_add_distinctive_word_base_request_response(client, jwt, app):
         {'word': 'SEWING', 'classification': 'DESC'},
         {'word': 'SERVICE', 'classification': 'DIST'},
         {'word': 'SERVICE', 'classification': 'DESC'},
-        {'word': 'MARKET', 'classification': 'DIST'},
-        {'word': 'MARKET', 'classification': 'DESC'},
-        {'word': 'CAFE', 'classification': 'DIST'},
-        {'word': 'CAFE', 'classification': 'DESC'},
         {'word': 'KITCHEN', 'classification': 'DIST'},
         {'word': 'KITCHEN', 'classification': 'DESC'},
         {'word': 'FOOD', 'classification': 'DIST'},
@@ -95,11 +91,6 @@ def test_add_distinctive_word_base_request_response(client, jwt, app):
          'request_action': 'NEW'
          },
         {'name': 'SEWING SERVICE LTD.',
-         'location': 'BC',
-         'entity_type': 'CR',
-         'request_action': 'NEW'
-         },
-        {'name': 'MARKET CAFE LTD.',
          'location': 'BC',
          'entity_type': 'CR',
          'request_action': 'NEW'

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
@@ -19,15 +19,16 @@ from ..common import token_header, claims
                              ('J & J HARDWOOD FLOORS AND FLOWERS LTD.', "J.J.'S HARDWOOD FLOORS AND DECORATING LTD."),
                              ('TRADEPRO PHOENIX ENTERPRISES LTD.', 'TRADEPRO/PHOENIX ENTERPRISES INC.'),
                              ("TEANOOK JOHNSON HOLDINGS INC.", "TEANOOK / JOHNSON HOLDINGS INC."),
-                             ('BIG MIKE FUN FARM INC.',"BIG MIKE'S FUN FARM INC."),
-                             ('PJI PIZZA POCO LTD.','PJI PIZZA(POCO) LTD.'),
-                             ("BEEDIE CH PROPERTY INC.",'BEEDIE CH PROPERTY (LOT 3-22) INC.'),
-                             ('DISCOVERY RESIDENTIAL HOLDINGS INC.','DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.'),
-                             ('RR SOLUTIONS LTD.','R R SOLUTIONS LTD.'),
-                             #("ISLAND H SERVICES INC.",'ISLAND H20 SERVICES INC.'),
-                             ('MR RENT A CAR LTD.','MR RENT-A-CAR LTD.'),
+                             ('BIG MIKE FUN FARM INC.', "BIG MIKE'S FUN FARM INC."),
+                             ('PJI PIZZA POCO LTD.', 'PJI PIZZA(POCO) LTD.'),
+                             ("BEEDIE CH PROPERTY INC.", 'BEEDIE CH PROPERTY (LOT 3-22) INC.'),
+                             ('DISCOVERY RESIDENTIAL HOLDINGS INC.', 'DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.'),
+                             ('RR SOLUTIONS LTD.', 'R R SOLUTIONS LTD.'),
+                             # ("ISLAND H SERVICES INC.",'ISLAND H20 SERVICES INC.'),
+                             ('MR RENT A CAR LTD.', 'MR RENT-A-CAR LTD.'),
                              ("ARMSTRONG PLUMBING & HEATING LTD.", "ARMSTRONG PLUMBING & HEATING LTD."),
-                             ("CATHEDRAL MINING LTD.", "CATHEDRAL MINING LTD.")
+                             ("CATHEDRAL MINING LTD.", "CATHEDRAL MINING LTD."),
+                             ("MARKET CAFE LTD.", "MARKET CAFE LTD.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
@@ -108,6 +109,10 @@ def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, 
                                  {'word': 'A', 'classification': 'DESC'},
                                  {'word': 'CAR', 'classification': 'DIST'},
                                  {'word': 'CAR', 'classification': 'DESC'},
+                                 {'word': 'MARKET', 'classification': 'DIST'},
+                                 {'word': 'MARKET', 'classification': 'DESC'},
+                                 {'word': 'CAFE', 'classification': 'DIST'},
+                                 {'word': 'CAFE', 'classification': 'DESC'},
                                  ]
     save_words_list_classification(words_list_classification)
 
@@ -118,11 +123,11 @@ def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, 
                         'JJ KK TRANSPORT SERVICES INC.', 'J&J TRANSPORTATION SERVICES', 'JJ TRANSPORT',
                         'J & J TRANSPORT',
                         "J.J.'S HARDWOOD FLOORS AND DECORATING LTD.", 'THUNDERROAD.ORG INVESTMENTS INC.',
-                        'TRADEPRO/PHOENIX ENTERPRISES INC.','TEANOOK / JOHNSON HOLDINGS INC.',
+                        'TRADEPRO/PHOENIX ENTERPRISES INC.', 'TEANOOK / JOHNSON HOLDINGS INC.',
                         'COAST WIDE HOMECARE/PAINTING NEEDS LTD.', "BIG MIKE'S FUN FARM INC.",
                         'PJI PIZZA(POCO) LTD.', 'BEEDIE CH PROPERTY (LOT 3-22) INC.',
-                        'DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.', 'R R SOLUTIONS LTD.','ISLAND H20 SERVICES INC.',
-                        'MR RENT-A-CAR LTD.' ]
+                        'DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.', 'R R SOLUTIONS LTD.', 'ISLAND H20 SERVICES INC.',
+                        'MR RENT-A-CAR LTD.', 'MARKET CAFE LTD.']
     save_words_list_name(conflict_list_db)
 
     # create JWT & setup header with a Bearer Token using the JWT

--- a/nro-legacy/sql/object/names/namex/procedure/sync_consumed_names.sql
+++ b/nro-legacy/sql/object/names/namex/procedure/sync_consumed_names.sql
@@ -1,0 +1,419 @@
+create or replace PROCEDURE SYNC_CONSUMED_NAMES 
+
+IS
+
+   name_row name_instance%ROWTYPE;
+   rs_row  request_state%ROWTYPE;
+   r_row request%ROWTYPE;
+   c_row corporation@colin_readonly%ROWTYPE;
+   cname_row corp_name@colin_readonly%ROWTYPE;
+   consumed_row name_instance%ROWTYPE;
+  
+
+   last_nr_num  VARCHAR2(10);
+   r_nr_num VARCHAR2(10);
+   next_request_id REQUEST.REQUEST_ID%TYPE;
+   r_request_id REQUEST.REQUEST_ID%TYPE;
+   request_type_var REQUEST_INSTANCE.REQUEST_TYPE_CD%TYPE;
+   name_id NAME.NAME_ID%TYPE;
+   eid event.event_id%TYPE;
+   l_msg APPLICATION_LOG.LOG_MESSAGE%TYPE;
+   jurisdiction_var REQUEST_INSTANCE.XPRO_JURISDICTION%TYPE;
+   txn_count NUMBER;
+   ni_count NUMBER;
+   filing_count NUMBER;
+   r_count NUMBER;
+   skip_count NUMBER;
+   counter NUMBER;
+   max_count NUMBER;
+
+
+   -- name consumption started going over to Namex on May 10th, 2019 was the first consumption in prod
+   cursor ld_cursor is
+   
+    SELECT * from namex.solr_dataimport_conflicts_vw@colin_readonly 
+    WHERE TRUNC(start_date)  <  to_date('20190510','YYYYMMDD') and id not in (select corp_num from namex_datafix) 
+    ORDER BY id;
+       
+  
+BEGIN
+max_count := 10000;
+counter := 0;
+
+FOR cur_row IN ld_cursor loop
+
+    SELECT count(c.corp_num) INTO skip_count 
+      FROM corp_name@colin_readonly c
+      LEFT OUTER JOIN namex.solr_dataimport_conflicts_vw@colin_readonly  solr ON solr.id = c.corp_num
+      WHERE c.corp_num = cur_row.id and c.end_event_id is null 
+        AND ((c.corp_name_typ_cd = 'NB' )
+        OR (solr.jurisdiction='FD' and c.corp_name_typ_cd='CO'));
+        
+     IF skip_count > 0 THEN 
+         l_msg := 'Skipped because it is a numbered company for FD jurisdiction';
+         last_nr_num := '';
+   		 GOTO track;
+	 END IF;
+      
+       
+       /*  GET THE REST OF THE SET UP DATA  */
+	  --get an eventID for all new rows
+		  SELECT event_seq.NEXTVAL  INTO eid  FROM dual;
+		  INSERT INTO event (event_id, event_type_cd, event_timestamp)
+          VALUES (eid, 'SYST', sysdate);
+          
+
+          --CURSOR RETURNS BC for BC jursidictionins5ead of BLANK-normalize data				  
+		  If cur_row.jurisdiction = 'BC' THEN 
+		      jurisdiction_var := NULL;
+          ELSE
+             jurisdiction_var := cur_row.jurisdiction;
+          END IF;
+
+          --get the corp_type not supplied in the cursor for the current corp
+  	     SELECT * INTO c_row FROM corporation@colin_readonly where corp_num = cur_row.id;
+
+		  --look for NR filing in CPRD and get the most recent one
+               
+         -- base nr on filing. effective
+         
+         SELECT count(f.nr_num) INTO filing_count
+         FROM filing@colin_readonly f
+		  INNER JOIN event@colin_readonly e ON e.event_id = f.event_id
+		  WHERE f.nr_num is not null and e.corp_num = cur_row.id 
+            and f.effective_dt = (SELECT MAX(f1.effective_dt)
+                                    FROM filing@colin_readonly f1
+		                           INNER JOIN event@colin_readonly e1 ON e1.event_id = f1.event_id
+                                    WHERE f1.nr_num is not null and e1.corp_num = cur_row.id);
+              
+          If filing_count > 0 THEN 
+            SELECT f.nr_num INTO last_nr_num 
+		    FROM filing@colin_readonly f
+		    INNER JOIN event@colin_readonly e ON e.event_id = f.event_id
+		    WHERE f.nr_num is not null and e.corp_num = cur_row.id
+            and f.effective_dt = (SELECT MAX(f1.effective_dt)
+                                    FROM filing@colin_readonly f1
+		                           INNER JOIN event@colin_readonly e1 ON e1.event_id = f1.event_id
+                                    WHERE f1.nr_num is not null and e1.corp_num = cur_row.id);
+		  END IF;        
+   
+         /* END OF THE SET UP DATA */
+
+        --NO NR EXISTS IN THE CPRD FILING TABLE
+        IF filing_count = 0 THEN
+
+           --check to see if name has already been consumed for the current corp_num
+           SELECT count(ni.corp_num) INTO ni_count
+            FROM name_instance ni
+            WHERE ni.end_event_id IS NULL 
+              and ni.corp_num = cur_row.id;
+           
+           IF ni_count > 1 THEN 
+              l_msg := 'NR # does not exist in CPRD filing table and Names but has duplicate NAME INSTANCE rows. ';
+              GOTO track;
+           END IF;
+           
+           IF ni_count = 1 THEN
+
+            -- NAME exists in NAMES, clean up messy consumption
+          
+              SELECT ni.* INTO consumed_row
+               FROM name_instance ni
+               WHERE ni.end_event_id IS NULL 
+                  and ni.corp_num = cur_row.id;
+                         
+              IF consumed_row.consumption_date IS NULL THEN 
+                 UPDATE name_instance
+                 SET consumption_date = cur_row.start_date
+                 WHERE name_instance_id = consumed_row.name_instance_id;
+              END IF;
+              
+               --get the NR #, request info
+               SELECT r.request_id, r.nr_num INTO r_request_id, r_nr_num
+               FROM request r
+               LEFT OUTER JOIN name n ON r.request_id = n.request_id
+               WHERE n.name_id = consumed_row.name_id ;
+            
+              SELECT rs.* INTO rs_row
+              FROM request_state rs
+              WHERE rs.request_id = r_request_id and rs.end_event_id IS NULL;
+            
+              IF rs_row.state_type_cd != 'COMPLETED' THEN
+              
+                  UPDATE request_state
+                  SET end_event_id = eid
+                  WHERE request_state_id = rs_row.request_state_id;
+                 
+                 -- add a clean completed state
+                   INSERT INTO request_state
+                   (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment)
+		           VALUES
+		           (request_state_seq.nextval, r_request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING COMPLETION state for CORP');
+                          
+              END IF;
+             
+              SELECT count(t.transaction_id)  INTO txn_count
+              FROM transaction t
+              WHERE request_id = r_request_id and t.transaction_type_cd = 'CONSUME';
+              IF txn_count = 0 THEN
+                    --trigger the extractor and complete consumption record set
+		           INSERT INTO transaction 
+		           (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+		            VALUES
+                   (transaction_seq.nextval, 'CONSUME', eid, r_request_id, 'FIX_NR');
+                   
+                   l_msg := 'Added Transaction CONSUME';
+              END IF;
+          
+             last_nr_num := r_nr_num;
+             GOTO track;
+          END IF; --ni_count != 1
+
+           --Otherwise, NO NR EXISTS IN CPRD FILING TABLE OR NAMESP, CREATE A NEW NR IN NAMES
+          SELECT request_seq.nextval INTO next_request_id FROM dual;
+
+            --generate a new NR #
+		   SELECT nro_util_pkg.get_new_nr_num() INTO last_nr_num FROM dual;
+
+             l_msg := 'NEW NR';
+
+            --get the request type.
+            CASE 
+               WHEN c_row.corp_typ_cd IN ('BC','QA','QB','QC','QD','QE','C') THEN request_type_var := 'CR';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd IN ('S','CS') THEN request_type_var := 'SO';
+               WHEN c_row.corp_typ_cd in ('A', 'B', 'EPR', 'FOR', 'REG') THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='B' THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='XS' THEN request_type_var := 'XSO';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd='LLC' THEN request_type_var := 'LC';
+             ELSE
+               request_type_var := c_row.corp_typ_cd;
+             END CASE;
+
+		     INSERT INTO request
+		     (request_id, nr_num, submit_count)
+		     VALUES
+		     (next_request_id, last_nr_num, 1);
+
+              --get the request type.
+             CASE 
+               WHEN c_row.corp_typ_cd IN ('BC','QA','QB','QC','QD','QE','C') THEN request_type_var := 'CR';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd IN ('S','CS')THEN request_type_var := 'SO';
+               WHEN c_row.corp_typ_cd in ('A', 'B', 'EPR', 'FOR', 'REG') THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='B' THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='XS' THEN request_type_var := 'XSO';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd='LLC' THEN request_type_var := 'LC';
+             ELSE
+               request_type_var := c_row.corp_typ_cd;
+             END CASE;
+
+		     INSERT INTO request_instance
+		     (request_instance_id, request_id, request_type_cd, start_event_id, xpro_jurisdiction, nature_Business_info, admin_comment)
+		     VALUES
+		     (request_instance_seq.nextval,next_request_id, request_type_var, eid, jurisdiction_var, 'Added Missing NR for Active Corp.','NEW NR');
+
+		     INSERT INTO request_state
+		     (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment)
+		     VALUES
+		     (request_state_seq.nextval, next_request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING NR FOR ACTIVE CORP');
+
+
+		     SELECT name_seq.nextval INTO name_id FROM dual;
+
+		     INSERT INTO name
+		     (name_id, request_id)
+		     VALUES
+		     (name_id, next_request_id);
+
+		     --add a clean consumption row
+		     INSERT INTO name_instance
+		     (name_instance_id, name_id, choice_number, name,  search_name, consumption_date, start_event_id, corp_num)
+		     VALUES
+		     (name_instance_seq.nextval, name_id, 1, cur_row.name,  REPLACE(cur_row.name,' ',''),cur_row.start_date, eid,cur_row.id );
+
+		     --add approved name state
+		    INSERT INTO name_state
+		    (name_state_id, name_id, name_state_type_cd, start_event_id)
+		    VALUES
+		    (name_state_seq.nextval, name_id, 'A', eid );
+
+		    --trigger the extractor and complete consumption record set
+		    INSERT INTO transaction 
+		    (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+		    VALUES
+		    (transaction_seq.nextval, 'CONSUME', eid, next_request_id, 'FIX_NR');
+            
+            l_msg := 'Does not exist in the filing table and does not exit in names';
+            GOTO track;
+
+	ELSE  -- NR_NUM IN FILING
+          
+            --compress the NR to get rid of formattig issues.
+            last_nr_num := REPLACE(last_nr_num, ' ', '');
+            
+            SELECT count(request_id) INTO r_count
+            FROM request  WHERE REPLACE(nr_num,' ','') = last_nr_num;
+             /*THE NR EXISTS IN CPRD FILING TABLE and finds it in NAMESP*/
+            IF r_count > 0 THEN
+               SELECT * INTO r_row
+               FROM request  WHERE REPLACE(nr_num,' ','') = last_nr_num;
+               --get the current state to ensure that it is correct for consumption
+		       SELECT * INTO rs_row FROM request_state WHERE request_id = r_row.request_id and end_event_id IS NULL;
+             
+               IF rs_row.state_type_cd != 'COMPLETED' THEN 
+                    UPDATE request_state
+			  	    SET end_event_id = eid
+				    WHERE request_id = rs_row.request_id AND end_event_id is NULL;
+
+				    INSERT INTO request_state
+				    (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment)
+				    VALUES
+				    (request_state_seq.nextval, rs_row.request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING COMPLETION FOR CLEAN CONSUMPTION');
+                END IF;
+
+                --ensure there is an approved name row  
+                SELECT count(ni.name_instance_id) INTO ni_count
+                FROM name n
+                LEFT OUTER JOIN name_instance ni on ni.name_id = n.name_id
+		        LEFT OUTER JOIN name_state ns on ns.name_id = n.name_id
+		        WHERE  n.request_id = r_row.request_id 
+		           and ns.name_state_type_cd in ('A','C') 
+		           and ni.end_event_id is null 
+			       and ns.end_event_id IS NULL;
+                   
+               IF ni_count > 1 THEN 
+                  l_msg := 'NR # does not exist in CPRD filing table and Names but has duplicate NAME INSTANCE rows. ';
+                  GOTO track;
+                END IF;  
+               
+               IF ni_count = 1 THEN
+                
+		         SELECT ni.* into name_row 
+                 FROM name n
+		         LEFT OUTER JOIN name_instance ni on ni.name_id = n.name_id
+		         LEFT OUTER JOIN name_state ns on ns.name_id = n.name_id
+		         WHERE  n.request_id = r_row.request_id 
+		            and ns.name_state_type_cd in ('A','C') 
+		            and ni.end_event_id is null 
+			        and ns.end_event_id IS NULL;
+
+                 --THE NR IS THE CORRECT STATE, CHECK THE CONSUMPTION and UPDATE IF IT IS MISSING DATA
+		         IF (name_row.consumption_date IS NULL  OR  name_row.corp_num IS NULL) THEN 
+             	    --end the current name instance
+		            UPDATE name_instance
+			        SET end_event_id = eid
+			        WHERE name_instance_id = name_row.name_instance_id;
+
+			        --add a clean consumption row
+			        INSERT INTO name_instance
+			        (name_instance_id, name_id, choice_number, name, designation, consumption_date, search_name, start_event_id, corp_num)
+			        VALUES
+			       (name_instance_seq.nextval, name_row.name_id, name_row.choice_number, name_row.name,name_row.designation, cur_row.start_date, name_row.search_name, eid,cur_row.id );
+                  END IF;
+                 
+                  SELECT count(t.transaction_id) INTO txn_count
+                  FROM transaction t
+                  WHERE request_id = r_request_id and t.transaction_type_cd = 'CONSUME';
+                  IF txn_count = 0 THEN
+                      --trigger the extractor and complete consumption record set
+		             INSERT INTO transaction 
+		             (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+		              VALUES
+                     (transaction_seq.nextval, 'CONSUME', eid, r_row.request_id, 'FIX_NR');
+                   
+                     l_msg := 'Added Transaction CONSUME, Exist in Filing and Names';
+                  END IF;
+                
+              ELSE --ni_count !=1
+
+                   l_msg := 'NR # exists in CPRD filing table and Names but does not exist in NAME INSTANCE or NAME STATE. Check--ensure there is an approved name row ';
+        	  END IF;
+
+
+		  ELSE --r_count !> 0  means that CPRD filing table has an NR that does not exist in Names
+               -- USing the existing NR that came from CPRD - to match it.
+			  --the NR does not exist in names, add all necessary table/rows for it to be consumed
+			  select request_seq.nextval INTO next_request_id FROM dual;
+              
+              --make sure NR format is correct for Names
+              IF SUBSTR(last_nr_num,3,1) != ' ' THEN 
+                 last_nr_num := REPLACE(last_nr_num,'NR', 'NR ');
+              END IF;
+
+			  INSERT INTO request
+			  (request_id, nr_num, submit_count)
+			  VALUES
+			  (next_request_id, last_nr_num, 1);
+            --determine request_type
+             CASE 
+               WHEN c_row.corp_typ_cd IN ('BC','QA','QB','QC','QD','QE', 'C') THEN request_type_var := 'CR';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd IN ('S','CS') THEN request_type_var := 'SO';
+               WHEN c_row.corp_typ_cd in ('A', 'B', 'EPR', 'FOR', 'REG') THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='B' THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='XS' THEN request_type_var := 'XSO';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd='LLC' THEN request_type_var := 'LC';
+             ELSE
+               request_type_var := c_row.corp_typ_cd;
+             END CASE;
+
+			  INSERT INTO request_instance
+			  (request_instance_id, request_id, request_type_cd, start_event_id, xpro_jurisdiction, nature_Business_info, admin_comment)
+			  VALUES
+			  (request_instance_seq.nextval,next_request_id, request_type_var, eid, jurisdiction_var, 'Added Missing NR for Active Corp','Datafix for conflict matching');
+
+			  INSERT INTO request_state
+			  (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment )
+			  VALUES
+			  (request_state_seq.nextval, next_request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING COMPLETION FOR CLEAN CONSUMPTION');
+
+			  SELECT name_seq.nextval INTO name_id FROM dual;
+
+			  INSERT INTO name
+			  (name_id, request_id)
+			  VALUES
+			  (name_id, next_request_id);
+
+			  --add a clean consumption row
+			  INSERT INTO name_instance
+			  (name_instance_id, name_id, choice_number, name,  search_name, consumption_date, start_event_id, corp_num)
+			  VALUES
+			  (name_instance_seq.nextval, name_id, 1, cur_row.name, REPLACE(cur_row.name,' ',''),cur_row.start_date, eid,cur_row.id );
+
+			  --add approved name state
+			  INSERT INTO name_state
+			  (name_state_id, name_id, name_state_type_cd, start_event_id)
+			  VALUES
+			  (name_state_seq.nextval, name_id, 'A', eid );
+
+			  --trigger the extractor and complete consumption
+			  INSERT INTO transaction 
+			  (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+			  values
+			  (transaction_seq.nextval, 'CONSUME', eid, next_request_id, 'FIX_NR');
+                l_msg := 'Added Transaction CONSUME, Exist in Filing but does not exist Names';
+		END IF; -- --r_row.request_id > 0
+
+	END IF;	--last_nr_num IS NULL OR last_nr_num='' THEN
+
+    <<track>>
+    --keep track of errors and what the last one completed is
+    INSERT INTO NAMEX_DATAFIX
+    (id, nr_num, corp_num, msg)
+    VALUES
+    (namex_datafix_seq.nextval, last_nr_num, cur_row.id, l_msg);
+    
+    --DBMS_OUTPUT.PUT_LINE('Corp_num:'||cur_row.id); 
+
+  COMMIT;
+  counter := counter + 1;
+  IF counter > max_count THEN
+      DBMS_OUTPUT.PUT_LINE('Max rows met:'||counter); 
+     EXIT;
+  END IF;
+END LOOP;
+END SYNC_CONSUMED_NAMES;

--- a/nro-legacy/sql/release/202006XX_namex-proc/names/namex/create.sql
+++ b/nro-legacy/sql/release/202006XX_namex-proc/names/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/names/namex/procedure/sync_consumed_names.sql


### PR DESCRIPTION
*I3921 #, Add search conflictsto well formed name:*

*Description of changes:*
Names with word under the same category provided to check_name_is_well_formed function search for conflicts before sending a response for either ADDING DESCRIPTIVE or ADDING DISTINCTIVE. If the search conflicts execution ends up with a conflict then this would be the response of check name is well formed and continue the analysis. Then, search conflicts process will be skip. The final response includes the conflict found in check_name_is_well_formed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
