### PR TITLE
4398 home juris num

### DIFF
--- a/api/namex/services/nro/request_utils.py
+++ b/api/namex/services/nro/request_utils.py
@@ -36,6 +36,7 @@ def add_nr_header(nr, nr_header, nr_submitter, user):
     nr.additionalInfo = nr_header['additional_info']
     nr.natureBusinessInfo = nr_header['nature_business_info']
     nr.xproJurisdiction = nr_header['xpro_jurisdiction']
+    nr.homeJurisNum = nr_header['home_juris_num']
     # TODO This should NOT be None, but due to some legacy issues, it's set to None
     nr.submittedDate = None if not nr_submitter else nr_submitter['submitted_date']
     nr.submitter_userid = None if not submitter else submitter.id

--- a/api/namex/services/nro/request_utils.py
+++ b/api/namex/services/nro/request_utils.py
@@ -209,7 +209,8 @@ def get_nr_header(session, nr_num):
         'expiration_date,'
         'additional_info,'
         'nature_business_info,'
-        'xpro_jurisdiction'
+        'xpro_jurisdiction,'
+        'home_juris_num'
         ' from request_vw'
         ' where nr_num = :nr'
     )

--- a/nro-legacy/sql/object/names/namex/view/request_vw.sql
+++ b/nro-legacy/sql/object/names/namex/view/request_vw.sql
@@ -11,12 +11,13 @@ CREATE OR REPLACE FORCE VIEW namex.request_vw (request_id,
                                                expiration_date,
                                                additional_info,
                                                nature_business_info,
-                                               xpro_jurisdiction
+                                               xpro_jurisdiction,
+											   home_juris_num
                                               )
 AS
     SELECT r.request_id, r.nr_num, r.previous_request_id, r.submit_count, ri.priority_cd,
            ri.request_type_cd, ri.expiration_date, ri.additional_info, ri.nature_business_info,
-           ri.xpro_jurisdiction
+           ri.xpro_jurisdiction, ri.home_juris_num
       FROM request r LEFT OUTER JOIN request_instance ri ON ri.request_id = r.request_id
       WHERE ri.end_event_id IS NULL
            ;

--- a/nro-legacy/sql/release/202009XX_request_vw/names/namex/create.sql
+++ b/nro-legacy/sql/release/202009XX_request_vw/names/namex/create.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+@ ../../../../object/names/namex/view/request_vw.sql


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Impacts NRO-Extractor, Get, GET Next, HOLD in Namex.  Adds the home_juris_num from oracle request_instance to postgres requests for completeness.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
