### PR TITLE
3921 v2 add search conflicts to well formed name

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -273,7 +273,7 @@ class Request(db.Model):
     # START NEW NAME_REQUEST SERVICE METHODS, WE WILL REFACTOR THESE SHORTLY
     # START NEW NAME_REQUEST SERVICE METHODS, WE WILL REFACTOR THESE SHORTLY
     @classmethod
-    def get_general_query(cls):
+    def get_general_query(cls, change_filter=False):
         criteria = []
         basic_filters = [
             cls.id == Name.nrId,
@@ -324,6 +324,28 @@ class Request(db.Model):
                  EntityTypes.XPRO_COOPERATIVE.value,
                  LegacyEntityTypes.XPRO_COOPERATIVE.XCCP.value,
                  LegacyEntityTypes.XPRO_COOPERATIVE.XRCP.value,
+                 EntityTypes.BENEFIT_COMPANY.value
+                 ] if not change_filter else [EntityTypes.PRIVATE_ACT.value,
+                 EntityTypes.CORPORATION.value,
+                 LegacyEntityTypes.CORPORATION.CCR.value,
+                 LegacyEntityTypes.CORPORATION.RCR.value,
+                 EntityTypes.COOPERATIVE.value,
+                 LegacyEntityTypes.COOPERATIVE.CCP.value,
+                 LegacyEntityTypes.COOPERATIVE.RCP.value,
+                 EntityTypes.FINANCIAL_INSTITUTION.value,
+                 LegacyEntityTypes.FINANCIAL_INSTITUTION.CFI.value,
+                 LegacyEntityTypes.FINANCIAL_INSTITUTION.RFI.value,
+                 LegacyEntityTypes.SOCIETY.ASO.value,
+                 LegacyEntityTypes.SOCIETY.CSO.value,
+                 LegacyEntityTypes.SOCIETY.RSO.value,
+                 EntityTypes.UNLIMITED_LIABILITY_COMPANY.value,
+                 LegacyEntityTypes.UNLIMITED_LIABILITY_COMPANY.UC.value,
+                 LegacyEntityTypes.UNLIMITED_LIABILITY_COMPANY.CUL.value,
+                 LegacyEntityTypes.UNLIMITED_LIABILITY_COMPANY.RUL.value,
+                 EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value,
+                 LegacyEntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.CC.value,
+                 LegacyEntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.RCC.value,
+                 EntityTypes.PARISH.value,
                  EntityTypes.BENEFIT_COMPANY.value
                  ]),
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -388,7 +388,7 @@ class Request(db.Model):
         return flattened
 
     @classmethod
-    def get_query_distinctive_descriptive(cls, descriptive_element, criteria, distinctive=False):
+    def get_query_distinctive_descriptive(cls, descriptive_element, criteria, distinctive=False, check_name_is_well_formed=False):
         special_characters_element= Request.set_special_characters(descriptive_element)
         for e in criteria:
             if not distinctive:
@@ -400,7 +400,11 @@ class Request(db.Model):
                 e.filters[0].append(func.lower(Name.name).op('~')(r' \y{}\y'.format(substitutions)))
             else:
                 substitutions = '|'.join(map(str, special_characters_element))
-                e.filters[0].append(func.lower(Name.name).op('~')(r'^(no.?)*\s*\d*\s*\W*({})\W*\s*'.format(substitutions)))
+                if not check_name_is_well_formed:
+                    e.filters[0].append(func.lower(Name.name).op('~')(r'^(no.?)*\s*\d*\s*\W*({})\W*\s*'.format(substitutions)))
+                else:
+                    e.filters[0].append(
+                        func.lower(Name.name).op('~')(r'^\s*\W*({})\W*\s*'.format(substitutions)))
 
         if distinctive:
             return criteria

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -78,7 +78,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
     '''
 
     @abc.abstractmethod
-    def check_name_is_well_formed(self, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
+    def check_name_is_well_formed(self, skip_search_conflicts, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
+++ b/api/namex/services/name_request/auto_analyse/abstract_name_analysis_builder.py
@@ -78,7 +78,7 @@ class AbstractNameAnalysisBuilder(GetSynonymsListsMixin, GetDesignationsListsMix
     '''
 
     @abc.abstractmethod
