### PR TITLE
4087 few tweaks line up fe and be

### DIFF
--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -315,9 +315,14 @@ request_type_mapping = [
     ('RFI', EntityTypes.FINANCIAL_INSTITUTION.value, RequestAction.REST.value),
     ('PA', EntityTypes.PRIVATE_ACT.value, RequestAction.NEW.value),
     ('PAR', EntityTypes.PARISH.value, RequestAction.NEW.value),
-    ('BC', EntityTypes.BENEFIT_COMPANY.value, RequestAction.NEW.value)
-]
-
+    ('BC', EntityTypes.BENEFIT_COMPANY.value, RequestAction.NEW.value),
+    ('BEAM', EntityTypes.BENEFIT_COMPANY.value, RequestAction.AML.value),
+    ('BEC', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CHG.value),
+    ('BECT', EntityTypes.BENEFIT_COMPANY.value, RequestAction.MVE.value),
+    ('BERE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.REST.value),
+    ('BECV', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value),
+    ('BECR', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value)
+    ]
 
 class NameState(Enum):
     NOT_EXAMINED = 'NE'

--- a/api/namex/resources/auto_analyse/analysis_options.py
+++ b/api/namex/resources/auto_analyse/analysis_options.py
@@ -111,6 +111,20 @@ def resolve_conflict_setup():
     )
 
 
+class AssumedNameSetup(Setup):
+    pass
+
+
+def assumed_name_setup():
+    return AssumedNameSetup(
+        type="assumed_name",
+        header=Template("Assumed Name"),
+        line1=Template("Send name to be examined as an Assumed Name."),
+        action=Template("I want to send my name to be examined as an Assumed Name."),
+        checkbox=Template("I want to send my name to be examined as an Assumed Name.")
+    )
+
+
 class SendToExaminerSetup(Setup):
     pass
 

--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis.py
@@ -56,7 +56,7 @@ def validate_name_request(location, entity_type, request_action):
 
         if entity_type in BCProtectedNameEntityTypes.list():
             is_protected = True
-            valid_request_actions = (AnalysisRequestActions.NEW.value, AnalysisRequestActions.AML.value)
+            valid_request_actions = (AnalysisRequestActions.NEW.value, AnalysisRequestActions.CHG.value, AnalysisRequestActions.DBA.value)
 
         elif entity_type in BCUnprotectedNameEntityTypes.list():
             is_unprotected = True
@@ -145,7 +145,8 @@ class BcNameAnalysis(Resource):
             return  # TODO: Return invalid response! What is it?
 
         try:
