### PR TITLE
Feature/2983 search conflicts compressed clean name

### DIFF
--- a/api/namex/services/name_processing/mixins/get_synonym_lists.py
+++ b/api/namex/services/name_processing/mixins/get_synonym_lists.py
@@ -3,17 +3,7 @@ class GetSynonymListsMixin(object):
     _synonyms = []
     _substitutions = []
     _stop_words = []
-    # TODO: Arturo _number_words is declared in multiple files
     _number_words = []
-    #_designated_end_words = []
-    #_designated_any_words = []
-    #_designated_all_words = []
-
-    #_eng_designated_end_words = []
-    #_eng_designated_end_words = []
-
-    #_fr_designated_any_words = []
-    #_fr_designated_any_words = []
 
     def get_prefixes(self):
         return self._prefixes
@@ -30,25 +20,5 @@ class GetSynonymListsMixin(object):
     def get_number_words(self):
         return self._number_words
 
-    # def get_designated_end_words(self):
-    #     return self._designated_end_words
-    #
-    # def get_designated_any_words(self):
-    #     return self._designated_any_words
-    #
-    # def get_designated_all_words(self):
-    #     return self._designated_all_words
-    #
-    # def get_eng_designated_end_words(self):
-    #     return self._eng_designated_end_words
-    #
-    # def get_eng_designated_any_words(self):
-    #     return self._eng_designated_any_words
-    #
-    # def get_fr_designated_end_words(self):
-    #     return self._fr_designated_end_words
-    #
-    # def get_fr_designated_any_words(self):
-    #     return self._fr_designated_any_words
 
 

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -75,6 +75,10 @@ class NameProcessingService(GetSynonymListsMixin):
         self._name_tokens = val
 
     @property
+    def stop_words(self):
+        return self._stop_words
+
+    @property
     def word_classification_service(self):
         return self._word_classification_service
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -82,29 +82,17 @@ def list_distinctive_descriptive(name_list, dist_list, desc_list):
     return dist_list_all, desc_list_all
 
 
-def get_all_substitutions(syn_svc, list_dist, list_desc, list_name):
-    all_dist_substitutions_synonyms = syn_svc.get_all_substitutions_synonyms(
-        words=list_dist,
-        words_are_distinctive=True
-    ).data
-
-    dist_substitution_dict = parse_dict_of_lists(all_dist_substitutions_synonyms)
-
-    all_desc_substitutions_synonyms = syn_svc.get_all_substitutions_synonyms(
-        words=list_desc,
-        words_are_distinctive=False
-    ).data
-
-    desc_substitution_dict = parse_dict_of_lists(all_desc_substitutions_synonyms)
-
-    all_substitution_dict = collections.OrderedDict()
+def get_all_dict_substitutions(dist_substitution_dict, desc_substitution_dict, list_name):
+    all_substitution_dict = {}
     for word in list_name:
-        if word in dist_substitution_dict:
-            all_substitution_dict[word] = dist_substitution_dict[word]
-        elif word in desc_substitution_dict:
-            all_substitution_dict[word] = desc_substitution_dict[word]
+        key_dist = next((key for key, value in dist_substitution_dict.items() if word == key or word in value), None)
+        if key_dist:
+            all_substitution_dict[word] = dist_substitution_dict[key_dist]
+        key_desc = next((key for key, value in desc_substitution_dict.items() if word == key or word in value), None)
+        if key_desc:
+            all_substitution_dict[word] = desc_substitution_dict[key_desc]
 
-    return all_substitution_dict, dist_substitution_dict, desc_substitution_dict
+    return all_substitution_dict
 
 
 def get_distinctive_substitutions(syn_svc, list_dist):
@@ -219,4 +207,3 @@ def get_classification(service, syn_svc, match, wc_svc, token_svc):
                                                           service.get_list_dist(),
                                                           service.get_list_desc())
     print(service.get_dict_name())
-

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -189,12 +189,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
 
                 for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
