### PR TITLE
4844/fixes uat rejection testing stand alones

### DIFF
--- a/api/namex/services/name_processing/mixins/get_synonym_lists.py
+++ b/api/namex/services/name_processing/mixins/get_synonym_lists.py
@@ -4,6 +4,7 @@ class GetSynonymListsMixin(object):
     _substitutions = []
     _stop_words = []
     _number_words = []
+    _stand_alone_words = []
 
     def get_prefixes(self):
         return self._prefixes
@@ -20,5 +21,5 @@ class GetSynonymListsMixin(object):
     def get_number_words(self):
         return self._number_words
 
-
-
+    def get_stand_alone_words(self):
+        return self._stand_alone_words

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -235,6 +235,7 @@ class NameProcessingService(GetSynonymListsMixin):
         self._stop_words = syn_svc.get_stop_words().data
         self._prefixes = syn_svc.get_prefixes().data
         self._number_words = syn_svc.get_number_words().data
+        self._stand_alone_words = syn_svc.get_stand_alone().data
 
         self._eng_designated_end_words = syn_svc.get_designated_end_all_words(lang=LanguageCodes.ENG.value).data
         self._eng_designated_any_words = syn_svc.get_designated_any_all_words(lang=LanguageCodes.ENG.value).data

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -187,8 +187,6 @@ class NameProcessingService(GetSynonymListsMixin):
 
         tokens = tokens.split()
 
-        #tokens = check_numbers_beginning(syn_svc, tokens)
-
         return [x.lower() for x in tokens if x]
 
     def exception_virtual_word_condition(self, text, vwc_svc):

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -187,7 +187,7 @@ class NameProcessingService(GetSynonymListsMixin):
 
         tokens = tokens.split()
 
-        tokens = check_numbers_beginning(syn_svc, tokens)
+        #tokens = check_numbers_beginning(syn_svc, tokens)
 
         return [x.lower() for x in tokens if x]
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -244,11 +244,13 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             syn_svc = self.synonym_service
             wc_svc = self.word_classification_service
             token_svc = self.token_classifier_service
+            np_svc = self._name_processing_service
+            stand_alone_words = np_svc.get_stand_alone_words()
 
             analysis = []
 
             # Configure the analysis for the supplied builder
-            get_classification(self, syn_svc, self.name_tokens, wc_svc, token_svc)
+            get_classification(self, stand_alone_words, syn_svc, self.name_tokens, wc_svc, token_svc)
 
             check_words_to_avoid = builder.check_words_to_avoid(self.name_tokens, self.processed_name)
             if not check_words_to_avoid.is_valid:

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -146,11 +146,11 @@ def check_numbers_beginning(syn_svc, tokens):
     return tokens
 
 
-def check_synonyms(syn_svc, list_dist_words, list_desc_words):
+def check_synonyms(syn_svc, stand_alone_words, list_dist_words, list_desc_words):
     both_list = list(set(list_dist_words) & set(list_desc_words))
     for word in both_list:
         substitution = syn_svc.get_word_synonyms(word=word).data
-        if substitution:
+        if substitution or porter.stem(word.lower()) in stand_alone_words:
             list_dist_words.remove(word)
         else:
             list_desc_words.remove(word)
@@ -195,7 +195,7 @@ def get_conflicts_same_classification(builder, name_tokens, processed_name, list
     return check_conflicts
 
 
-def get_classification(service, syn_svc, match, wc_svc, token_svc):
+def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc):
     desc_compound_dict = get_compound_descriptives(service, syn_svc)
     match = update_list(list(desc_compound_dict.keys()), match)
 
@@ -210,7 +210,9 @@ def get_classification(service, syn_svc, match, wc_svc, token_svc):
                 service.get_list_none(),
                 match
             )
