### PR TITLE
feature/4579 uat rejection

### DIFF
--- a/jobs/rejection-uat/uat-rejection.py
+++ b/jobs/rejection-uat/uat-rejection.py
@@ -43,9 +43,9 @@ def name_profile_data(nr_num, state, choice, name, decision_text, conflict1_num,
                     'choice': choice,
                     'name': name,
                     'name_state': State.REJECTED,
-                    'decision_text': decision_text,
-                    'conflict_num1': conflict1_num,
-                    'conflict1': conflict1
+                    'decision_text': decision_text if decision_text else 'NULL',
+                    'conflict_num1': conflict1_num if conflict1_num else 'NULL',
+                    'conflict1': conflict1 if conflict1 else 'NULL'
                     }
 
     return name_profile

--- a/jobs/rejection-uat/uat-rejection.py
+++ b/jobs/rejection-uat/uat-rejection.py
@@ -84,6 +84,7 @@ if __name__ == "__main__":
         sql = "select r.id, r.nr_num, r.state_cd, n.choice, n.name, n.decision_text, n.conflict1_num, n.conflict1, n.conflict1_num " \
               "from requests r, names n " \
               "where r.id = n.nr_id and n.state = " + '\'' + State.REJECTED + '\'' + " and " \
+              "r.state_cd in(" + '\'' + State.APPROVED + '\',' + '\'' + State.CONDITIONAL + '\',' + '\'' + State.REJECTED + '\') and '\
               "r.request_type_cd = " + '\'' + EntityTypes.CORPORATION.value + '\'' + " and " \
               "r.nr_num not in (select nr_num from uat_results) " \
               "order by r.submitted_date " \

--- a/jobs/rejection-uat/uat-rejection.py
+++ b/jobs/rejection-uat/uat-rejection.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
               "from requests r, names n " \
               "where r.id = n.nr_id and n.state = " + '\'' + State.REJECTED + '\'' + " and " \
               "r.request_type_cd = " + '\'' + EntityTypes.CORPORATION.value + '\'' + " and " \
-              "n.name = 'DLB CRANES LTD.' " \
+              "r.nr_num not in (select nr_num from uat_results) " \
               "order by r.submitted_date " \
               "limit " + MAX_ROW_LIMIT
 

--- a/jobs/rejection-uat/uat-rejection.py
+++ b/jobs/rejection-uat/uat-rejection.py
@@ -1,5 +1,7 @@
 import sys, os, re
 from datetime import datetime
+
+import psycopg2
 from flask import Flask, g, current_app
 from namex import db
 from namex.constants import BCProtectedNameEntityTypes, EntityTypes
@@ -33,8 +35,9 @@ def unicode_to_string(json_str):
     return re.sub(r'\\u([0-9A-F]{4})', lambda m: chr(int(m.group(1), 16)), json_str)
 
 