-                    list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
-                                                                 dict_highest_counter,
-                                                                 change_filter, list_name_compound, check_name_is_well_formed,
-                                                                 queue)
-                    if list_details:
-                        return list_details, forced
+                    list_details_compound, forced = self.get_conflicts_db(dist_dict, desc_dict,
+                                                                          dict_highest_counter,
+                                                                          change_filter, list_name_compound,
+                                                                          check_name_is_well_formed,
+                                                                          queue)
+                    if list_details_compound:
+                        return list_details_compound, forced
 
         return list_details, forced
 
@@ -618,6 +619,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         ).data
 
         desc_synonym_dict = parse_dict_of_lists(all_desc_substitutions_synonyms)
+
+        for key, value in desc_synonym_dict.items():
+            if key not in value:
+                desc_synonym_list = desc_synonym_dict.get(key)
+                desc_synonym_list.append(key)
+                desc_synonym_dict[key] = desc_synonym_list
+
         return desc_synonym_dict
 
     def check_name_is_well_formed_response(self, list_original_name, list_name, list_dist, result_code):
@@ -767,4 +775,3 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             list_dict_desc_compound.append(dict_desc_compound)
 
         return list_dict_desc_compound
-

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -182,8 +182,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         if not forced:
             print("Search for conflicts considering compound words.")
-            dict_compound_dist, dict_desc, list_name_compound = self.get_compound_words(dist_substitution_dict,
-                                                                                        desc_synonym_dict, list_name)
+            dict_compound_dist = self.get_compound_words(dist_substitution_dict, desc_synonym_dict, list_name)
             if dict_compound_dist:
                 dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
                 desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
@@ -191,7 +190,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
                     list_details_compound, forced = self.get_conflicts_db(dist_dict, desc_dict,
                                                                           dict_highest_counter,
-                                                                          change_filter, list_name_compound,
+                                                                          change_filter,
+                                                                          list(dict_compound_dist.keys()),
                                                                           check_name_is_well_formed,
                                                                           queue)
                     if list_details_compound:
@@ -697,13 +697,21 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return result
 
     '''
+    Input:
+    dict_dist: {'victoria': ['victoria'], 
+                 'south': ['south']}
+    dict_desc: {'land': ['emigr', 'emigra', 'imigr', ..., 'structur'], 
+                'developers': ['abod', 'acr', 'build', 'builder', ...,'structur', 'developers']}  
+    list_name: ['victoria', 'south', 'land', 'developers']
     
+    Output:
+    dict_compound_dist: {'victoriasouth': ['victoriasouth'], 
+                         'southland': ['southemigr', 'southemigra', 'southimigr', ..., 'southstructur']}        
     '''
 
     def get_compound_words(self, dict_dist, dict_descriptive, list_name):
         dict_compound_dist = {}
         dict_desc = dict(dict_descriptive)
-        list_name_compound = []
         for idx, elem in enumerate(list_name[:-1]):
             a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else None
             next_idx = idx + 1
@@ -715,12 +723,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     compound.append(''.join(item))
                     dict_compound_dist[list_name[idx] + list_name[next_idx]] = compound
 
-                list_name_compound.append(list_name[idx] + list_name[next_idx])
-
                 if list_name[next_idx] in dict_desc:
                     del dict_desc[list_name[next_idx]]
 
-        return dict_compound_dist, dict_desc, list_name_compound
+        return dict_compound_dist
 
     def get_dictionary(self, dct, lst):
         for elem in lst:

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -117,9 +117,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         result = ProcedureResult()
         result.is_valid = True
 
-        # TODO: Arturo plz check the word against the list, provide it as an input for word_condition_service.get_words_to_avoid()
-        all_words_to_avoid_list = self.word_condition_service.get_words_to_avoid()
-        all_words_to_avoid_list = [word.lower() for word in all_words_to_avoid_list]
+        all_words_to_avoid_list = [word.lower() for word in self.word_condition_service.get_words_to_avoid()]
         all_words_to_avoid_list.sort(key=len, reverse=True)
 
         word_avoid_alternators = '|'.join(map(re.escape, all_words_to_avoid_list))

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -622,9 +622,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         for key, value in desc_synonym_dict.items():
             if key not in value:
-                desc_synonym_list = desc_synonym_dict.get(key)
-                desc_synonym_list.append(key)
-                desc_synonym_dict[key] = desc_synonym_list
+                value.append(key)
 
         return desc_synonym_dict
 
