### PR TITLE
fixed reapply to extend the expiry date for REH and REN request actions

### DIFF
--- a/api/namex/resources/name_requests/name_request.py
+++ b/api/namex/resources/name_requests/name_request.py
@@ -361,7 +361,7 @@ class NameRequestFields(NameRequestResource):
         nr_svc = self.nr_service
 
         if nr_model.submitCount < 3:
-            if nr_svc.request_action in [RequestAction.REH.value, RequestAction.REN.value]:
+            if nr_model.request_action_cd in [RequestAction.REH.value, RequestAction.REN.value]:
                 # If request action is REH or REST extend by 1 year (+ 56 default) days
                 nr_model = nr_svc.extend_expiry_date(nr_model, (datetime.utcnow() + relativedelta(years=1)))
                 nr_model = nr_svc.update_request_submit_count(nr_model)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pointing to the service rather than the model so wasnt handling REH/REN request_actions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
