### PR TITLE
feature/2983 search conflicts compressed clean name v2

### DIFF
--- a/api/namex/services/name_processing/mixins/get_synonym_lists.py
+++ b/api/namex/services/name_processing/mixins/get_synonym_lists.py
@@ -3,17 +3,7 @@ class GetSynonymListsMixin(object):
     _synonyms = []
     _substitutions = []
     _stop_words = []
-    # TODO: Arturo _number_words is declared in multiple files
     _number_words = []
-    #_designated_end_words = []
-    #_designated_any_words = []
-    #_designated_all_words = []
-
-    #_eng_designated_end_words = []
-    #_eng_designated_end_words = []
-
-    #_fr_designated_any_words = []
-    #_fr_designated_any_words = []
 
     def get_prefixes(self):
         return self._prefixes
@@ -30,25 +20,5 @@ class GetSynonymListsMixin(object):
     def get_number_words(self):
         return self._number_words
 
-    # def get_designated_end_words(self):
-    #     return self._designated_end_words
-    #
-    # def get_designated_any_words(self):
-    #     return self._designated_any_words
-    #
-    # def get_designated_all_words(self):
-    #     return self._designated_all_words
-    #
-    # def get_eng_designated_end_words(self):
-    #     return self._eng_designated_end_words
-    #
-    # def get_eng_designated_any_words(self):
-    #     return self._eng_designated_any_words
-    #
-    # def get_fr_designated_end_words(self):
-    #     return self._fr_designated_end_words
-    #
-    # def get_fr_designated_any_words(self):
-    #     return self._fr_designated_any_words
 
 

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -75,6 +75,10 @@ class NameProcessingService(GetSynonymListsMixin):
         self._name_tokens = val
 
     @property
+    def stop_words(self):
+        return self._stop_words
+
+    @property
     def word_classification_service(self):
         return self._word_classification_service
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -82,29 +82,17 @@ def list_distinctive_descriptive(name_list, dist_list, desc_list):
     return dist_list_all, desc_list_all
 
 
-def get_all_substitutions(syn_svc, list_dist, list_desc, list_name):
-    all_dist_substitutions_synonyms = syn_svc.get_all_substitutions_synonyms(
-        words=list_dist,
-        words_are_distinctive=True
-    ).data
-
-    dist_substitution_dict = parse_dict_of_lists(all_dist_substitutions_synonyms)
-
-    all_desc_substitutions_synonyms = syn_svc.get_all_substitutions_synonyms(
-        words=list_desc,
-        words_are_distinctive=False
-    ).data
-
-    desc_substitution_dict = parse_dict_of_lists(all_desc_substitutions_synonyms)
-
-    all_substitution_dict = collections.OrderedDict()
+def get_all_dict_substitutions(dist_substitution_dict, desc_substitution_dict, list_name):
+    all_substitution_dict = {}
     for word in list_name:
-        if word in dist_substitution_dict:
-            all_substitution_dict[word] = dist_substitution_dict[word]
-        elif word in desc_substitution_dict:
-            all_substitution_dict[word] = desc_substitution_dict[word]
+        key_dist = next((key for key, value in dist_substitution_dict.items() if word == key or word in value), None)
+        if key_dist:
+            all_substitution_dict[word] = dist_substitution_dict[key_dist]
+        key_desc = next((key for key, value in desc_substitution_dict.items() if word == key or word in value), None)
+        if key_desc:
+            all_substitution_dict[word] = desc_substitution_dict[key_desc]
 
-    return all_substitution_dict, dist_substitution_dict, desc_substitution_dict
+    return all_substitution_dict
 
 
 def get_distinctive_substitutions(syn_svc, list_dist):
@@ -219,4 +207,3 @@ def get_classification(service, syn_svc, match, wc_svc, token_svc):
                                                           service.get_list_dist(),
                                                           service.get_list_desc())
     print(service.get_dict_name())
-

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -117,9 +117,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         result = ProcedureResult()
         result.is_valid = True
 
-        # TODO: Arturo plz check the word against the list, provide it as an input for word_condition_service.get_words_to_avoid()
-        all_words_to_avoid_list = self.word_condition_service.get_words_to_avoid()
-        all_words_to_avoid_list = [word.lower() for word in all_words_to_avoid_list]
+        all_words_to_avoid_list = [word.lower() for word in self.word_condition_service.get_words_to_avoid()]
         all_words_to_avoid_list.sort(key=len, reverse=True)
 
         word_avoid_alternators = '|'.join(map(re.escape, all_words_to_avoid_list))

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -182,8 +182,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         if not forced:
             print("Search for conflicts considering compound words.")
