### PR TITLE
temp fix fo oracle probelm so we dont keep creating bad data

### DIFF
--- a/api/namex/services/nro/change_nr.py
+++ b/api/namex/services/nro/change_nr.py
@@ -18,7 +18,7 @@ from namex.models import State
 from namex.constants import NROChangeFlags
 
 
-def update_nr(nr, ora_cursor, change_flags):
+def update_nr(nr, ora_cursor, change_flags,con):
     """Update the Name Request in NRO
     :raises Exception: what ever error we get, let our caller handle, this is here in case we want to wrap it - future
     """
@@ -27,9 +27,15 @@ def update_nr(nr, ora_cursor, change_flags):
     current_app.logger.debug('got to update_nr() for NR:{}'.format(nr.nrNum))
     current_app.logger.debug('event ID for NR Details edit:{}'.format(eid))
     _create_nro_transaction(ora_cursor, nr, eid, transaction_type='CORRT')
+    con.commit()
+
     _update_nro_request_state(ora_cursor, nr, eid, change_flags)
+    con.commit()
+
     _update_request(ora_cursor, nr, eid, change_flags)
+    con.commit()
     _update_nro_names(ora_cursor, nr, eid, change_flags)
+    con.commit()
     _update_nro_address(ora_cursor, nr, eid, change_flags)
     _update_nro_partner_name_system(ora_cursor, nr, eid, change_flags)
     _update_consent(ora_cursor, nr, eid, change_flags)

--- a/api/namex/services/nro/oracle_services.py
+++ b/api/namex/services/nro/oracle_services.py
@@ -317,7 +317,7 @@ class NROServices(object):
             con.begin()  # explicit transaction in case we need to do other things than just call the stored proc
 
             cursor = con.cursor()
-            update_nr(nr, cursor, change_flags)
+            update_nr(nr, cursor, change_flags,con)
 
             con.commit()
 
@@ -348,7 +348,7 @@ class NROServices(object):
             con.begin()  # explicit transaction in case we need to do other things than just call the stored proc
 
             cursor = con.cursor()
-            new_nr(nr, cursor)
+            new_nr(nr, cursor,con)
 
             con.commit()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A temporary workaround to solve oracle namesd connection issue until a permanent solution can be created.  One will be to update the add_nr and chnage_nr for better error handling/trapping as well as multiple commits.  May use the return syntax as well the server SDU size needs to be increased and the client connection we also need to add an SDU parameters in the cx_oracle connection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