-    def check_name_is_well_formed(self, skip_search_conflicts, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
+    def check_name_is_well_formed(self, dict_name, list_dist, list_desc, list_none, list_name, list_original_name):
         return ProcedureResult(is_valid=True)
 
     '''

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -137,6 +137,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
+        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()
@@ -215,8 +216,8 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self._list_dist_words, self._list_desc_words = check_synonyms(syn_svc, self._list_dist_words,
                                                                       self._list_desc_words)
 
-        self._dict_name_words = get_classification_summary(self.name_tokens, self._list_dist_words, self._list_desc_words)
-
+        self._dict_name_words = get_classification_summary(self.name_tokens, self._list_dist_words,
+                                                           self._list_desc_words)
 
     '''
     This is the main execution call that wraps name analysis checks. 
@@ -241,14 +242,19 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 return analysis
 
             check_name_is_well_formed = builder.check_name_is_well_formed(
-                    self._dict_name_words,
-                    self._list_dist_words,
-                    self._list_desc_words,
-                    self.name_tokens,
-                    self.name_original_tokens
-                )
-            if not check_name_is_well_formed.is_valid:
+                self._dict_name_words,
+                self._list_dist_words,
+                self._list_desc_words,
+                self.name_tokens,
+                self.processed_name,
+                self.name_original_tokens
+            )
+            if check_name_is_well_formed.result_code in (
+            AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
+                    not check_name_is_well_formed.is_valid:
                 analysis.append(check_name_is_well_formed)
+            elif check_name_is_well_formed.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
+                self.skip_search_conflicts = True
 
             if analysis:
                 return analysis
@@ -324,6 +330,9 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             ]
 
             analysis = analysis + self.do_analysis()
+            if self.skip_search_conflicts:
+                analysis.append(check_name_is_well_formed)
+                
             analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)
 
             return analysis

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -257,7 +257,9 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 analysis.append(check_words_to_avoid)
                 return analysis
 