-def name_profile_data(request_id, nr_num, state, choice, name, decision_text, conflict1_num, conflict1):
-    name_profile = {'id': request_id,
+def name_profile_data(nr_num, state, choice, name, decision_text, conflict1_num, conflict1):
+    seq_id = db.session.execute("select nextval('uat_results_seq') as id").fetchone()
+    name_profile = {'id': seq_id[0],
                     'nr_num': nr_num,
                     'nr_state': state,
                     'choice': choice,
@@ -112,7 +115,7 @@ if __name__ == "__main__":
                 analysis_response = AnalysisResponse(service, analysis)
                 payload = analysis_response.build_response()
 
-                profile_data = name_profile_data(request_id, nr_num, state_cd, choice, name, decision_text,
+                profile_data = name_profile_data(nr_num, state_cd, choice, name, decision_text,
                                                  conflict1_num, conflict1)
                 response_data = name_response_data(payload)
 

--- a/jobs/rejection-uat/uat-rejection.py
+++ b/jobs/rejection-uat/uat-rejection.py
@@ -1,14 +1,22 @@
 import sys, os
-from datetime import datetime, timedelta
+from datetime import datetime
 from flask import Flask, g, current_app
 from namex import db
+from namex.constants import BCProtectedNameEntityTypes, EntityTypes
+from namex.models.state import State
+from namex.services.name_request.auto_analyse import AnalysisIssueCodes
+from namex.services.name_request.auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
+from namex.services.name_request.builders.name_analysis_builder import NameAnalysisBuilder
+from namex.resources.auto_analyse.paths.bc_name_analysis.bc_name_analysis_response import \
+    BcAnalysisResponse as AnalysisResponse
 from namex.utils.logging import setup_logging
-
 from config import Config
-import zlib, json
 
+setup_logging()  ## important to do this first
 
-setup_logging() ## important to do this first
+entry_params = {
+    'entity_type': 'CR',
+}
 
 
 def create_app(config=Config):
@@ -20,49 +28,104 @@ def create_app(config=Config):
 
     return app
 
-app = create_app(Config)
-start_time = datetime.utcnow()
-row_count = 0
-MAX_ROW_LIMIT = os.getenv('MAX_ROWS', '100')
 
-try:
+def name_profile_data(request_id, nr_num, state, choice, name, decision_text, conflict1_num, conflict1):
+    name_profile = {'id': request_id,
+                    'nr_num': nr_num,
+                    'nr_state': state,
+                    'choice': choice,
+                    'name': name,
+                    'name_state': State.REJECTED,
+                    'decision_text': decision_text,
+                    'conflict_num1': conflict1_num,
+                    'conflict1': conflict1
+                    }
 
-    sql = "select r.id, r.nr_num, n.choice, n.name, n.decision_text, n.conflict1_num, n.conflict1, n.conflict1_num "\
-          "from requests r, names n "\
-          "where r.id = n.nr_id and n.state = 'REJECTED' and r.state_cd = 'REJECTED' "\
-          "order by  r.submitted_date" \
-          "limit " + MAX_ROW_LIMIT
-
-    requests= db.session.execute(sql)
-    for request_id, nr_num in requests:
-        current_app.logger.debug('processing id: {}'.format(request_id))
-        ## TO auto-analyze steps
-
-        #to get the results and format the jsonb column
-        #we will nee dto handle the update to the jsonb col and may need to pull stuff out of the reponse issues
-        # we will nee dto review each response issue and determine how we will deal with it.
+    return name_profile
 
 
-        update_sql = "update events " \
-                     "set event_json='{json_input}'::jsonb " \
-                     "where id={id}".format(id=event_id, json_input=formatted_json)
+def name_response_data(payload):
+    name_response = {'result_state': 'NULL',
+                     'result_decision_text': 'NULL',
+                     'result_conflict_num1': 'NULL',
+                     'result_conflict1': 'NULL',
+                     'result_response': 'NULL'
+                     }
 
-        insert_sql = "insert into uat_results " \
-                     "(id, nr_num,nr_state, choice, name, name_state, decision_text,  conflict1_num, conflict1, result_state "  \
-                     " result_decision_text, result_conflict1_num, result_conflict1, result_response)" \
-                     "values"\
-                     "( )"
+    decision_text = ''
+    for element in payload.issues:
+        decision_text += 'issue_type: ' + element.issue_type + '. Line1: ' + element.line1 + '. '
 
-        db.session.execute(insert_sql)
-        db.session.commit()
-        row_count += 1
+        if element.issue_type in (AnalysisIssueCodes.CORPORATE_CONFLICT, AnalysisIssueCodes.QUEUE_CONFLICT):
+            for conflict in element.conflicts:
+                name_response['result_conflict_num1'] = conflict.id
+                name_response['result_conflict1'] = conflict.name
 
-except Exception as err:
-    db.session.rollback()
-    print('Failed to update events: ', err, err.with_traceback(None), file=sys.stderr)
-    exit(1)
+        elif element.issue_type in (AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD,
+                                    AnalysisIssueCodes.WORDS_TO_AVOID, AnalysisIssueCodes.TOO_MANY_WORDS):
+            name_response['result_state'] = State.REJECTED
+        else:
+            name_response['result_state'] = 'NULL'
 
-app.do_teardown_appcontext()
-end_time = datetime.utcnow()
-print("job - columns updated: {0} completed in:{1}".format(row_count, end_time-start_time))
-exit(0)
+    name_response['result_decision_text'] = decision_text
+    name_response['result_response'] = payload.to_json()
+
+    return name_response
+
+
+if __name__ == "__main__":
+    app = create_app(Config)
+    start_time = datetime.utcnow()
+    row_count = 0
+    MAX_ROW_LIMIT = os.getenv('MAX_ROWS', '100')
+
+    try:
+
+        sql = "select r.id, r.nr_num, r.state_cd, n.choice, n.name, n.decision_text, n.conflict1_num, n.conflict1, n.conflict1_num " \
+              "from requests r, names n " \
+              "where r.id = n.nr_id and n.state = " + '\'' + State.REJECTED + '\'' + " and " \
+              "r.request_type_cd = " + '\'' + EntityTypes.CORPORATION.value + '\'' + " and " \
+              "n.name = 'DLB CRANES LTD.' " \
+              "order by r.submitted_date " \
+              "limit " + MAX_ROW_LIMIT
+
+        requests = db.session.execute(sql)
+        for request_id, nr_num, state_cd, choice, name, decision_text, conflict1_num, conflict1, conflict_num1 in requests:
+            if entry_params['entity_type'] in BCProtectedNameEntityTypes.list():
+                service = ProtectedNameAnalysisService()
+                builder = NameAnalysisBuilder(service)
+
+                service.use_builder(builder)
+                service.set_entity_type(entry_params.get('entity_type'))
+                service.set_name(name)
+
+                analysis = service.execute_analysis()
+
+                # Build the appropriate response for the analysis result
+                analysis_response = AnalysisResponse(service, analysis)
+                payload = analysis_response.build_response()
+
+                profile_data = name_profile_data(request_id, nr_num, state_cd, choice, name, decision_text,
+                                                 conflict1_num, conflict1)
+                response_data = name_response_data(payload)
+
+                data_dict = profile_data.copy()
+                data_dict.update(response_data)
+
+            cols = data_dict.keys()
+            cols_str = ','.join(cols)
+            record_to_insert = tuple([data_dict[k] for k in cols])
+
+            db.session.execute('insert into uat_results VALUES {};'.format(record_to_insert))
+            db.session.commit()
+            row_count += 1
+
+    except Exception as err:
+        db.session.rollback()
+        print('Failed to update events: ', err, err.with_traceback(None), file=sys.stderr)
+        exit(1)
+
+    app.do_teardown_appcontext()
+    end_time = datetime.utcnow()
+    print("job - columns updated: {0} completed in:{1}".format(row_count, end_time - start_time))
+    exit(0)

--- a/jobs/rejection-uat/uat-rejection.py
+++ b/jobs/rejection-uat/uat-rejection.py
@@ -97,6 +97,9 @@ def name_response_data(payload, duration):
                                     AnalysisIssueCodes.WORDS_TO_AVOID, AnalysisIssueCodes.TOO_MANY_WORDS):
             name_response['result_state'] = State.REJECTED
 
+    if not payload.issues:
+        name_response['result_state'] = State.APPROVED
+
     name_response['result_decision_text'] = decision_text
     name_response['result_response'] = payload.to_json()
     name_response['result_duration_secs'] = duration.seconds


### PR DESCRIPTION
*#4579, Build Auto-Analyze Rejection Script:*

*Description of changes:*
Script to get rejected names from database with entity type 'CR' and execute analysis to obtain the responses to compare with the response issue by examiner. In this way, we would be able to evaluate manually through comparing the results stored in uat_results table.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
