### PR TITLE
fix Valid Sources Issue on postgres insert

### DIFF
--- a/api/namex/services/nro/request_utils.py
+++ b/api/namex/services/nro/request_utils.py
@@ -42,6 +42,7 @@ def add_nr_header(nr, nr_header, nr_submitter, user):
     nr.submitter_userid = None if not submitter else submitter.id
     nr.nroLastUpdate = nr_header['last_update']
     nr.lastUpdate = nr.nroLastUpdate # this needs to be set to the same Point In Time as NRO until NameX owns it
+    nr.source = 'NRO'
 
     if nr_header['priority_cd'] in ('PQ', 'PJ', 'RJ'):
         nr.priorityCd = 'Y'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To fix psycopg2.ProgrammingError: can't adapt type 'ValidSources' in the extractor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
