### PR TITLE
4748-Update Conflict Messaging for Specific Entity Types (XPRO).

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_options.py
+++ b/api/namex/resources/auto_analyse/analysis_options.py
@@ -125,6 +125,21 @@ def assumed_name_setup():
     )
 
 
+class AlternativeAssumedNameSetup(Setup):
+    pass
+
+
+def alternative_assumed_name_setup():
+    return AlternativeAssumedNameSetup(
+        type="assumed_name",
+        header=Template("Not Assumed Name"),
+        line1=Template(
+            "There is an existing BC entity with a similar name therefore you must use a different name in BC. "
+            "This may require you to register the new name in your home jurisdiction first before proceeding here."),
+        line2=Template("")
+    )
+
+
 class SendToExaminerSetup(Setup):
     pass
 

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
@@ -1,3 +1,4 @@
+from namex.constants import EntityTypes
 from ... import QueueNameConflictIssue
 from ...analysis_response import AnalysisResponse
 
@@ -25,6 +26,7 @@ from ...analysis_options import \
     remove_setup, \
     remove_or_replace_setup, \
     assumed_name_setup, \
+    alternative_assumed_name_setup, \
     resolve_conflict_setup, \
     send_to_examiner_setup, \
     obtain_consent_setup, \
@@ -203,7 +205,10 @@ class XproAnalysisResponse(AnalysisResponse):
         :param issue_idx:
         :return:
         """
-        option1 = assumed_name_setup()
+        option1 = assumed_name_setup() if self.entity_type in (
+            EntityTypes.XPRO_CORPORATION.value, EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY.value,
+            EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
+            else alternative_assumed_name_setup()
         # Tweak the header
         option1.header = "Helpful Hint"
 
@@ -227,7 +232,10 @@ class XproAnalysisResponse(AnalysisResponse):
         return issue
 
     def build_queue_conflict_issue(self, procedure_result, issue_count, issue_idx):
-        option1 = assumed_name_setup()
+        option1 = assumed_name_setup() if self.entity_type in (
+            EntityTypes.XPRO_CORPORATION.value, EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY.value,
+            EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
+            else alternative_assumed_name_setup()
         # Tweak the header
         option1.header = "Helpful Hint"
 


### PR DESCRIPTION
*4748 #, Update Conflict Messaging for Specific EntityTypes:*

*Description of changes:*
Additional message for XPRO analysis considering Entity Types different to 'CR', 'XUL' and  'RLC' to refer to this new message:
"There is an existing BC entity with a similar name therefore you must use a different name in BC. "
 "This may require you to register the new name in your home jurisdiction first before proceeding here."

Entity Types equal to 'CR', 'XUL' or  'RLC'  refer to the same message:
"Extra provincial or registration of a foreign entity in BC requires use of an Assumed Name when there is an existing BC entity with a similar name."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