-    service._list_dist_words, service._list_desc_words = check_synonyms(syn_svc, service.get_list_dist(),
+    service._list_dist_words, service._list_desc_words = check_synonyms(syn_svc,
+                                                                        stand_alone_words,
+                                                                        service.get_list_dist(),
                                                                         service.get_list_desc())
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -150,7 +150,7 @@ def check_synonyms(syn_svc, stand_alone_words, list_dist_words, list_desc_words)
     both_list = list(set(list_dist_words) & set(list_desc_words))
     for word in both_list:
         substitution = syn_svc.get_word_synonyms(word=word).data
-        if substitution or porter.stem(word.lower()) in stand_alone_words:
+        if substitution or word.lower() in stand_alone_words:
             list_dist_words.remove(word)
         else:
             list_desc_words.remove(word)

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -634,9 +634,9 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def stand_alone_name_different(self, lst_dist_name1, lst_dist_name2, lst_desc_name1, lst_desc_name2,
                                    stand_alone_words):
         if self.is_standalone_name(lst_desc_name1, stand_alone_words) and self.is_standalone_name(lst_desc_name2,
-                                                                                                  stand_alone_words):
-            if lst_dist_name1.__len__() != lst_dist_name2.__len__() or lst_desc_name1.__len__() != lst_desc_name2.__len__():
-                return True
+                                                                                                  stand_alone_words) and (
+                lst_dist_name1.__len__() != lst_dist_name2.__len__() or lst_desc_name1.__len__() != lst_desc_name2.__len__()):
+            return True
 
         return False
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -444,10 +444,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         list_desc = list(desc_synonym_dict.keys())
         if matches:
             syn_svc = self.synonym_service
+            nproc_svc = self.name_processing_service
             service = ProtectedNameAnalysisService()
             np_svc = service.name_processing_service
             wc_svc = service.word_classification_service
             token_svc = service.token_classifier_service
+            stand_alone_words = nproc_svc.get_stand_alone_words()
 
             total = len(matches)
             print("Possible conflicts returned: ", total)
@@ -470,14 +472,19 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                                                                  dist_substitution_dict)
                     similarity_dist = round(self.get_similarity(vector1_dist, vector2_dist, entropy_dist), 2)
 
-                    vector2_desc, entropy_desc = self.get_vector(remove_spaces_list(service.get_list_desc()), list_desc, desc_synonym_dict)
+                    vector2_desc, entropy_desc = self.get_vector(remove_spaces_list(service.get_list_desc()), list_desc,
+                                                                 desc_synonym_dict)
                     similarity_desc = round(
                         self.get_similarity(vector1_desc, vector2_desc, entropy_desc), 2)
 
                     similarity = round((similarity_dist + similarity_desc) / 2, 2)
                     print(similarity)
 
-                if similarity >= MINIMUM_SIMILARITY:
+                if similarity >= MINIMUM_SIMILARITY and not self.stand_alone_name_different(list_dist,
+                                                                                            service.get_list_dist(),
+                                                                                            list_desc,
+                                                                                            service.get_list_desc(),
+                                                                                            stand_alone_words):
                     dict_matches_counter.update({match.name: similarity})
                     selected_matches.append(match)
                     if self.stop_search(similarity, matches):
@@ -619,6 +626,20 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         return dist_substitution_dict
 
+    def is_standalone_name(self, list_name, stand_alone_words):
+        if any(stand_alone in list_name for stand_alone in stand_alone_words):
+            return True
+        return False
+
+    def stand_alone_name_different(self, lst_dist_name1, lst_dist_name2, lst_desc_name1, lst_desc_name2,
+                                   stand_alone_words):
+        if self.is_standalone_name(lst_desc_name1, stand_alone_words) and self.is_standalone_name(lst_desc_name2,
+                                                                                                  stand_alone_words):
+            if lst_dist_name1.__len__() > lst_dist_name2.__len__() or lst_desc_name1.__len__() > lst_desc_name2.__len__():
+                return True
+
+        return False
+
     def get_substitutions_descriptive(self, w_desc):
         syn_svc = self.synonym_service
 