-            dict_compound_dist, dict_desc, list_name_compound = self.compound_words(dist_substitution_dict,
-                                                                                    desc_synonym_dict, list_name)
+            dict_compound_dist, dict_desc, list_name_compound = self.get_compound_words(dist_substitution_dict,
+                                                                                        desc_synonym_dict, list_name)
             if dict_compound_dist:
                 dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
                 desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
@@ -696,27 +696,29 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         }
         return result
 
-    def compound_words(self, dict_dist, dict_descriptive, list_name):
+    '''
+    
+    '''
+
+    def get_compound_words(self, dict_dist, dict_descriptive, list_name):
         dict_compound_dist = {}
         dict_desc = dict(dict_descriptive)
         list_name_compound = []
         for idx, elem in enumerate(list_name[:-1]):
-            try:
-                a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
-            except KeyError:
-                idx += 1
-                a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
+            a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else None
+            next_idx = idx + 1
+            if a and next_idx < len(list_name):
+                b = dict_dist[list_name[next_idx]] if list_name[next_idx] in dict_dist else dict_desc[list_name[next_idx]]
+                compound = []
 
-            if idx + 1 < len(list_name):
-                b = dict_dist[list_name[idx + 1]] if list_name[idx + 1] in dict_dist else dict_desc[list_name[idx + 1]]
-                if a in dict_dist.values():
-                    compound = []
-                    for item in itertools.product(a, b):
-                        compound.append(''.join(item))
-                        dict_compound_dist[list_name[idx] + list_name[idx + 1]] = compound
-                    list_name_compound.append(list_name[idx] + list_name[idx + 1])
-                    if list_name[idx + 1] in dict_desc:
-                        del dict_desc[list_name[idx + 1]]
+                for item in itertools.product(a, b):
+                    compound.append(''.join(item))
+                    dict_compound_dist[list_name[idx] + list_name[next_idx]] = compound
+
+                list_name_compound.append(list_name[idx] + list_name[next_idx])
+
+                if list_name[next_idx] in dict_desc:
+                    del dict_desc[list_name[next_idx]]
 
         return dict_compound_dist, dict_desc, list_name_compound
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -622,9 +622,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         for key, value in desc_synonym_dict.items():
             if key not in value:
-                desc_synonym_list = desc_synonym_dict.get(key)
-                desc_synonym_list.append(key)
-                desc_synonym_dict[key] = desc_synonym_list
+                value.append(key)
 
         return desc_synonym_dict
 
@@ -709,7 +707,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 idx += 1
                 a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
 
-            if idx + 1 < len(list_name[:-1]):
+            if idx + 1 < len(list_name):
                 b = dict_dist[list_name[idx + 1]] if list_name[idx + 1] in dict_dist else dict_desc[list_name[idx + 1]]
                 if a in dict_dist.values():
                     compound = []

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -184,16 +184,17 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             print("Search for conflicts considering compound words.")
             dict_compound_dist, dict_desc, list_name_compound = self.compound_words(dist_substitution_dict,
                                                                                     desc_synonym_dict, list_name)
-            dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
-            desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
+            if dict_compound_dist:
+                dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
+                desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
 
-            for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
-                list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
-                                                             dict_highest_counter,
-                                                             change_filter, list_name_compound, check_name_is_well_formed,
-                                                             queue)
-                if list_details:
-                    return list_details, forced
+                for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
+                    list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
+                                                                 dict_highest_counter,
+                                                                 change_filter, list_name_compound, check_name_is_well_formed,
+                                                                 queue)
+                    if list_details:
+                        return list_details, forced
 
         return list_details, forced
 
@@ -700,7 +701,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 idx += 1
                 a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else dict_desc[list_name[idx]]
 
-            if idx + 1 < len(list_name):
+            if idx + 1 < len(list_name[:-1]):
                 b = dict_dist[list_name[idx + 1]] if list_name[idx + 1] in dict_dist else dict_desc[list_name[idx + 1]]
                 if a in dict_dist.values():
                     compound = []

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -1,6 +1,6 @@
 import re
 import itertools