+            self.set_skip_search_conflicts(True)
             check_name_is_well_formed = builder.check_name_is_well_formed(
+                self.skip_search_conflicts,
                 self._dict_name_words,
                 self._list_dist_words,
                 self._list_desc_words,
@@ -266,11 +268,13 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 self.name_original_tokens
             )
             if check_name_is_well_formed.result_code in (
-            AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
+                    AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
                     not check_name_is_well_formed.is_valid:
                 analysis.append(check_name_is_well_formed)
             elif check_name_is_well_formed.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
-                self.skip_search_conflicts = True
+                self.set_skip_search_conflicts(True)
+            else:
+                self.set_skip_search_conflicts(False)
 
             if analysis:
                 return analysis
@@ -348,7 +352,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             analysis = analysis + self.do_analysis()
             if self.skip_search_conflicts:
                 analysis.append(check_name_is_well_formed)
-                
+
             analysis = self.sort_analysis_issues(analysis, analysis_issues_sort_order)
 
             return analysis

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -98,6 +98,14 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self._token_classifier = token_classifier
 
     @property
+    def skip_search_conflicts(self):
+        return self._skip_search_conflicts
+
+    @skip_search_conflicts.setter
+    def skip_search_conflicts(self, skip_search_conflicts):
+        self._skip_search_conflicts = skip_search_conflicts
+
+    @property
     def word_classification_tokens(self):
         return \
             self.token_classifier.distinctive_word_tokens, \
@@ -137,7 +145,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
-        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()
@@ -147,6 +154,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self.token_classifier = None
 
         self.entity_type = None
+        self.skip_search_conflicts = False
 
     # Call this method from whatever is using this director
     def use_builder(self, builder):
@@ -159,6 +167,14 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     # Convenience method for extending implementations
     def set_entity_type(self, entity_type):
         self.entity_type = entity_type
+
+    # Convenience method for extending implementations
+    def get_skip_search_conflicts(self):
+        return self._skip_search_conflicts
+
+    # Convenience method for extending implementations
+    def set_skip_search_conflicts(self, skip_search_conflicts):
+        self.skip_search_conflicts = skip_search_conflicts
 
     # API for extending implementations
     def get_name_tokens(self):

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -145,7 +145,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
-        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -145,6 +145,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_as_submitted_tokenized
 
     def __init__(self):
+        self.skip_search_conflicts = False
         self.synonym_service = SynonymService()
         self.word_classification_service = WordClassificationService()
         self.word_condition_service = VirtualWordConditionService()

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -259,7 +259,6 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
             self.set_skip_search_conflicts(True)
             check_name_is_well_formed = builder.check_name_is_well_formed(
-                self.skip_search_conflicts,
                 self._dict_name_words,
                 self._list_dist_words,
                 self._list_desc_words,

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -154,6 +154,6 @@ def get_classification_summary(list_name, list_dist_words, list_desc_words):
 def get_conflicts_same_classification(builder, name_tokens, processed_name, list_dist, list_desc):
     list_dist, list_desc = \
         list_distinctive_descriptive(name_tokens, list_dist, list_desc)
-    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name)
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name, True)
 
     return check_conflicts

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -50,6 +50,38 @@ def remove_stop_words(name, stop_words, exception_stop_word_designation):
     return " ".join(text.split())
 
 
+def list_distinctive_descriptive(name_list, dist_list, desc_list):
+    queue_dist = collections.deque(dist_list)
+    dist_list_tmp, dist_list_all, desc_list_tmp, desc_list_all = [], [], [], []
+
+    dist_list_tmp.append(list(queue_dist))
+
+    while len(queue_dist) > 1:
+        queue_dist.pop()
+        dist_list_tmp.append(list(queue_dist))
+
+    dist_list_tmp.reverse()
+
+    for dist in dist_list_tmp:
+        desc_list_tmp.append([i for i in name_list if i not in dist and i in desc_list])
+
+    # Validate generation of list of lists of distinctives and descriptives with the correct combinations:
+    for idx, element in enumerate(dist_list_tmp):
+        if dist_list_tmp[idx] + desc_list_tmp[idx] == name_list:
+            dist_list_all.append(dist_list_tmp[idx])
+            desc_list_all.append(desc_list_tmp[idx])
+
+    for idx, element in enumerate(dist_list_all):
+        if len(dist_list_all) > 1 and (len(dist_list_all[idx]) == 0 or len(desc_list_all[idx]) == 0):
+            del dist_list_all[idx]
+            del desc_list_all[idx]
+
+    if len(dist_list_all) == 0 and len(desc_list_all) == 0:
+        return [dist_list_all], [desc_list_all]
+
+    return dist_list_all, desc_list_all
+
+
 def get_all_substitutions(syn_svc, list_dist, list_desc, list_name):
     all_dist_substitutions_synonyms = syn_svc.get_all_substitutions_synonyms(
         words=list_dist,
@@ -117,3 +149,11 @@ def check_synonyms(syn_svc, list_dist_words, list_desc_words):
 def get_classification_summary(list_name, list_dist_words, list_desc_words):
     return {word: DataFrameFields.DISTINCTIVE.value if word in list_dist_words else DataFrameFields.DESCRIPTIVE.value \
         if word in list_desc_words else DataFrameFields.UNCLASSIFIED.value for word in list_name}
+
+
+def get_conflicts_same_classification(builder, name_tokens, processed_name, list_dist, list_desc):
+    list_dist, list_desc = \
+        list_distinctive_descriptive(name_tokens, list_dist, list_desc)
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name)
+
+    return check_conflicts

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -44,15 +44,16 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         results = []
 
         # Return any combination of these checks
