### PR TITLE
Fix/4280-Remove additional filters.

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -105,7 +105,6 @@ class NameSchema(ma.ModelSchema):
     class Meta:
         model = Name
         fields = (
-            'id',
             'name',
             'state',
             'choice',

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -373,7 +373,7 @@ class Request(db.Model):
             criteria.append(RequestConditionCriteria(
                 fields=[Name.name, sqlalchemy.null().label('consumptionDate'), cls.submittedDate,
                         sqlalchemy.null().label('corpNum'), cls.nrNum],
-                filters=[basic_filters, not_consumed_filters]
+                filters=[basic_filters]
             ))
         else:
             criteria.append(RequestConditionCriteria(

--- a/api/namex/resources/auto_analyse/issues/corporate_name_conflict.py
+++ b/api/namex/resources/auto_analyse/issues/corporate_name_conflict.py
@@ -4,7 +4,6 @@ from string import Template
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
 # Import DTOs
-from tests.python.end_points.auto_analyse.protected_names import QUEUE_CONFLICT_MESSAGE
 from .abstract import AnalysisResponseIssue
 from ..response_objects import NameAnalysisIssue
 from ..response_objects import NameAction, NameActions, Conflict

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
@@ -90,4 +90,3 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
             assert_issues_count_is_gt(0, payload_lst)
             assert_correct_conflict(AnalysisIssueCodes.QUEUE_CONFLICT, payload_lst, expected)
             assert_additional_conflict_parameters(AnalysisIssueCodes.QUEUE_CONFLICT, payload_lst)
-            assert_conflict_message(AnalysisIssueCodes.QUEUE_CONFLICT, payload_lst, queue=True)

--- a/api/tests/python/end_points/common.py
+++ b/api/tests/python/end_points/common.py
@@ -166,11 +166,7 @@ def save_words_list_name(words_list, queue=False):
 
         nr = RequestDAO()
         nr.nrNum = nr_num
-        if queue:
-            nr.stateCd = State.DRAFT
-            nr.expirationDate = datetime.date.today() + datetime.timedelta(days=1)
-        else:
-            nr.stateCd = State.APPROVED
+        nr.stateCd = State.DRAFT if queue else State.APPROVED
         nr.requestId = req
         nr.requestTypeCd = EntityTypes.CORPORATION.value
         nr._source = 'NAMEREQUEST'

--- a/api/tests/python/end_points/common.py
+++ b/api/tests/python/end_points/common.py
@@ -119,20 +119,6 @@ def assert_additional_conflict_parameters(issue_type, issues):
     assert is_correct is True
 
 
-def assert_conflict_message(issue_type, issues, queue=False):
-    is_correct = False
-    for issue in issues:
-        if queue:
-            if issue.get('issue_type') == issue_type.value and (value['line1'] == QUEUE_CONFLICT_MESSAGE for value in
-                                                                issue.get('conflicts')):
-                is_correct = True
-        else:
-            if issue.get('issue_type') == issue_type.value and (value['line1'] == CORP_CONFLICT_MESSAGE for value in
-                                                                issue.get('conflicts')):
-                is_correct = True
-    assert is_correct is True
-
-
 def save_words_list_classification(words_list):
     from namex.models import WordClassification as WordClassificationDAO
     for record in words_list:


### PR DESCRIPTION
*4280 #, Remove additional filters:*

*Description of changes:*

- Remove  the following additional filters not needed:
   expirationDate > Today,
   corpNum is empty,
   consumptionDate is empty

- Corresponding updates in test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
