### PR TITLE
XPROs missing stand-alone words.

### DIFF
--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -47,12 +47,13 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
             syn_svc = self.synonym_service
             wc_svc = self.word_classification_service
             token_svc = self.token_classifier_service
+            np_svc = self._name_processing_service
+            stand_alone_words = np_svc.get_stand_alone_words()
 
             analysis = []
 
             # Configure the analysis for the supplied builder
-            #self.configure_analysis()
-            get_classification(self, syn_svc, self.name_tokens, wc_svc, token_svc)
+            get_classification(self, stand_alone_words, syn_svc, self.name_tokens, wc_svc, token_svc)
 
             check_words_to_avoid = builder.check_words_to_avoid(self.name_tokens, self.processed_name)
             if not check_words_to_avoid.is_valid:


### PR DESCRIPTION
*hotfix/Missing Stand-alone words in XPRO names:*

*Description of changes:*
Missing parameter in get_classification located in utils. Added stand-alone words for XPRO names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