-        check_conflicts = builder.search_conflicts(
-            self.get_list_dist(),
-            self.get_list_desc(),
-            self.name_tokens,
-            self.processed_name
-        )
+        if not self.skip_search_conflicts:
+            check_conflicts = builder.search_conflicts(
+                [self.get_list_dist()],
+                [self.get_list_desc()],
+                self.name_tokens,
+                self.processed_name
+            )
 
-        if not check_conflicts.is_valid:
-            results.append(check_conflicts)
+            if not check_conflicts.is_valid:
+                results.append(check_conflicts)
 
         # TODO: Use the list_name array, don't use a string in the method!
         # check_words_requiring_consent = builder.check_words_requiring_consent(list_name)  # This is correct

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -33,26 +33,21 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_classification = next(iter(name_dict.values()))
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
-        valid = False
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
-            for i, value in enumerate(name_dict.values()):
-                if value == DataFrameFields.DESCRIPTIVE.value:
-                    valid = True
-                    break
+            valid = self.check_descriptive(name_dict)
             if not valid:
                 if len(name_dict) > 0:
-                    result = self.check_conflicts_response(self, processed_name, list_original_name, list_name,
-                                                           list_dist,
-                                                           AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
+                    result = self.check_conflict_well_formed_response(processed_name, list_original_name, list_name, list_dist,
+                                                                      AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
                     if result.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
                         return result
                 else:
                     result = self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
                                                                      AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
         else:
-            result = self.check_conflicts_response(self, processed_name, list_original_name, list_name, list_dist,
-                                                   AnalysisIssueCodes.ADD_DISTINCTIVE_WORD)
+            result = self.check_conflict_well_formed_response(processed_name, list_original_name, list_name, list_dist,
+                                                              AnalysisIssueCodes.ADD_DISTINCTIVE_WORD)
             if result.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
                 return result
 
@@ -560,7 +555,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         return result
 
-    def check_conflicts_response(self, processed_name, list_original_name, list_name, list_dist, issue):
+    def check_conflict_well_formed_response(self, processed_name, list_original_name, list_name, list_dist, issue):
         check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
                                                             list_name)
         if check_conflicts.is_valid:
@@ -568,3 +563,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                                                            issue)
         else:
             return check_conflicts
+
+    def check_descriptive(self, name_dict):
+        valid = False
+        for i, value in enumerate(name_dict.values()):
+            if value == DataFrameFields.DESCRIPTIVE.value:
+                valid = True
+                break
+
+        return valid

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -102,7 +102,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
         valid = False
-        self.director.skip_search_conflicts = True
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             for i, value in enumerate(name_dict.values()):
@@ -110,8 +109,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
-                                                                    list_name)
+                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
                 if check_conflicts.is_valid:
                     result = ProcedureResult()
                     result.is_valid = False
@@ -137,7 +135,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             else:
                 return check_conflicts
 
-        self.director.skip_search_conflicts = False
         return result
 
     '''

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -102,6 +102,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
         valid = False
+        self.director.skip_search_conflicts = True
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             for i, value in enumerate(name_dict.values()):
@@ -109,7 +110,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
+                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+                                                                    list_name)
                 if check_conflicts.is_valid:
                     result = ProcedureResult()
                     result.is_valid = False
@@ -135,6 +137,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             else:
                 return check_conflicts
 
+        self.director.skip_search_conflicts = False
         return result
 
     '''

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -41,13 +41,17 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
-                                                                    list_name)
-                if check_conflicts.is_valid:
+                if len(name_dict) > 0:
+                    check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+                                                                        list_name)
+                    if check_conflicts.is_valid:
+                        result = self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
+                                                                         AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
+                    else:
+                        return check_conflicts
+                else:
                     result = self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
                                                                      AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