@@ -709,7 +707,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 idx += 1
                 a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
 
-            if idx + 1 < len(list_name[:-1]):
+            if idx + 1 < len(list_name):
                 b = dict_dist[list_name[idx + 1]] if list_name[idx + 1] in dict_dist else dict_desc[list_name[idx + 1]]
                 if a in dict_dist.values():
                     compound = []

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -184,16 +184,17 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             print("Search for conflicts considering compound words.")
             dict_compound_dist, dict_desc, list_name_compound = self.compound_words(dist_substitution_dict,
                                                                                     desc_synonym_dict, list_name)
-            dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
-            desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
+            if dict_compound_dist:
+                dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
+                desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
 
-            for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
-                list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
-                                                             dict_highest_counter,
-                                                             change_filter, list_name_compound, check_name_is_well_formed,
-                                                             queue)
-                if list_details:
-                    return list_details, forced
+                for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
+                    list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
+                                                                 dict_highest_counter,
+                                                                 change_filter, list_name_compound, check_name_is_well_formed,
+                                                                 queue)
+                    if list_details:
+                        return list_details, forced
 
         return list_details, forced
 
@@ -700,7 +701,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 idx += 1
                 a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
 
-            if idx + 1 < len(list_name):
+            if idx + 1 < len(list_name[:-1]):
                 b = dict_dist[list_name[idx + 1]] if list_name[idx + 1] in dict_dist else dict_desc[list_name[idx + 1]]
                 if a in dict_dist.values():
                     compound = []

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -147,13 +147,11 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def search_conflicts(self, list_dist_words, list_desc_words, list_name, name, check_name_is_well_formed=False,
                          queue=False):
-        result = ProcedureResult()
         list_conflicts, most_similar_names = [], []
         dict_highest_counter, response = {}, {}
 
         for w_dist, w_desc in zip(list_dist_words, list_desc_words):
             if w_dist and w_desc:
-                print(w_dist, ":DIST ", w_desc, ":DESC")
                 list_details, forced = self.get_conflicts(dict_highest_counter, w_dist, w_desc, list_name,
                                                           check_name_is_well_formed, queue)
                 list_conflicts.extend(list_details)
@@ -166,10 +164,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             sorted(list_conflicts, key=lambda item: (-item['score'], item['name']))[
             0:MAX_MATCHES_LIMIT])
 
-        if most_similar_names:
-            result = self.prepare_response(most_similar_names, queue, list_name, list_dist_words, list_desc_words)
-
-        return result
+        return self.prepare_response(most_similar_names, queue, list_name, list_dist_words, list_desc_words)
 
     def get_conflicts(self, dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed, queue):
         dist_substitution_dict, desc_synonym_dict, dist_substitution_compound_dict, desc_synonym_compound_dict = {}, {}, {}, {}
@@ -185,17 +180,22 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         list_details, forced = self.get_conflicts_db(dist_substitution_dict, desc_synonym_dict, dict_highest_counter,
                                                      change_filter, list_name, check_name_is_well_formed, queue)
 
-        if not list_details and not forced:
+        if not forced:
             print("Search for conflicts considering compound words.")
-            dist_substitution_compound_dict, desc_synonym_compound_dict, list_name_compound = self.compound_words(
-                dist_substitution_dict,
-                desc_synonym_dict,
-                list_name)
+            dict_compound_dist, dict_desc, list_name_compound = self.compound_words(dist_substitution_dict,
+                                                                                    desc_synonym_dict, list_name)
+            dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
+            desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
 
-            return self.get_conflicts_db(dist_substitution_compound_dict, desc_synonym_compound_dict,
-                                         dict_highest_counter,
-                                         change_filter, list_name_compound, check_name_is_well_formed,
-                                         queue)
+            for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
+                list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
+                                                             dict_highest_counter,
+                                                             change_filter, list_name_compound, check_name_is_well_formed,
+                                                             queue)
+                if list_details:
+                    return list_details, forced
+
+        return list_details, forced
 
     def get_conflicts_db(self, dist_substitution_dict, desc_synonym_dict, dict_highest_counter, change_filter,
                          list_name, check_name_is_well_formed, queue):
