### PR TITLE
added home-juris-num to get header from oracle

### DIFF
--- a/api/namex/services/nro/request_utils.py
+++ b/api/namex/services/nro/request_utils.py
@@ -36,6 +36,7 @@ def add_nr_header(nr, nr_header, nr_submitter, user):
     nr.additionalInfo = nr_header['additional_info']
     nr.natureBusinessInfo = nr_header['nature_business_info']
     nr.xproJurisdiction = nr_header['xpro_jurisdiction']
+    nr.homeJurisNum = nr_header['home_juris_num']
     # TODO This should NOT be None, but due to some legacy issues, it's set to None
     nr.submittedDate = None if not nr_submitter else nr_submitter['submitted_date']
     nr.submitter_userid = None if not submitter else submitter.id

--- a/api/namex/services/nro/request_utils.py
+++ b/api/namex/services/nro/request_utils.py
@@ -209,7 +209,8 @@ def get_nr_header(session, nr_num):
         'expiration_date,'
         'additional_info,'
         'nature_business_info,'
-        'xpro_jurisdiction'
+        'xpro_jurisdiction,'
+        'home_juris_num'
         ' from request_vw'
         ' where nr_num = :nr'
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This update the get_header that impacts the extractor as well as Get, Get Next,  set to Hold in Namex.  HOME_JURIS_NUM is added to the namex database for completeness of data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