@@ -716,7 +737,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_compound_distinctives(self, dict_dist):
         list_dict = list(dict_dist.keys())
 
-        list_dist_compound= list()
+        list_dist_compound = list()
         for i in range(2, len(list_dict)):
             list_dist_compound.extend(subsequences(list_dict, i))
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -481,10 +481,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     print(similarity)
 
                 if similarity >= MINIMUM_SIMILARITY and not self.stand_alone_additional_dist_desc(list_dist,
-                                                                                            service.get_list_dist(),
-                                                                                            list_desc,
-                                                                                            service.get_list_desc(),
-                                                                                            stand_alone_words):
+                                                                                                  service.get_list_dist(),
+                                                                                                  list_desc,
+                                                                                                  service.get_list_desc(),
+                                                                                                  stand_alone_words):
                     dict_matches_counter.update({match.name: similarity})
                     selected_matches.append(match)
                     if self.stop_search(similarity, matches):
@@ -632,7 +632,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return False
 
     def stand_alone_additional_dist_desc(self, lst_dist_name1, lst_dist_name2, lst_desc_name1, lst_desc_name2,
-                                   stand_alone_words):
+                                         stand_alone_words):
         if self.is_standalone_name(lst_desc_name1, stand_alone_words) and self.is_standalone_name(lst_desc_name2,
                                                                                                   stand_alone_words) and (
                 lst_dist_name1.__len__() != lst_dist_name2.__len__() or lst_desc_name1.__len__() != lst_desc_name2.__len__()):

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -480,7 +480,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     similarity = round((similarity_dist + similarity_desc) / 2, 2)
                     print(similarity)
 