-                else:
-                    return check_conflicts
         else:
             check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
             if check_conflicts.is_valid:
@@ -152,12 +156,14 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         dict_highest_counter, response = {}, {}
 
         for w_dist, w_desc in zip(list_dist_words, list_desc_words):
-            list_conflicts.extend(self.get_conflicts(dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed))
-            list_conflicts = [i for n, i in enumerate(list_conflicts) if
-                              i not in list_conflicts[n + 1:]]  # Remove duplicates
+            if w_dist and w_desc:
+                list_conflicts.extend(
+                    self.get_conflicts(dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed))
+                list_conflicts = [i for n, i in enumerate(list_conflicts) if
+                                  i not in list_conflicts[n + 1:]]  # Remove duplicates
 
-            if self.is_exact_match(list_conflicts):
-                break
+                if self.is_exact_match(list_conflicts):
+                    break
 
         most_similar_names.extend(
             sorted(list_conflicts, key=lambda item: (-item['score'], len(item['name'])))[

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -25,7 +25,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult[] An array of procedure results
     '''
 
-    def check_name_is_well_formed(self, skip_search_conflict, name_dict, list_dist, list_desc, list_name,
+    def check_name_is_well_formed(self, name_dict, list_dist, list_desc, list_name,
                                   processed_name, list_original_name):
         result = ProcedureResult()
         result.is_valid = True

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -102,6 +102,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         first_word = next(iter(name_dict))
         name_dict.pop(first_word)
         valid = False
+        self.director.skip_search_conflicts = True
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             for i, value in enumerate(name_dict.values()):
@@ -109,7 +110,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     valid = True
                     break
             if not valid:
-                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
+                check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+                                                                    list_name)
                 if check_conflicts.is_valid:
                     result = ProcedureResult()
                     result.is_valid = False
@@ -135,6 +137,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             else:
                 return check_conflicts
 
+        self.director.skip_search_conflicts = False
         return result
 
     '''
@@ -269,8 +272,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         dist_substitution_list = self.get_subsitutions_distinctive(w_dist)
         desc_synonym_list = self.get_substitutions_descriptive(w_desc)
 
+        change_filter = True if self.director.skip_search_conflicts else False
+
         for dist in dist_substitution_list:
-            criteria = Request.get_general_query()
+            criteria = Request.get_general_query(change_filter)
             criteria = Request.get_query_distinctive_descriptive(dist, criteria, True)
             # Inject descriptive section into query, execute and add matches to list
             for desc in desc_synonym_list:
@@ -407,11 +412,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def check_end_designation_more_than_once(self, list_name, all_designation_end_list, correct_designations_user, misplaced_designation_end):
+    def check_end_designation_more_than_once(self, list_name, all_designation_end_list, correct_designations_user,
+                                             misplaced_designation_end):
         result = ProcedureResult()
         result.is_valid = True
 
-        designation_end_list = [designation for designation in all_designation_end_list if designation in correct_designations_user]
+        designation_end_list = [designation for designation in all_designation_end_list if
+                                designation in correct_designations_user]
         correct_end_designations = designation_end_list + list(
             set(misplaced_designation_end) - set(designation_end_list))
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -42,23 +42,19 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     break
             if not valid:
                 if len(name_dict) > 0:
-                    check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
-                                                                        list_name)
-                    if check_conflicts.is_valid:
-                        result = self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
-                                                                         AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
-                    else:
-                        return check_conflicts
+                    result = self.check_conflicts_response(self, processed_name, list_original_name, list_name,
+                                                           list_dist,
+                                                           AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
+                    if result.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
+                        return result
                 else:
                     result = self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
                                                                      AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD)
         else:
-            check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name, list_name)
-            if check_conflicts.is_valid:
-                result = self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
-                                                                 AnalysisIssueCodes.ADD_DISTINCTIVE_WORD)
-            else:
-                return check_conflicts
+            result = self.check_conflicts_response(self, processed_name, list_original_name, list_name, list_dist,
+                                                   AnalysisIssueCodes.ADD_DISTINCTIVE_WORD)
+            if result.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
+                return result
 
         return result
 