-            if location == ValidLocations.CA_BC.value and entity_type in BCProtectedNameEntityTypes.list() and request_action in (AnalysisRequestActions.NEW.value, AnalysisRequestActions.AML.value):
+            if location == ValidLocations.CA_BC.value and entity_type in BCProtectedNameEntityTypes.list() and request_action in \
+                    (AnalysisRequestActions.NEW.value, AnalysisRequestActions.CHG.value, AnalysisRequestActions.DBA.value):
                 # Use ProtectedNameAnalysisService
                 service = ProtectedNameAnalysisService()
                 builder = NameAnalysisBuilder(service)

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/add_descriptive_word.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/add_descriptive_word.py
@@ -14,7 +14,7 @@ class XproAddDescriptiveWordIssue(AddDescriptiveWordIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/add_distinctive_word.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/add_distinctive_word.py
@@ -14,7 +14,7 @@ class XproAddDistinctiveWordIssue(AddDistinctiveWordIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/contains_unclassifiable_word.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/contains_unclassifiable_word.py
@@ -14,7 +14,7 @@ class XproContainsUnclassifiableWordIssue(ContainsUnclassifiableWordIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/contains_words_to_avoid.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/contains_words_to_avoid.py
@@ -14,7 +14,7 @@ class XproContainsWordsToAvoidIssue(ContainsWordsToAvoidIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/corporate_name_conflict.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/corporate_name_conflict.py
@@ -14,7 +14,7 @@ class XproCorporateNameConflictIssue(CorporateNameConflictIssue):
             designations=None,
             show_reserve_button=None,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=[],
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/designation_mismatch.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/designation_mismatch.py
@@ -14,7 +14,7 @@ class XproDesignationMismatchIssue(DesignationMismatchIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/designation_misplaced.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/designation_misplaced.py
@@ -14,7 +14,7 @@ class XproDesignationMisplacedIssue(DesignationMisplacedIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/designation_non_existent.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/designation_non_existent.py
@@ -14,7 +14,7 @@ class XproDesignationNonExistentIssue(DesignationNonExistentIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/incorrect_category.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/incorrect_category.py
@@ -14,7 +14,7 @@ class XproIncorrectCategoryIssue(IncorrectCategoryIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/name_requires_consent.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/name_requires_consent.py
@@ -18,7 +18,7 @@ class XproNameRequiresConsentIssue(NameRequiresConsentIssue):
             designations=None,
             show_reserve_button=None,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/too_many_words.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/too_many_words.py
@@ -14,7 +14,7 @@ class XproTooManyWordsIssue(TooManyWordsIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=None

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/word_special_use.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/word_special_use.py
@@ -14,7 +14,7 @@ class XproWordSpecialUseIssue(WordSpecialUseIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=True,
+            show_examination_button=False,
             conflicts=None,
             setup=None,
             name_actions=[]

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
@@ -49,7 +49,7 @@ def validate_name_request(location, entity_type, request_action):
     if location == ValidLocations.CA_NOT_BC.list():
         # If XPRO, nothing is protected (for now anyway)
         valid_request_actions = (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value, AnalysisRequestActions.CNV.value,
-                                 AnalysisRequestActions.MVE.value, AnalysisRequestActions.REH.value)
+                                 AnalysisRequestActions.MVE.value, AnalysisRequestActions.REH.value, AnalysisRequestActions.REN.value)
 
         if entity_type not in XproUnprotectedNameEntityTypes.list():
             raise ValueError('Invalid entity_type provided for an XPRO entity')

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
@@ -9,6 +9,7 @@ from flask_jwt_oidc import AuthError
 
 from urllib.parse import unquote_plus
 
+from namex.services.name_request.auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
 from namex.utils.util import cors_preflight
 from namex.utils.logging import setup_logging
 
@@ -110,7 +111,11 @@ class XproNameAnalysis(Resource):
             return  # TODO: Return invalid response! What is it?
 
         try:
-            if location in (ValidLocations.CA_NOT_BC.value, ValidLocations.INTL.value) and entity_type in XproUnprotectedNameEntityTypes.list() and request_action in (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value):
+            if location == ValidLocations.CA_NOT_BC.value and entity_type in XproUnprotectedNameEntityTypes.list() and request_action and request_action == AnalysisRequestActions.MVE.value:
+                # Use ProtectedNameAnalysisService
+                service = ProtectedNameAnalysisService()
+                builder = NameAnalysisBuilder(service)
+            elif location in (ValidLocations.CA_NOT_BC.value, ValidLocations.INTL.value) and entity_type in XproUnprotectedNameEntityTypes.list() and request_action in (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value):
                 # Use UnprotectedNameAnalysisService
                 service = XproNameAnalysisService()
                 builder = NameAnalysisBuilder(service)

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
@@ -46,9 +46,10 @@ def validate_name_request(location, entity_type, request_action):
         raise ValueError('Invalid request action provided')
 
     # Throw any errors related to invalid entity_type or request_action for a location
-    if location in (ValidLocations.CA_NOT_BC.list(), ValidLocations.INTL.list()):
+    if location == ValidLocations.CA_NOT_BC.list():
         # If XPRO, nothing is protected (for now anyway)
-        valid_request_actions = (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value)
+        valid_request_actions = (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value, AnalysisRequestActions.CNV.value,
+                                 AnalysisRequestActions.MVE.value, AnalysisRequestActions.REH.value)
 
         if entity_type not in XproUnprotectedNameEntityTypes.list():
             raise ValueError('Invalid entity_type provided for an XPRO entity')
@@ -111,11 +112,12 @@ class XproNameAnalysis(Resource):
             return  # TODO: Return invalid response! What is it?
 
         try:
-            if location == ValidLocations.CA_NOT_BC.value and entity_type in XproUnprotectedNameEntityTypes.list() and request_action and request_action == AnalysisRequestActions.MVE.value:
+            if location == ValidLocations.CA_NOT_BC.value and entity_type in XproUnprotectedNameEntityTypes.list() and request_action == AnalysisRequestActions.MVE.value:
                 # Use ProtectedNameAnalysisService
                 service = ProtectedNameAnalysisService()
                 builder = NameAnalysisBuilder(service)
-            elif location in (ValidLocations.CA_NOT_BC.value, ValidLocations.INTL.value) and entity_type in XproUnprotectedNameEntityTypes.list() and request_action in (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value):
+            elif location == ValidLocations.CA_NOT_BC.value and entity_type in XproUnprotectedNameEntityTypes.list() and \
+                    request_action in (AnalysisRequestActions.NEW.value, AnalysisRequestActions.DBA.value, AnalysisRequestActions.CNV.value, AnalysisRequestActions.REH.value):
                 # Use UnprotectedNameAnalysisService
                 service = XproNameAnalysisService()
                 builder = NameAnalysisBuilder(service)

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
@@ -23,6 +23,7 @@ from ...analysis_options import \
     too_many_words_setup, \
     remove_setup, \
     remove_or_replace_setup, \
+    assumed_name_setup, \
     resolve_conflict_setup, \
     send_to_examiner_setup, \
     obtain_consent_setup, \
@@ -188,22 +189,24 @@ class XproAnalysisResponse(AnalysisResponse):
         return issue
 
     def build_corporate_conflict_issue(self, procedure_result, issue_count, issue_idx):
-        option1 = resolve_conflict_setup()
+        """
+        For the XPRO path, corp_conflict issue type Options must change. Option 2 and 3 should be removed.
+        Change the Helpful Hint to:
+        Extra provincial or registration of a foreign entity in BC requires use of an Assumed Name when there is an existing BC entity with a similar name.
+
+        Option 1: (Same text)
+        New setup button: Need a checkbox for assumed_name. The front-end should should turn the checkbox into" I want to send my name to be examined as an Assumed Name.
+        :param procedure_result:
+        :param issue_count:
+        :param issue_idx:
+        :return:
+        """
+        option1 = assumed_name_setup()
         # Tweak the header
         option1.header = "Option 1"
 
-        option2 = send_to_examiner_setup()
-        # Tweak the header
-        option2.header = "Option 2"
-
-        option3 = conflict_self_consent_setup()
-        # Tweak the header
-        option3.header = "Option 3"
-
         issue = response_issues(procedure_result.result_code)(self, [
-            option1,
-            option2,
-            option3
+            option1
         ])
 
         '''

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -347,7 +347,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         result = ProcedureResult()
         result.is_valid = True
 
-        if not all_designations:
+        if all_designations_user and not all_designations:
             result.is_valid = False
             result.result_code = AnalysisIssueCodes.DESIGNATION_NON_EXISTENT
             result.values = {

--- a/api/namex/services/nro/change_nr.py
+++ b/api/namex/services/nro/change_nr.py
@@ -144,49 +144,9 @@ def _update_request(oracle_cursor, nr, event_id, change_flags):
                               event_id=event_id,
                               req_inst_id=req_inst_id)
 
-        # create curosr for env
-        test_env = 'prod'
-        #create curosr for env
-        if test_env in app_config:
-            oracle_cursor.execute("""
-                    INSERT INTO request_instance(request_instance_id, request_id,priority_cd, request_type_cd,
-                    expiration_date, start_event_id, tilma_ind, xpro_jurisdiction,
-                    nuans_expiration_date, queue_position, additional_info, nature_business_info,
-                    user_note, nuans_num, tilma_transaction_id, assumed_nuans_num, assumed_nuans_name, assumed_nuans_expiration_date,
-                    last_nuans_update_role, admin_comment)
-                    VALUES (request_instance_seq.nextval, :request_id, :priority_cd, :request_type_cd, 
-                              :expiration_date, :event_id, :tilma_ind, :xpro_jurisdiction, 
-                              :nuans_expiration_date, :queue_position, :additional_info, :nature_business_info,
-                              :user_note, :nuans_num, :tilma_transaction_id, :assumed_nuans_num, 
-                              :assumed_nuans_name, :assumed_nuans_expiration_date, :last_nuans_updated_role, 
-                              :admin_comment)
-                    """,
-                                  request_id=nr.requestId,
-                                  priority_cd=row[2],
-                                  request_type_cd=nr.requestTypeCd,
-                                  expiration_date=nr.expirationDate,
-                                  event_id=event_id,
-                                  tilma_ind=row[7],
-                                  xpro_jurisdiction=nr.xproJurisdiction,
-                                  nuans_expiration_date=row[9],
-                                  queue_position=row[10],
-                                  additional_info=nr.additionalInfo,
-                                  nature_business_info=nr.natureBusinessInfo,
-                                  user_note=row[13],
-                                  nuans_num=row[14],
-                                  tilma_transaction_id=row[15],
-                                  assumed_nuans_num=row[16],
-                                  assumed_nuans_name=row[17],
-                                  assumed_nuans_expiration_date=row[18],
-                                  last_nuans_updated_role=row[19],
-                                  admin_comment=row[20]
-                                  )
-
-
-        else:
-
-            # create new request_instance record
-            oracle_cursor.execute("""
+        # create cursor for env
+        # create new request_instance record
+        oracle_cursor.execute("""
             INSERT INTO request_instance(request_instance_id, request_id,priority_cd, request_type_cd,
             expiration_date, start_event_id, tilma_ind, xpro_jurisdiction,
             nuans_expiration_date, queue_position, additional_info, nature_business_info,

--- a/api/tests/python/end_points/auto_analyse/common.py
+++ b/api/tests/python/end_points/auto_analyse/common.py
@@ -34,15 +34,6 @@ claims = {
 
 
 @pytest.mark.skip
-def assert_issues_count_is(count, issues):
-    if issues.__len__() > count:
-        print('\n' + 'Issue types:' + '\n')
-        for issue in issues:
-            print('- ' + issue.issueType.value + '\n')
-    assert issues.__len__() == count
-
-
-@pytest.mark.skip
 def assert_issues_count_is_gt(count, issues):
     print('\n' + 'Issue types:' + '\n')
     for issue in issues:

--- a/api/tests/python/end_points/auto_analyse/common.py
+++ b/api/tests/python/end_points/auto_analyse/common.py
@@ -51,6 +51,14 @@ def assert_issues_count_is_gt(count, issues):
 
 
 @pytest.mark.skip
+def assert_issues_count_is_zero(issues):
+    print('\n' + 'Issue types:' + '\n')
+    for issue in issues:
+        print('- ' + issue.get('issue_type') + '\n')
+    assert issues.__len__() == 0
+
+
+@pytest.mark.skip
 def assert_issue_type_is_one_of(types, issue):
     assert issue.get('issue_type') in types
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_request_actions_bc.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_request_actions_bc.py
@@ -1,0 +1,51 @@
+import pytest
+import jsonpickle
+
+from urllib.parse import quote_plus
+
+from ..common import save_words_list_classification, assert_issues_count_is_zero
+from ..common import ENDPOINT_PATH
+from ..common import token_header, claims
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_designation_existence_request_response(client, jwt, app):
+    words_list_classification = [{'word': 'ARMSTRONG', 'classification': 'DIST'},
+                                 {'word': 'ARMSTRONG', 'classification': 'DESC'},
+                                 {'word': 'PLUMBING', 'classification': 'DIST'},
+                                 {'word': 'PLUMBING', 'classification': 'DESC'}]
+    save_words_list_classification(words_list_classification)
+    # create JWT & setup header with a Bearer Token using the JWT
+    token = jwt.create_jwt(claims, token_header)
+    headers = {'Authorization': 'Bearer ' + token, 'content-type': 'application/json'}
+
+    test_params = [
+        {
+            'name': 'ARMSTRONG PLUMBING LTD.',
+            'location': 'BC',
+            'entity_type': 'CR',
+            'request_action': 'CHG'
+        },
+        {
+            'name': 'ARMSTRONG PLUMBING LTD.',
+            'location': 'BC',
+            'entity_type': 'CR',
+            'request_action': 'DBA'
+        },
+        {
+            'name': 'ARMSTRONG PLUMBING LTD.',
+            'location': 'BC',
+            'entity_type': 'CR',
+            'request_action': 'NEW'
+        }
+    ]
+
+    for entry in test_params:
+        query = '&'.join("{!s}={}".format(k, quote_plus(v)) for (k, v) in entry.items())
+        path = ENDPOINT_PATH + '?' + query
+        print('\n' + 'request: ' + path + '\n')
+        response = client.get(path, headers=headers)
+        payload = jsonpickle.decode(response.data)
+        print("Assert that the payload contains issues")
+        if isinstance(payload.get('issues'), list):
+            assert_issues_count_is_zero(payload.get('issues'))

--- a/nro-legacy/sql/object/names/namex/procedure/sync_consumed_names.sql
+++ b/nro-legacy/sql/object/names/namex/procedure/sync_consumed_names.sql
@@ -1,0 +1,419 @@
+create or replace PROCEDURE SYNC_CONSUMED_NAMES 
+
+IS
+
+   name_row name_instance%ROWTYPE;
+   rs_row  request_state%ROWTYPE;
+   r_row request%ROWTYPE;
+   c_row corporation@colin_readonly%ROWTYPE;
+   cname_row corp_name@colin_readonly%ROWTYPE;
+   consumed_row name_instance%ROWTYPE;
+  
+
+   last_nr_num  VARCHAR2(10);
+   r_nr_num VARCHAR2(10);
+   next_request_id REQUEST.REQUEST_ID%TYPE;
+   r_request_id REQUEST.REQUEST_ID%TYPE;
+   request_type_var REQUEST_INSTANCE.REQUEST_TYPE_CD%TYPE;
+   name_id NAME.NAME_ID%TYPE;
+   eid event.event_id%TYPE;
+   l_msg APPLICATION_LOG.LOG_MESSAGE%TYPE;
+   jurisdiction_var REQUEST_INSTANCE.XPRO_JURISDICTION%TYPE;
+   txn_count NUMBER;
+   ni_count NUMBER;
+   filing_count NUMBER;
+   r_count NUMBER;
+   skip_count NUMBER;
+   counter NUMBER;
+   max_count NUMBER;
+
+
+   -- name consumption started going over to Namex on May 10th, 2019 was the first consumption in prod
+   cursor ld_cursor is
+   
+    SELECT * from namex.solr_dataimport_conflicts_vw@colin_readonly 
+    WHERE TRUNC(start_date)  <  to_date('20190510','YYYYMMDD') and id not in (select corp_num from namex_datafix) 
+    ORDER BY id;
+       
+  
+BEGIN
+max_count := 10000;
+counter := 0;
+
+FOR cur_row IN ld_cursor loop
+
+    SELECT count(c.corp_num) INTO skip_count 
+      FROM corp_name@colin_readonly c
+      LEFT OUTER JOIN namex.solr_dataimport_conflicts_vw@colin_readonly  solr ON solr.id = c.corp_num
+      WHERE c.corp_num = cur_row.id and c.end_event_id is null 
+        AND ((c.corp_name_typ_cd = 'NB' )
+        OR (solr.jurisdiction='FD' and c.corp_name_typ_cd='CO'));
+        
+     IF skip_count > 0 THEN 
+         l_msg := 'Skipped because it is a numbered company for FD jurisdiction';
+         last_nr_num := '';
+   		 GOTO track;
+	 END IF;
+      
+       
+       /*  GET THE REST OF THE SET UP DATA  */
+	  --get an eventID for all new rows
+		  SELECT event_seq.NEXTVAL  INTO eid  FROM dual;
+		  INSERT INTO event (event_id, event_type_cd, event_timestamp)
+          VALUES (eid, 'SYST', sysdate);
+          
+
+          --CURSOR RETURNS BC for BC jursidictionins5ead of BLANK-normalize data				  
+		  If cur_row.jurisdiction = 'BC' THEN 
+		      jurisdiction_var := NULL;
+          ELSE
+             jurisdiction_var := cur_row.jurisdiction;
+          END IF;
+
+          --get the corp_type not supplied in the cursor for the current corp
+  	     SELECT * INTO c_row FROM corporation@colin_readonly where corp_num = cur_row.id;
+
+		  --look for NR filing in CPRD and get the most recent one
+               
+         -- base nr on filing. effective
+         
+         SELECT count(f.nr_num) INTO filing_count
+         FROM filing@colin_readonly f
+		  INNER JOIN event@colin_readonly e ON e.event_id = f.event_id
+		  WHERE f.nr_num is not null and e.corp_num = cur_row.id 
+            and f.effective_dt = (SELECT MAX(f1.effective_dt)
+                                    FROM filing@colin_readonly f1
+		                           INNER JOIN event@colin_readonly e1 ON e1.event_id = f1.event_id
+                                    WHERE f1.nr_num is not null and e1.corp_num = cur_row.id);
+              
+          If filing_count > 0 THEN 
+            SELECT f.nr_num INTO last_nr_num 
+		    FROM filing@colin_readonly f
+		    INNER JOIN event@colin_readonly e ON e.event_id = f.event_id
+		    WHERE f.nr_num is not null and e.corp_num = cur_row.id
+            and f.effective_dt = (SELECT MAX(f1.effective_dt)
+                                    FROM filing@colin_readonly f1
+		                           INNER JOIN event@colin_readonly e1 ON e1.event_id = f1.event_id
+                                    WHERE f1.nr_num is not null and e1.corp_num = cur_row.id);
+		  END IF;        
+   
+         /* END OF THE SET UP DATA */
+
+        --NO NR EXISTS IN THE CPRD FILING TABLE
+        IF filing_count = 0 THEN
+
+           --check to see if name has already been consumed for the current corp_num
+           SELECT count(ni.corp_num) INTO ni_count
+            FROM name_instance ni
+            WHERE ni.end_event_id IS NULL 
+              and ni.corp_num = cur_row.id;
+           
+           IF ni_count > 1 THEN 
+              l_msg := 'NR # does not exist in CPRD filing table and Names but has duplicate NAME INSTANCE rows. ';
+              GOTO track;
+           END IF;
+           
+           IF ni_count = 1 THEN
+
+            -- NAME exists in NAMES, clean up messy consumption
+          
+              SELECT ni.* INTO consumed_row
+               FROM name_instance ni
+               WHERE ni.end_event_id IS NULL 
+                  and ni.corp_num = cur_row.id;
+                         
+              IF consumed_row.consumption_date IS NULL THEN 
+                 UPDATE name_instance
+                 SET consumption_date = cur_row.start_date
+                 WHERE name_instance_id = consumed_row.name_instance_id;
+              END IF;
+              
+               --get the NR #, request info
+               SELECT r.request_id, r.nr_num INTO r_request_id, r_nr_num
+               FROM request r
+               LEFT OUTER JOIN name n ON r.request_id = n.request_id
+               WHERE n.name_id = consumed_row.name_id ;
+            
+              SELECT rs.* INTO rs_row
+              FROM request_state rs
+              WHERE rs.request_id = r_request_id and rs.end_event_id IS NULL;
+            
+              IF rs_row.state_type_cd != 'COMPLETED' THEN
+              
+                  UPDATE request_state
+                  SET end_event_id = eid
+                  WHERE request_state_id = rs_row.request_state_id;
+                 
+                 -- add a clean completed state
+                   INSERT INTO request_state
+                   (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment)
+		           VALUES
+		           (request_state_seq.nextval, r_request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING COMPLETION state for CORP');
+                          
+              END IF;
+             
+              SELECT count(t.transaction_id)  INTO txn_count
+              FROM transaction t
+              WHERE request_id = r_request_id and t.transaction_type_cd = 'CONSUME';
+              IF txn_count = 0 THEN
+                    --trigger the extractor and complete consumption record set
+		           INSERT INTO transaction 
+		           (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+		            VALUES
+                   (transaction_seq.nextval, 'CONSUME', eid, r_request_id, 'FIX_NR');
+                   
+                   l_msg := 'Added Transaction CONSUME';
+              END IF;
+          
+             last_nr_num := r_nr_num;
+             GOTO track;
+          END IF; --ni_count != 1
+
+           --Otherwise, NO NR EXISTS IN CPRD FILING TABLE OR NAMESP, CREATE A NEW NR IN NAMES
+          SELECT request_seq.nextval INTO next_request_id FROM dual;
+
+            --generate a new NR #
+		   SELECT nro_util_pkg.get_new_nr_num() INTO last_nr_num FROM dual;
+
+             l_msg := 'NEW NR';
+
+            --get the request type.
+            CASE 
+               WHEN c_row.corp_typ_cd IN ('BC','QA','QB','QC','QD','QE','C') THEN request_type_var := 'CR';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd IN ('S','CS') THEN request_type_var := 'SO';
+               WHEN c_row.corp_typ_cd in ('A', 'B', 'EPR', 'FOR', 'REG') THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='B' THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='XS' THEN request_type_var := 'XSO';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd='LLC' THEN request_type_var := 'LC';
+             ELSE
+               request_type_var := c_row.corp_typ_cd;
+             END CASE;
+
+		     INSERT INTO request
+		     (request_id, nr_num, submit_count)
+		     VALUES
+		     (next_request_id, last_nr_num, 1);
+
+              --get the request type.
+             CASE 
+               WHEN c_row.corp_typ_cd IN ('BC','QA','QB','QC','QD','QE','C') THEN request_type_var := 'CR';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd IN ('S','CS')THEN request_type_var := 'SO';
+               WHEN c_row.corp_typ_cd in ('A', 'B', 'EPR', 'FOR', 'REG') THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='B' THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='XS' THEN request_type_var := 'XSO';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd='LLC' THEN request_type_var := 'LC';
+             ELSE
+               request_type_var := c_row.corp_typ_cd;
+             END CASE;
+
+		     INSERT INTO request_instance
+		     (request_instance_id, request_id, request_type_cd, start_event_id, xpro_jurisdiction, nature_Business_info, admin_comment)
+		     VALUES
+		     (request_instance_seq.nextval,next_request_id, request_type_var, eid, jurisdiction_var, 'Added Missing NR for Active Corp.','NEW NR');
+
+		     INSERT INTO request_state
+		     (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment)
+		     VALUES
+		     (request_state_seq.nextval, next_request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING NR FOR ACTIVE CORP');
+
+
+		     SELECT name_seq.nextval INTO name_id FROM dual;
+
+		     INSERT INTO name
+		     (name_id, request_id)
+		     VALUES
+		     (name_id, next_request_id);
+
+		     --add a clean consumption row
+		     INSERT INTO name_instance
+		     (name_instance_id, name_id, choice_number, name,  search_name, consumption_date, start_event_id, corp_num)
+		     VALUES
+		     (name_instance_seq.nextval, name_id, 1, cur_row.name,  REPLACE(cur_row.name,' ',''),cur_row.start_date, eid,cur_row.id );
+
+		     --add approved name state
+		    INSERT INTO name_state
+		    (name_state_id, name_id, name_state_type_cd, start_event_id)
+		    VALUES
+		    (name_state_seq.nextval, name_id, 'A', eid );
+
+		    --trigger the extractor and complete consumption record set
+		    INSERT INTO transaction 
+		    (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+		    VALUES
+		    (transaction_seq.nextval, 'CONSUME', eid, next_request_id, 'FIX_NR');
+            
+            l_msg := 'Does not exist in the filing table and does not exit in names';
+            GOTO track;
+
+	ELSE  -- NR_NUM IN FILING
+          
+            --compress the NR to get rid of formattig issues.
+            last_nr_num := REPLACE(last_nr_num, ' ', '');
+            
+            SELECT count(request_id) INTO r_count
+            FROM request  WHERE REPLACE(nr_num,' ','') = last_nr_num;
+             /*THE NR EXISTS IN CPRD FILING TABLE and finds it in NAMESP*/
+            IF r_count > 0 THEN
+               SELECT * INTO r_row
+               FROM request  WHERE REPLACE(nr_num,' ','') = last_nr_num;
+               --get the current state to ensure that it is correct for consumption
+		       SELECT * INTO rs_row FROM request_state WHERE request_id = r_row.request_id and end_event_id IS NULL;
+             
+               IF rs_row.state_type_cd != 'COMPLETED' THEN 
+                    UPDATE request_state
+			  	    SET end_event_id = eid
+				    WHERE request_id = rs_row.request_id AND end_event_id is NULL;
+
+				    INSERT INTO request_state
+				    (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment)
+				    VALUES
+				    (request_state_seq.nextval, rs_row.request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING COMPLETION FOR CLEAN CONSUMPTION');
+                END IF;
+
+                --ensure there is an approved name row  
+                SELECT count(ni.name_instance_id) INTO ni_count
+                FROM name n
+                LEFT OUTER JOIN name_instance ni on ni.name_id = n.name_id
+		        LEFT OUTER JOIN name_state ns on ns.name_id = n.name_id
+		        WHERE  n.request_id = r_row.request_id 
+		           and ns.name_state_type_cd in ('A','C') 
+		           and ni.end_event_id is null 
+			       and ns.end_event_id IS NULL;
+                   
+               IF ni_count > 1 THEN 
+                  l_msg := 'NR # does not exist in CPRD filing table and Names but has duplicate NAME INSTANCE rows. ';
+                  GOTO track;
+                END IF;  
+               
+               IF ni_count = 1 THEN
+                
+		         SELECT ni.* into name_row 
+                 FROM name n
+		         LEFT OUTER JOIN name_instance ni on ni.name_id = n.name_id
+		         LEFT OUTER JOIN name_state ns on ns.name_id = n.name_id
+		         WHERE  n.request_id = r_row.request_id 
+		            and ns.name_state_type_cd in ('A','C') 
+		            and ni.end_event_id is null 
+			        and ns.end_event_id IS NULL;
+
+                 --THE NR IS THE CORRECT STATE, CHECK THE CONSUMPTION and UPDATE IF IT IS MISSING DATA
+		         IF (name_row.consumption_date IS NULL  OR  name_row.corp_num IS NULL) THEN 
+             	    --end the current name instance
+		            UPDATE name_instance
+			        SET end_event_id = eid
+			        WHERE name_instance_id = name_row.name_instance_id;
+
+			        --add a clean consumption row
+			        INSERT INTO name_instance
+			        (name_instance_id, name_id, choice_number, name, designation, consumption_date, search_name, start_event_id, corp_num)
+			        VALUES
+			       (name_instance_seq.nextval, name_row.name_id, name_row.choice_number, name_row.name,name_row.designation, cur_row.start_date, name_row.search_name, eid,cur_row.id );
+                  END IF;
+                 
+                  SELECT count(t.transaction_id) INTO txn_count
+                  FROM transaction t
+                  WHERE request_id = r_request_id and t.transaction_type_cd = 'CONSUME';
+                  IF txn_count = 0 THEN
+                      --trigger the extractor and complete consumption record set
+		             INSERT INTO transaction 
+		             (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+		              VALUES
+                     (transaction_seq.nextval, 'CONSUME', eid, r_row.request_id, 'FIX_NR');
+                   
+                     l_msg := 'Added Transaction CONSUME, Exist in Filing and Names';
+                  END IF;
+                
+              ELSE --ni_count !=1
+
+                   l_msg := 'NR # exists in CPRD filing table and Names but does not exist in NAME INSTANCE or NAME STATE. Check--ensure there is an approved name row ';
+        	  END IF;
+
+
+		  ELSE --r_count !> 0  means that CPRD filing table has an NR that does not exist in Names
+               -- USing the existing NR that came from CPRD - to match it.
+			  --the NR does not exist in names, add all necessary table/rows for it to be consumed
+			  select request_seq.nextval INTO next_request_id FROM dual;
+              
+              --make sure NR format is correct for Names
+              IF SUBSTR(last_nr_num,3,1) != ' ' THEN 
+                 last_nr_num := REPLACE(last_nr_num,'NR', 'NR ');
+              END IF;
+
+			  INSERT INTO request
+			  (request_id, nr_num, submit_count)
+			  VALUES
+			  (next_request_id, last_nr_num, 1);
+            --determine request_type
+             CASE 
+               WHEN c_row.corp_typ_cd IN ('BC','QA','QB','QC','QD','QE', 'C') THEN request_type_var := 'CR';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd IN ('S','CS') THEN request_type_var := 'SO';
+               WHEN c_row.corp_typ_cd in ('A', 'B', 'EPR', 'FOR', 'REG') THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='B' THEN request_type_var := 'XCR';
+               WHEN c_row.corp_typ_cd='XS' THEN request_type_var := 'XSO';
+               WHEN c_row.corp_typ_cd='ULC' THEN request_type_var := 'UL';
+               WHEN c_row.corp_typ_cd='LLC' THEN request_type_var := 'LC';
+             ELSE
+               request_type_var := c_row.corp_typ_cd;
+             END CASE;
+
+			  INSERT INTO request_instance
+			  (request_instance_id, request_id, request_type_cd, start_event_id, xpro_jurisdiction, nature_Business_info, admin_comment)
+			  VALUES
+			  (request_instance_seq.nextval,next_request_id, request_type_var, eid, jurisdiction_var, 'Added Missing NR for Active Corp','Datafix for conflict matching');
+
+			  INSERT INTO request_state
+			  (request_state_id, request_id, state_type_cd, start_event_id, examiner_idir, examiner_comment )
+			  VALUES
+			  (request_state_seq.nextval, next_request_id, 'COMPLETED', eid, 'FIX_NR', 'ADDED MISSING COMPLETION FOR CLEAN CONSUMPTION');
+
+			  SELECT name_seq.nextval INTO name_id FROM dual;
+
+			  INSERT INTO name
+			  (name_id, request_id)
+			  VALUES
+			  (name_id, next_request_id);
+
+			  --add a clean consumption row
+			  INSERT INTO name_instance
+			  (name_instance_id, name_id, choice_number, name,  search_name, consumption_date, start_event_id, corp_num)
+			  VALUES
+			  (name_instance_seq.nextval, name_id, 1, cur_row.name, REPLACE(cur_row.name,' ',''),cur_row.start_date, eid,cur_row.id );
+
+			  --add approved name state
+			  INSERT INTO name_state
+			  (name_state_id, name_id, name_state_type_cd, start_event_id)
+			  VALUES
+			  (name_state_seq.nextval, name_id, 'A', eid );
+
+			  --trigger the extractor and complete consumption
+			  INSERT INTO transaction 
+			  (transaction_id, transaction_type_cd, event_id, request_id, staff_idir)
+			  values
+			  (transaction_seq.nextval, 'CONSUME', eid, next_request_id, 'FIX_NR');
+                l_msg := 'Added Transaction CONSUME, Exist in Filing but does not exist Names';
+		END IF; -- --r_row.request_id > 0
+
+	END IF;	--last_nr_num IS NULL OR last_nr_num='' THEN
+
+    <<track>>
+    --keep track of errors and what the last one completed is
+    INSERT INTO NAMEX_DATAFIX
+    (id, nr_num, corp_num, msg)
+    VALUES
+    (namex_datafix_seq.nextval, last_nr_num, cur_row.id, l_msg);
+    
+    --DBMS_OUTPUT.PUT_LINE('Corp_num:'||cur_row.id); 
+
+  COMMIT;
+  counter := counter + 1;
+  IF counter > max_count THEN
+      DBMS_OUTPUT.PUT_LINE('Max rows met:'||counter); 
+     EXIT;
+  END IF;
+END LOOP;
+END SYNC_CONSUMED_NAMES;

--- a/nro-legacy/sql/release/202006XX_namex-proc/names/namex/create.sql
+++ b/nro-legacy/sql/release/202006XX_namex-proc/names/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/names/namex/procedure/sync_consumed_names.sql


### PR DESCRIPTION
*#4087, Few Tweaks to line up the Front-End and Back-End:*

*Description of changes:*

Changes in protect names:
- Return non_existent_designation issue when the entity type has designation. Otherwise, do not return it.
- In protected name analysis, add request_action CHG, DBA for location ='BC' 

Changes in XPRO names:
- If request action = MVE and location != BC, then go to protected auto analyse.
- if request action != MVE and location !=BC, then go to xpro auto analyse.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