-                if similarity >= MINIMUM_SIMILARITY and not self.stand_alone_name_different(list_dist,
+                if similarity >= MINIMUM_SIMILARITY and not self.stand_alone_additional_dist_desc(list_dist,
                                                                                             service.get_list_dist(),
                                                                                             list_desc,
                                                                                             service.get_list_desc(),
@@ -631,7 +631,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             return True
         return False
 
-    def stand_alone_name_different(self, lst_dist_name1, lst_dist_name2, lst_desc_name1, lst_desc_name2,
+    def stand_alone_additional_dist_desc(self, lst_dist_name1, lst_dist_name2, lst_desc_name1, lst_desc_name2,
                                    stand_alone_words):
         if self.is_standalone_name(lst_desc_name1, stand_alone_words) and self.is_standalone_name(lst_desc_name2,
                                                                                                   stand_alone_words) and (

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -635,7 +635,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                                    stand_alone_words):
         if self.is_standalone_name(lst_desc_name1, stand_alone_words) and self.is_standalone_name(lst_desc_name2,
                                                                                                   stand_alone_words):
-            if lst_dist_name1.__len__() > lst_dist_name2.__len__() or lst_desc_name1.__len__() > lst_desc_name2.__len__():
+            if lst_dist_name1.__len__() != lst_dist_name2.__len__() or lst_desc_name1.__len__() != lst_desc_name2.__len__():
                 return True
 
         return False

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -466,7 +466,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     similarity = EXACT_MATCH
                 else:
                     match_list = np_svc.name_tokens
-                    get_classification(service, syn_svc, match_list, wc_svc, token_svc)
+                    get_classification(service, stand_alone_words, syn_svc, match_list, wc_svc, token_svc)
 
                     vector2_dist, entropy_dist = self.get_vector(service.get_list_dist(), list_dist,
                                                                  dist_substitution_dict)

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_both_classifications_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_both_classifications_request.py
@@ -54,12 +54,13 @@ def test_add_descriptive_word_both_classifications_request_response(client, jwt,
         #     'entity_type_cd': 'CR',
         #     'request_action_cd': 'NEW'
         # },
-        {
-            'name': 'SEWING SERVICE LTD.',
-            'location': 'BC',
-            'entity_type_cd': 'CR',
-            'request_action_cd': 'NEW'
-        },
+        # Not valid name SEWING is descriptive and SERVICE distinctive, the order is reversed.
+        # {
+        #     'name': 'SEWING SERVICE LTD.',
+        #     'location': 'BC',
+        #     'entity_type_cd': 'CR',
+        #     'request_action_cd': 'NEW'
+        # },
     ]
 
     for entry in test_params:

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_compound_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_compound_word_request.py
@@ -50,12 +50,12 @@ def test_name_requires_consent_compound_word_request_response(client, jwt, app):
             'request_action_cd': 'NEW'
         },
         # All words are identified as distinctive because none of them are in synonym table
-        {
-            'name': 'BLAKE ENGINEERING LTD.',
-            'location': 'BC',
-            'entity_type_cd': 'CR',
-            'request_action_cd': 'NEW'
-        }
+        # {
+        #     'name': 'BLAKE ENGINEERING LTD.',
+        #     'location': 'BC',
+        #     'entity_type_cd': 'CR',
+        #     'request_action_cd': 'NEW'
+        # }
     ]
 
     for entry in test_params:

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_more_than_one_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_more_than_one_word_request.py
@@ -40,12 +40,13 @@ def test_name_requires_consent_more_than_one_word_request_response(client, jwt, 
     headers = {'Authorization': 'Bearer ' + token, 'content-type': 'application/json'}
 
     test_params = [
-        {
-            'name': 'BLAKE 4H ENGINEERING LTD.',
-            'location': 'BC',
-            'entity_type_cd': 'CR',
-            'request_action_cd': 'NEW'
-        },
+        # All words are distinctive, it is not well formed.
+        # {
+        #     'name': 'BLAKE 4H ENGINEERING LTD.',
+        #     'location': 'BC',
+        #     'entity_type_cd': 'CR',
+        #     'request_action_cd': 'NEW'
+        # },
         {
             'name': 'EQTEC HONEYWELL ENGINEERING LTD.',
             'location': 'BC',

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_more_than_one_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_more_than_one_word_request.py
@@ -16,7 +16,12 @@ def test_name_requires_consent_more_than_one_word_request_response(client, jwt, 
                                  {'word': 'BLAKE', 'classification': 'DESC'},
                                  {'word': 'ENGINEERING', 'classification': 'DIST'},
                                  {'word': 'ENGINEERING', 'classification': 'DESC'},
-                                 {'word': 'EQTEC', 'classification': 'DIST'}]
+                                 {'word': 'EQTEC', 'classification': 'DIST'},
+                                 {'word': 'ECOMMERCE', 'classification': 'DIST'},
+                                 {'word': 'ECOMMERCE', 'classification': 'DESC'},
+                                 {'word': 'SOLUTIONS', 'classification': 'DIST'},
+                                 {'word': 'SOLUTIONS', 'classification': 'DESC'},
+                                 ]
     save_words_list_classification(words_list_classification)
 
     words_list_virtual_word_condition = [
@@ -40,15 +45,15 @@ def test_name_requires_consent_more_than_one_word_request_response(client, jwt, 
     headers = {'Authorization': 'Bearer ' + token, 'content-type': 'application/json'}
 
     test_params = [
-        # All words are distinctive, it is not well formed.
-        # {
-        #     'name': 'BLAKE 4H ENGINEERING LTD.',
-        #     'location': 'BC',
-        #     'entity_type_cd': 'CR',
-        #     'request_action_cd': 'NEW'
-        # },
+
         {
-            'name': 'EQTEC HONEYWELL ENGINEERING LTD.',
+            'name': 'BLAKE 4H ENGINEERING ECOMMERCE LTD.',
+            'location': 'BC',
+            'entity_type_cd': 'CR',
+            'request_action_cd': 'NEW'
+        },
+        {
+            'name': 'EQTEC HONEYWELL ENGINEERING SOLUTIONS LTD.',
             'location': 'BC',
             'entity_type_cd': 'CR',
             'request_action_cd': 'NEW'

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
@@ -14,9 +14,13 @@ from ...common import token_header, claims
 @pytest.mark.parametrize("name, expected",
                          [
                              ("ARMSTRONG PLUMBING LTD.", "ARMSTRONG PLUMBING & HEATING LTD."),
+                             # Stand alone names with additional distinctive or descriptive have to be approved.
+                             # Test case no longer valid
                              ("NO. 001 CATHEDRAL MINING LTD.", "NO. 003 CATHEDRAL MINING LTD."),
                              ("ARMSTRONG PLUMBING & CAFE INC.", "ARMSTRONG PLUMBING & HEATING LTD."),
-                             ("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."),
+                             # Stand alone names with additional distinctive or descriptive have to be approved.
+                             # Test case no longer valid
+                             #("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."),
                              ("LE BLUE CAFE LTD.", "LE BLUE RESTAURANT LTD.")
                          ]
                          )

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
@@ -16,7 +16,7 @@ from ...common import token_header, claims
                              ("ARMSTRONG PLUMBING LTD.", "ARMSTRONG PLUMBING & HEATING LTD."),
                              # Stand alone names with additional distinctive or descriptive have to be approved.
                              # Test case no longer valid
-                             ("NO. 001 CATHEDRAL MINING LTD.", "NO. 003 CATHEDRAL MINING LTD."),
+                             # ("NO. 001 CATHEDRAL MINING LTD.", "NO. 003 CATHEDRAL MINING LTD."),
                              ("ARMSTRONG PLUMBING & CAFE INC.", "ARMSTRONG PLUMBING & HEATING LTD."),
                              # Stand alone names with additional distinctive or descriptive have to be approved.
                              # Test case no longer valid

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -47,8 +47,11 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         if word:
             filters.append(func.lower(model.stems_text).op('~')(r'\y{}\y'.format(porter.stem(word).replace(" ", ""))))
 
-        field = [model.category] if category else [model.synonyms_text] if stand_alone else [model.stems_text,
-                                                                                             model.synonyms_text]
+        field = []
+        if category:
+            field = [model.category]
+        else:
+            field = [model.synonyms_text] if stand_alone else [model.stems_text, model.synonyms_text]
 
         criteria = SynonymQueryCriteria(
             word=word,

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -40,14 +40,15 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
     Designations, distinctives and descriptives return stems_text
     '''
 
-    def find_word_synonyms(self, word, filters, category=False):
+    def find_word_synonyms(self, word, filters, stand_alone=False, category=False):
         model = self.get_model()
         word = word.lower() if isinstance(word, str) else None
 
         if word:
             filters.append(func.lower(model.stems_text).op('~')(r'\y{}\y'.format(porter.stem(word).replace(" ", ""))))
 
-        field = [model.category] if category else [model.stems_text, model.synonyms_text]
+        field = [model.category] if category else [model.synonyms_text] if stand_alone else [model.stems_text,
+                                                                                             model.synonyms_text]
 
         criteria = SynonymQueryCriteria(
             word=word,
@@ -112,7 +113,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
             func.lower(model.category).op('~')(r'\y{}\y'.format('stand-alone'))
         ]
 
-        results = self.find_word_synonyms(None, filters)
+        results = self.find_word_synonyms(None, filters, stand_alone=True)
         flattened = list(map(str.strip, (list(filter(None, self.flatten_synonyms_text(results))))))
         return flattened
 


### PR DESCRIPTION
*I4844 #, Fixes UAT Rejection Testing Stand Alones:*

*Description of changes:*
Search for exact stand alone word using synonyms_text instead of stems_Text.
Check if stand alone is having an additional descriptive or distinctive.
Allow numbers at the beginning of a name



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