@@ -211,12 +211,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         else:
             print("Search conflicts for APPROVED, CONDITIONAL, COND_RESERVED, RESERVED")
 
-        for dist in dist_substitution_dict.values():
+        for key_dist, value_dist in dist_substitution_dict.items():
             criteria = Request.get_general_query(change_filter, queue)
-            criteria = Request.get_distinctive_query(dist, criteria, stop_words, check_name_is_well_formed)
-            for desc in desc_synonym_dict.values():
-                print(dist, ":DIST ", desc, ":DESC")
-                criteria = Request.get_descriptive_query(desc, criteria, queue)
+            criteria = Request.get_distinctive_query(value_dist, criteria, stop_words, check_name_is_well_formed)
+            for key_desc, value_desc in desc_synonym_dict.items():
+                print(key_dist, ":DIST ", key_desc, ":DESC")
+                criteria = Request.get_descriptive_query(value_desc, criteria, queue)
                 matches = Request.find_by_criteria_array(criteria, queue)
                 list_conflicts_details, forced = self.get_most_similar_names(
                     dict_highest_counter,
@@ -431,7 +431,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def get_most_similar_names(self, dict_highest_counter, matches, dist_substitution_dict, desc_synonym_dict,
                                list_name):
-        list_details, selected_matches = [],[]
+        list_details, selected_matches = [], []
         dict_matches_counter = {}
         forced = False
         list_dist = list(dist_substitution_dict.keys())
@@ -443,19 +443,25 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             wc_svc = service.word_classification_service
             token_svc = service.token_classifier_service
 
-            print(list_dist, ": DIST ", list_desc, ": DESC")
+            total = len(matches)
+            print("Possible conflicts returned: ", total)
 
             vector1_dist = self.text_to_vector(list_dist)
             vector1_desc = self.text_to_vector(list_desc)
+
+            num = 1
             for match in matches:
+                print(num, '/', total)
                 np_svc.set_name(match.name)
+                num += 1
                 if np_svc.name_tokens == list_name:
                     similarity = EXACT_MATCH
                 else:
                     match_list = np_svc.name_tokens
                     get_classification(service, syn_svc, match_list, wc_svc, token_svc)
 
-                    vector2_dist, entropy_dist = self.get_vector(service.get_list_dist(), list_dist,dist_substitution_dict)
+                    vector2_dist, entropy_dist = self.get_vector(service.get_list_dist(), list_dist,
+                                                                 dist_substitution_dict)
                     similarity_dist = round(self.get_similarity(vector1_dist, vector2_dist, entropy_dist), 2)
 
                     vector2_desc, entropy_desc = self.get_vector(service.get_list_desc(), list_desc, desc_synonym_dict)
@@ -704,8 +710,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     list_name_compound.append(list_name[idx] + list_name[idx + 1])
                     if list_name[idx + 1] in dict_desc:
                         del dict_desc[list_name[idx + 1]]
-            else:
-                list_name_compound.append(list_name[idx])
 
         return dict_compound_dist, dict_desc, list_name_compound
 
@@ -713,3 +717,53 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         for elem in lst:
             dct[elem] = [elem]
         return dct
+
+    '''
+    Inputs:
+    list_name_compound: ['victoriasouth', 'southland']
+    dist_dict: {'victoria': ['victoria'], 'south': ['south']}
+    dict_compound_dist: {'victoriasouth': ['victoriasouth'], 
+                         'southland': ['southemigr', 'southemigra', 'southimigr', 'southimigra', ... , 'southstructur']}
+    
+    Output:
+    list_dict_dist_compound: [
+                               {'victoriasouth': ['victoriasouth']}, 
+                               {'southland': ['southemigr', 'southemigra', ..., 'southstructur']}]
+    '''
+
+    def get_distinctive_compounds(self, dict_compound_dist):
+        list_dict_dist_compound = []
+        for key, value in dict_compound_dist.items():
+            list_dict_dist_compound.append({key: value})
+
+        return list_dict_dist_compound
+
+    '''
+    Input:
+    dist_list_compound: [{'victoriasouth': ['victoriasouth']}, 
+                         {'southland': ['southemigr', 'southemigra', 'southimigr', ... , 'southstructur']}
+                        ]
+    desc_dict={'land': ['emigr', 'emigra', 'imigr', ..., 'structur'], 
+               'developers': ['abod', 'acr', 'build', 'builder', ... , 'structur']}
+    
+    Output:
+    list_dict_desc_compound: [{'land': ['emigr', 'emigra', 'imigr', ..., 'structur'], 
+                               'developers': ['abod', 'acr', 'build', 'builder', ... , 'structur']}, 
+                              {'developers': ['abod', 'acr', 'build', 'builder', ... , 'structur']}]
+    
+    
+    '''
+
+    def get_descriptive_compounds(self, dist_list_compound, desc_dict):
+        list_dict_desc_compound = []
+        desc_list = list(desc_dict.keys())
+        for compound_names in dist_list_compound:
+            dict_desc_compound = {}
+            for desc in desc_list:
+                key_desc = "".join([desc for name in compound_names if desc not in name])
+                if key_desc.__len__() > 0:
+                    dict_desc_compound[key_desc] = desc_dict.get(key_desc)
+            list_dict_desc_compound.append(dict_desc_compound)
+
+        return list_dict_desc_compound
+

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -182,8 +182,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         if not forced:
             print("Search for conflicts considering compound words.")
-            dict_compound_dist, dict_desc, list_name_compound = self.compound_words(dist_substitution_dict,
-                                                                                    desc_synonym_dict, list_name)
+            dict_compound_dist, dict_desc, list_name_compound = self.get_compound_words(dist_substitution_dict,
+                                                                                        desc_synonym_dict, list_name)
             if dict_compound_dist:
                 dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
                 desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
@@ -696,27 +696,29 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         }
         return result
 