@@ -563,3 +559,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         }
 
         return result
+
+    def check_conflicts_response(self, processed_name, list_original_name, list_name, list_dist, issue):
+        check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+                                                            list_name)
+        if check_conflicts.is_valid:
+            return self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,
+                                                           issue)
+        else:
+            return check_conflicts

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_base_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_base_request.py
@@ -26,6 +26,12 @@ def test_add_descriptive_word_base_request_response(client, jwt, app):
             'location': 'BC',
             'entity_type': 'CR',
             'request_action': 'NEW'
+        },
+        {
+            'name': 'ABC INC.',
+            'location': 'BC',
+            'entity_type': 'CR',
+            'request_action': 'NEW'
         }
     ]
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_base_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_base_request.py
@@ -13,7 +13,8 @@ from ..common import token_header, claims
 # 2.- Unique word classified as distinctive
 @pytest.mark.xfail(raises=ValueError)
 def test_add_descriptive_word_base_request_response(client, jwt, app):
-    words_list_classification = [{'word': 'COSTAS', 'classification': 'DIST'}]
+    words_list_classification = [{'word': 'COSTAS', 'classification': 'DIST'},
+                                 {'word': 'ABC', 'classification': 'DIST'}]
     save_words_list_classification(words_list_classification)
 
     # create JWT & setup header with a Bearer Token using the JWT

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_distinctive_word_base_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_distinctive_word_base_request.py
@@ -35,10 +35,6 @@ def test_add_distinctive_word_base_request_response(client, jwt, app):
         {'word': 'SEWING', 'classification': 'DESC'},
         {'word': 'SERVICE', 'classification': 'DIST'},
         {'word': 'SERVICE', 'classification': 'DESC'},
-        {'word': 'MARKET', 'classification': 'DIST'},
-        {'word': 'MARKET', 'classification': 'DESC'},
-        {'word': 'CAFE', 'classification': 'DIST'},
-        {'word': 'CAFE', 'classification': 'DESC'},
         {'word': 'KITCHEN', 'classification': 'DIST'},
         {'word': 'KITCHEN', 'classification': 'DESC'},
         {'word': 'FOOD', 'classification': 'DIST'},
