### PR TITLE
4347 xpro back end bugs

### DIFF
--- a/api/namex/resources/auto_analyse/issues/abstract/analysis_response_issue.py
+++ b/api/namex/resources/auto_analyse/issues/abstract/analysis_response_issue.py
@@ -125,7 +125,7 @@ class AnalysisResponseIssue:
         if current_processed_token.find(current_original_token) == -1:
             return False, 0, 0, current_original_token
 
-        while len(original_tokens) >= 0:
+        while len(original_tokens) > 0:
             if token_string == processed_token:
                 break
 

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis.py
@@ -52,6 +52,7 @@ def validate_name_request(location, entity_type, request_action):
         AnalysisRequestActions.CHG.value,
         AnalysisRequestActions.CNV.value,
         AnalysisRequestActions.DBA.value,
+        AnalysisRequestActions.MVE.value,
         AnalysisRequestActions.REH.value,
         AnalysisRequestActions.REST.value,
         AnalysisRequestActions.REN.value

--- a/api/namex/services/name_request/auto_analyse/mixins/set_designation_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/set_designation_lists.py
@@ -62,12 +62,14 @@ class SetDesignationsListsMixin(object):
         entity_type = self.entity_type
 
         entity_type_code = None
-        if BCProtectedNameEntityTypes(entity_type):
+        if BCProtectedNameEntityTypes.has_value(entity_type) and BCProtectedNameEntityTypes(entity_type):
             entity_type_code = BCProtectedNameEntityTypes(entity_type)
-        elif BCUnprotectedNameEntityTypes(entity_type):
+        elif BCUnprotectedNameEntityTypes.has_value(entity_type) and BCUnprotectedNameEntityTypes(entity_type):
             entity_type_code = BCUnprotectedNameEntityTypes(entity_type)
-        elif XproUnprotectedNameEntityTypes(entity_type):
+        elif XproUnprotectedNameEntityTypes.has_value(entity_type) and XproUnprotectedNameEntityTypes(entity_type):
             entity_type_code = XproUnprotectedNameEntityTypes(entity_type)
+        else:
+            raise Exception('Could not set entity type user designations - entity type [' + entity_type + '] was not found in BC or XPRO entity types!')
 
         self._eng_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.ANY.value,

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -166,7 +166,7 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
 
         # We don't need to check for designations, so we're skipping that here...
 
-        check_special_words = builder.check_word_special_use(self.name_tokens, self.get_original_name())
+        check_special_words = builder.check_word_special_use(self.name_tokens, self.get_processed_name())
 
         if not check_special_words.is_valid:
             results.append(check_special_words)


### PR DESCRIPTION
*4347 #, XPRO BackEnd Bugs:*

*Description of changes:*

- MVE is added in XPRO analysis

- There is change required in FrontEnd, the request actions are not mapped correctly

- In word special use, configure issue is taking list_name which contains the list of processed name. Designations such as LLC are removed from processed name. However, there are some word special use which are related to designations such as LLC. As a result, when getting the word index is looking LLC in the processed name and fails to get the index. In Protected Names, the processed name is passed to word special use check, so we do not have this type of problems. The solution is to change original name for processed name

- get_next_token_if_composite function got cycle because the queue original_tokens was without elements but the condition stated that original_tokens can be equal than 0, so it never left the cycle.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