-    def compound_words(self, dict_dist, dict_descriptive, list_name):
+    '''
+    
+    '''
+
+    def get_compound_words(self, dict_dist, dict_descriptive, list_name):
         dict_compound_dist = {}
         dict_desc = dict(dict_descriptive)
         list_name_compound = []
         for idx, elem in enumerate(list_name[:-1]):
-            try:
-                a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
-            except KeyError:
-                idx += 1
-                a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
+            a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else None
+            next_idx = idx + 1
+            if a and next_idx < len(list_name):
+                b = dict_dist[list_name[next_idx]] if list_name[next_idx] in dict_dist else dict_desc[list_name[next_idx]]
+                compound = []
 
-            if idx + 1 < len(list_name):
-                b = dict_dist[list_name[idx + 1]] if list_name[idx + 1] in dict_dist else dict_desc[list_name[idx + 1]]
-                if a in dict_dist.values():
-                    compound = []
-                    for item in itertools.product(a, b):
-                        compound.append(''.join(item))
-                        dict_compound_dist[list_name[idx] + list_name[idx + 1]] = compound
-                    list_name_compound.append(list_name[idx] + list_name[idx + 1])
-                    if list_name[idx + 1] in dict_desc:
-                        del dict_desc[list_name[idx + 1]]
+                for item in itertools.product(a, b):
+                    compound.append(''.join(item))
+                    dict_compound_dist[list_name[idx] + list_name[next_idx]] = compound
+
+                list_name_compound.append(list_name[idx] + list_name[next_idx])
+
+                if list_name[next_idx] in dict_desc:
+                    del dict_desc[list_name[next_idx]]
 
         return dict_compound_dist, dict_desc, list_name_compound
 
@@ -726,7 +728,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return dct
 
     '''
-    Inputs:
+    Input:
     list_name_compound: ['victoriasouth', 'southland']
     dist_dict: {'victoria': ['victoria'], 'south': ['south']}
     dict_compound_dist: {'victoriasouth': ['victoriasouth'], 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -1,6 +1,6 @@
 import re
 import itertools
-from . import porter, STEM_W, OTHER_W, SUBS_W, STEM_COS_W, SUBS_COS_W, EXACT_MATCH, MINIMUM_SIMILARITY, \
+from . import porter, STEM_W, OTHER_W, SUBS_W, EXACT_MATCH, MINIMUM_SIMILARITY, \
     HIGH_CONFLICT_RECORDS, HIGH_SIMILARITY
 import math
 from collections import Counter

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -697,16 +697,11 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return result
 
     '''