@@ -95,11 +91,6 @@ def test_add_distinctive_word_base_request_response(client, jwt, app):
          'request_action': 'NEW'
          },
         {'name': 'SEWING SERVICE LTD.',
-         'location': 'BC',
-         'entity_type': 'CR',
-         'request_action': 'NEW'
-         },
-        {'name': 'MARKET CAFE LTD.',
          'location': 'BC',
          'entity_type': 'CR',
          'request_action': 'NEW'

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
@@ -19,15 +19,16 @@ from ..common import token_header, claims
                              ('J & J HARDWOOD FLOORS AND FLOWERS LTD.', "J.J.'S HARDWOOD FLOORS AND DECORATING LTD."),
                              ('TRADEPRO PHOENIX ENTERPRISES LTD.', 'TRADEPRO/PHOENIX ENTERPRISES INC.'),
                              ("TEANOOK JOHNSON HOLDINGS INC.", "TEANOOK / JOHNSON HOLDINGS INC."),
-                             ('BIG MIKE FUN FARM INC.',"BIG MIKE'S FUN FARM INC."),
-                             ('PJI PIZZA POCO LTD.','PJI PIZZA(POCO) LTD.'),
-                             ("BEEDIE CH PROPERTY INC.",'BEEDIE CH PROPERTY (LOT 3-22) INC.'),
-                             ('DISCOVERY RESIDENTIAL HOLDINGS INC.','DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.'),
-                             ('RR SOLUTIONS LTD.','R R SOLUTIONS LTD.'),
-                             #("ISLAND H SERVICES INC.",'ISLAND H20 SERVICES INC.'),
-                             ('MR RENT A CAR LTD.','MR RENT-A-CAR LTD.'),
+                             ('BIG MIKE FUN FARM INC.', "BIG MIKE'S FUN FARM INC."),
+                             ('PJI PIZZA POCO LTD.', 'PJI PIZZA(POCO) LTD.'),
+                             ("BEEDIE CH PROPERTY INC.", 'BEEDIE CH PROPERTY (LOT 3-22) INC.'),
+                             ('DISCOVERY RESIDENTIAL HOLDINGS INC.', 'DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.'),
+                             ('RR SOLUTIONS LTD.', 'R R SOLUTIONS LTD.'),
+                             # ("ISLAND H SERVICES INC.",'ISLAND H20 SERVICES INC.'),
+                             ('MR RENT A CAR LTD.', 'MR RENT-A-CAR LTD.'),
                              ("ARMSTRONG PLUMBING & HEATING LTD.", "ARMSTRONG PLUMBING & HEATING LTD."),
-                             ("CATHEDRAL MINING LTD.", "CATHEDRAL MINING LTD.")
+                             ("CATHEDRAL MINING LTD.", "CATHEDRAL MINING LTD."),
+                             ("MARKET CAFE LTD.", "MARKET CAFE LTD.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
@@ -108,6 +109,10 @@ def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, 
                                  {'word': 'A', 'classification': 'DESC'},
                                  {'word': 'CAR', 'classification': 'DIST'},
                                  {'word': 'CAR', 'classification': 'DESC'},
+                                 {'word': 'MARKET', 'classification': 'DIST'},
+                                 {'word': 'MARKET', 'classification': 'DESC'},
+                                 {'word': 'CAFE', 'classification': 'DIST'},
+                                 {'word': 'CAFE', 'classification': 'DESC'},
                                  ]
     save_words_list_classification(words_list_classification)
 
@@ -118,11 +123,11 @@ def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, 
                         'JJ KK TRANSPORT SERVICES INC.', 'J&J TRANSPORTATION SERVICES', 'JJ TRANSPORT',
                         'J & J TRANSPORT',
                         "J.J.'S HARDWOOD FLOORS AND DECORATING LTD.", 'THUNDERROAD.ORG INVESTMENTS INC.',
-                        'TRADEPRO/PHOENIX ENTERPRISES INC.','TEANOOK / JOHNSON HOLDINGS INC.',
+                        'TRADEPRO/PHOENIX ENTERPRISES INC.', 'TEANOOK / JOHNSON HOLDINGS INC.',
                         'COAST WIDE HOMECARE/PAINTING NEEDS LTD.', "BIG MIKE'S FUN FARM INC.",
                         'PJI PIZZA(POCO) LTD.', 'BEEDIE CH PROPERTY (LOT 3-22) INC.',
-                        'DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.', 'R R SOLUTIONS LTD.','ISLAND H20 SERVICES INC.',
-                        'MR RENT-A-CAR LTD.' ]
+                        'DISCOVERY RESIDENTIAL HOLDINGS (LOT 4) INC.', 'R R SOLUTIONS LTD.', 'ISLAND H20 SERVICES INC.',
+                        'MR RENT-A-CAR LTD.', 'MARKET CAFE LTD.']
     save_words_list_name(conflict_list_db)
 
     # create JWT & setup header with a Bearer Token using the JWT


### PR DESCRIPTION
*3921 #, Add Search Conflicts to Well Formed Name:*

*Description of changes:*
Names with word under the same category provided to check_name_is_well_formed function search for conflicts before sending a response for either ADDING DESCRIPTIVE or ADDING DISTINCTIVE. If the search conflicts execution ends up with a conflict then this would be the response of check name is well formed and continue the analysis. Then, search conflicts process will be skip. The final response includes the conflict found in check_name_is_well_formed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