-from . import porter, STEM_W, OTHER_W, SUBS_W, STEM_COS_W, SUBS_COS_W, EXACT_MATCH, MINIMUM_SIMILARITY, \
+from . import porter, STEM_W, OTHER_W, SUBS_W, EXACT_MATCH, MINIMUM_SIMILARITY, \
     HIGH_CONFLICT_RECORDS, HIGH_SIMILARITY
 import math
 from collections import Counter

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -182,8 +182,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         if not forced:
             print("Search for conflicts considering compound words.")
-            dict_compound_dist, dict_desc, list_name_compound = self.get_compound_words(dist_substitution_dict,
-                                                                                        desc_synonym_dict, list_name)
+            dict_compound_dist = self.get_compound_words(dist_substitution_dict, desc_synonym_dict, list_name)
             if dict_compound_dist:
                 dist_list_dict_compound = self.get_distinctive_compounds(dict_compound_dist)
                 desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
@@ -191,7 +190,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
                     list_details_compound, forced = self.get_conflicts_db(dist_dict, desc_dict,
                                                                           dict_highest_counter,
-                                                                          change_filter, list_name_compound,
+                                                                          change_filter,
+                                                                          list(dict_compound_dist.keys()),
                                                                           check_name_is_well_formed,
                                                                           queue)
                     if list_details_compound:
@@ -697,13 +697,16 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return result
 
     '''
-    
+    dict_dist: Dictionary of distinctive tokens with its corresponding substitutions (if they exist) included in a list.
+    dict_desc: Dictionary of descriptive tokens with its corresponding substitutions (if they exist) included in a list.
+    list_name: List of words which form a clean name
+    @return dict_compound_dist: dictionary of compound distinctive items (made of two words) with its corresponding 
+    substitutions (if they exist) included as list
     '''
 
     def get_compound_words(self, dict_dist, dict_descriptive, list_name):
         dict_compound_dist = {}
         dict_desc = dict(dict_descriptive)
-        list_name_compound = []
         for idx, elem in enumerate(list_name[:-1]):
             a = dict_dist[list_name[idx]] if list_name[idx] in dict_dist else None
             next_idx = idx + 1
@@ -715,12 +718,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     compound.append(''.join(item))
                     dict_compound_dist[list_name[idx] + list_name[next_idx]] = compound
 
-                list_name_compound.append(list_name[idx] + list_name[next_idx])
-
                 if list_name[next_idx] in dict_desc:
                     del dict_desc[list_name[next_idx]]
 
-        return dict_compound_dist, dict_desc, list_name_compound
+        return dict_compound_dist
 
     def get_dictionary(self, dct, lst):
         for elem in lst:

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -189,12 +189,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 desc_list_dict_compound = self.get_descriptive_compounds(dist_list_dict_compound, desc_synonym_dict)
 
                 for dist_dict, desc_dict in zip(dist_list_dict_compound, desc_list_dict_compound):
-                    list_details, forced = self.get_conflicts_db(dist_dict, desc_dict,
-                                                                 dict_highest_counter,
-                                                                 change_filter, list_name_compound, check_name_is_well_formed,
-                                                                 queue)
-                    if list_details:
-                        return list_details, forced
+                    list_details_compound, forced = self.get_conflicts_db(dist_dict, desc_dict,
+                                                                          dict_highest_counter,
+                                                                          change_filter, list_name_compound,
+                                                                          check_name_is_well_formed,
+                                                                          queue)
+                    if list_details_compound:
+                        return list_details_compound, forced
 
         return list_details, forced
 
@@ -618,6 +619,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         ).data
 
         desc_synonym_dict = parse_dict_of_lists(all_desc_substitutions_synonyms)
+
+        for key, value in desc_synonym_dict.items():
+            if key not in value:
+                desc_synonym_list = desc_synonym_dict.get(key)
+                desc_synonym_list.append(key)
+                desc_synonym_dict[key] = desc_synonym_list
+
         return desc_synonym_dict
 
     def check_name_is_well_formed_response(self, list_original_name, list_name, list_dist, result_code):
@@ -750,4 +758,3 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             list_dict_desc_compound.append(dict_desc_compound)
 
         return list_dict_desc_compound
-


### PR DESCRIPTION
*#2983, Search for Conflicts compressed clean name:*

*Description of changes:*
Implementation of additional search using compressed version of distinctive items adding up to one descriptive. For instance, consider the following scenarios:

name distinctive descriptive compound distinctive match
south land development [south, land] [development ] [southland, landdevelopment] southland development
south land ventures [south, land] [ventures] [southland, landventures] south landventures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