-    Input:
-    dict_dist: {'victoria': ['victoria'], 
-                 'south': ['south']}
-    dict_desc: {'land': ['emigr', 'emigra', 'imigr', ..., 'structur'], 
-                'developers': ['abod', 'acr', 'build', 'builder', ...,'structur', 'developers']}  
-    list_name: ['victoria', 'south', 'land', 'developers']
-    
-    Output:
-    dict_compound_dist: {'victoriasouth': ['victoriasouth'], 
-                         'southland': ['southemigr', 'southemigra', 'southimigr', ..., 'southstructur']}        
+    dict_dist: Dictionary of distinctive tokens with its corresponding substitutions (if they exist) included in a list.
+    dict_desc: Dictionary of descriptive tokens with its corresponding substitutions (if they exist) included in a list.
+    list_name: List of words which form a clean name
+    @return dict_compound_dist: dictionary of compound distinctive items (made of two words) with its corresponding 
+    substitutions (if they exist) included as list
     '''
 
     def get_compound_words(self, dict_dist, dict_descriptive, list_name):
@@ -734,16 +729,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return dct
 
     '''
-    Input:
-    list_name_compound: ['victoriasouth', 'southland']
-    dist_dict: {'victoria': ['victoria'], 'south': ['south']}
-    dict_compound_dist: {'victoriasouth': ['victoriasouth'], 
-                         'southland': ['southemigr', 'southemigra', 'southimigr', 'southimigra', ... , 'southstructur']}
-    
-    Output:
-    list_dict_dist_compound: [
-                               {'victoriasouth': ['victoriasouth']}, 
-                               {'southland': ['southemigr', 'southemigra', ..., 'southstructur']}]
+    dict_compound_dist: Dictionary of all valid compound words
+    @return list_dict_dist_compound: Dictionary is added to the list list_dict_dist_compound for further analysis.
     '''
 
     def get_distinctive_compounds(self, dict_compound_dist):
@@ -754,25 +741,16 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return list_dict_dist_compound
 
     '''
-    Input:
-    dist_list_compound: [{'victoriasouth': ['victoriasouth']}, 
-                         {'southland': ['southemigr', 'southemigra', 'southimigr', ... , 'southstructur']}
-                        ]
-    desc_dict={'land': ['emigr', 'emigra', 'imigr', ..., 'structur'], 
-               'developers': ['abod', 'acr', 'build', 'builder', ... , 'structur']}
-    
-    Output:
-    list_dict_desc_compound: [{'land': ['emigr', 'emigra', 'imigr', ..., 'structur'], 
-                               'developers': ['abod', 'acr', 'build', 'builder', ... , 'structur']}, 
-                              {'developers': ['abod', 'acr', 'build', 'builder', ... , 'structur']}]
-    
-    
+    list_dict_compound: List of dictionary including all compound words and its substitutions as list.
+    desc_dict: Dictionary of descriptive elements with its substitutions.
+    @return list_dict_desc_compound: List of dictionary of descriptive items with its corresponding substitutions 
+    (if they exist) included as list
     '''
 
-    def get_descriptive_compounds(self, dist_list_compound, desc_dict):
+    def get_descriptive_compounds(self, list_dict_compound, desc_dict):
         list_dict_desc_compound = []
         desc_list = list(desc_dict.keys())
-        for compound_names in dist_list_compound:
+        for compound_names in list_dict_compound:
             dict_desc_compound = {}
             for desc in desc_list:
                 key_desc = "".join([desc for name in compound_names if desc not in name])


### PR DESCRIPTION
*2983 #, Search for Conflicts compressed clean name:*

*Description of changes:*
Implementation of additional search using compressed version of distinctive items adding up to one descriptive. For instance, consider the following scenarios:

name                                    distinctive               descriptive               compound distinctive                        match
south land development   [south, land]           [development ]      [southland, landdevelopment]         southland development
south land ventures           [south, land]           [ventures]              [southland, landventures]                south landventures


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
