### PR TITLE
fixed-valid-sources-for-jobs

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -432,7 +432,6 @@ class Request(db.Model):
 
         return list_special_characters
 
-
 # set the source from NRO, Societis Online, Name Request
 @event.listens_for(Request, 'before_update')
 def set_source(mapper, connection, target):  # pylint: disable=unused-argument; SQLAlchemy callback signature
@@ -440,14 +439,15 @@ def set_source(mapper, connection, target):  # pylint: disable=unused-argument; 
     request = target
     soc_list = []
     soc_list = ['SO', 'ASO', 'CSO', 'RSO', 'CTSO', 'XSO', 'XCSO', 'XRSO', 'XASO', 'XCASO', 'CSSO']
+    so_source = ValidSources.SO.value
+    nro_source = ValidSources.NRO.value
 
     # comes from NRO/Societies Online
     if (request._source is None):
         if (request.requestTypeCd not in soc_list):
-            request._source = ValidSources.NRO.value  # pylint: disable=protected-access
+            request._source = nro_source  # pylint: disable=protected-access
         if (request.requestTypeCd in soc_list):
-            request._source = ValidSources.SO.value  # pylint: disable=protected-access
-
+            request._source = so_source  # pylint: disable=protected-access
 
 @event.listens_for(Request, 'before_insert')
 @event.listens_for(Request, 'before_update')


### PR DESCRIPTION
*Issue #, if available:*
ValidSources enum causes an psycopg error cant adapt on the event listener when you have to include namex-api as a requirement in another job.  This solves that problem.


*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
