### PR TITLE
4978/add rule dist desc dist desc pattern

### DIFF
--- a/api/namex/models/word_classification.py
+++ b/api/namex/models/word_classification.py
@@ -44,8 +44,8 @@ class WordClassification(db.Model):
 
     @classmethod
     def find_word_classification(cls, word):
-        results = db.session.query(cls.word, cls.classification) \
-            .filter(func.lower(cls.word).op('~')(r"(\y{0}(''[a-zA-Z])?\y)".format(word.lower()))) \
+        results = db.session.query(cls.word, cls.classification).distinct(cls.word, cls.classification) \
+            .filter(func.lower(cls.word).op('~')(r"(^{0}(''[a-zA-Z])?\y)".format(word.lower()))) \
             .filter(cls.end_dt.is_(None)) \
             .filter(cls.start_dt <= date.today()) \
             .filter(cls.approved_dt <= date.today()).all()

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -75,6 +75,14 @@ class NameProcessingService(GetSynonymListsMixin):
         self._name_tokens = val
 
     @property
+    def name_tokens_search_conflict(self):
+        return self._name_tokens_search_conflict
+
+    @name_tokens_search_conflict.setter
+    def name_tokens_search_conflict(self, val):
+        self._name_tokens_search_conflict = val
+
+    @property
     def stop_words(self):
         return self._stop_words
 
@@ -112,6 +120,7 @@ class NameProcessingService(GetSynonymListsMixin):
         self.name_original_tokens = None
         self.processed_name = None
         self.name_tokens = None
+        self.name_tokens_search_conflict = None
         self.distinctive_word_tokens = None
         self.descriptive_word_tokens = None
         self.unclassified_word_tokens = None

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -93,6 +93,11 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_processing_service.name_tokens if np_svc else ''
 
     @property
+    def name_tokens_search_conflict(self):
+        np_svc = self.name_processing_service
+        return self.name_processing_service.name_tokens_search_conflict if np_svc else ''
+
+    @property
     def name_original_tokens(self):
         np_svc = self.name_processing_service
         return self.name_processing_service.name_original_tokens if np_svc else ''
@@ -192,6 +197,14 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
     # API for extending implementations
     def set_name_tokens(self, name_tokens):
         self.name_processing_service.name_tokens = name_tokens
+
+    # API for extending implementations
+    def get_name_tokens_search_conflict(self):
+        return self.name_tokens_search_conflict
+
+    # API for extending implementations
+    def set_name_tokens_search_conflict(self, name_tokens_search_conflict):
+        self.name_processing_service.name_tokens_search_conflict = name_tokens_search_conflict
 
     # API for extending implementations
     # TODO: Just for backward compat. et rid of this when we are done refactoring!

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -202,7 +202,7 @@ def get_conflicts_same_classification(builder, name_tokens, processed_name, list
 
 def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc):
     desc_compound_dict = get_compound_descriptives(service, syn_svc)
-    match = update_token_list(list(desc_compound_dict.keys()), match)
+    match = update_compound_tokens(list(desc_compound_dict.keys()), match)
 
     service.token_classifier = wc_svc.classify_tokens(match)
     service._list_dist_words, service._list_desc_words, service._list_none_words = service.word_classification_tokens
@@ -222,22 +222,22 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
+    service.set_name_tokens(update_compound_tokens(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
+
     dict_name_words_original = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
                                                           service.name_tokens)
-    service.set_name_tokens(remove_spaces_list(service.name_tokens))
+    # service.set_name_tokens(remove_spaces_list(service.name_tokens))
     print("Original Classification:")
     print(dict_name_words_original)
 
     service.set_name_tokens_search_conflict(service.name_tokens)
     service._list_dist_words = remove_misplaced_distinctive(service.get_list_dist(), service.get_list_desc(),
-                                                            service.name_tokens)
+                                                            service.name_tokens_search_conflict)
 
     service._list_desc_words = remove_descriptive_same_category(dict_desc)
 
-    service.set_name_tokens(update_token_list(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
-
-    service.set_name_tokens_search_conflict(update_elements_list(service.get_list_dist() + service.get_list_desc(),
-                                                                 service.name_tokens))
+    service.set_name_tokens_search_conflict(update_token_list(service.get_list_dist() + service.get_list_desc(),
+                                                              service.name_tokens_search_conflict))
 
     service._dict_name_words = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
                                                           service.name_tokens_search_conflict)
@@ -270,7 +270,7 @@ def search_word(d, search_item):
     return None
 
 
-def update_token_list(list_desc_compound, original_list):
+def update_compound_tokens(list_desc_compound, original_list):
     list_compound = list_desc_compound + original_list
     str_original = " ".join(original_list)
 
@@ -280,6 +280,14 @@ def update_token_list(list_desc_compound, original_list):
 
     return compound_name
 
+
+def update_token_list(list_dist_desc, list_name):
+    list_name_updated= []
+    for item in list_name:
+        if item in list_dist_desc:
+            list_name_updated.append(item)
+
+    return list_name_updated
 
 def update_elements_list(list_desc_dist, list_name):
     list_name_search_conflict = []
@@ -305,9 +313,10 @@ def remove_spaces_list(lst):
 
 
 def remove_misplaced_distinctive(list_dist, list_desc, list_name):
-    for word in list_name[list_name.index(list_desc[0]) + 1:]:
-        if word in list_dist:
-            list_dist.remove(word)
+    if list_desc.__len__() > 0 and list_dist.__len__() > 0:
+        for word in list_name[list_name.index(list_desc[0]) + 1:]:
+            if word in list_dist:
+                list_dist.remove(word)
     return list_dist
 
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -320,7 +320,7 @@ def remove_descriptive_same_category(dict_desc):
     for base_key in base_keys:
         c = 0
         for key, values in dict_desc.items():
-            if base_key in values:
+            if base_key in values or porter.stem(base_key) in values:
                 c += 1
             if c > 1:
                 desc_list.remove(base_key)

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -182,15 +182,13 @@ def change_descriptive(list_dist_words, list_desc_words, list_name):
     return list_dist_words, list_desc_words
 
 
-def get_classification_summary(service):
+def get_classification_summary(list_dist, list_desc, list_name):
     classification_summary = {
         word.replace(" ",
-                     ""): DataFrameFields.DISTINCTIVE.value if word in service.get_list_dist() else DataFrameFields.DESCRIPTIVE.value if any(
-            word in desc_word for desc_word in service.get_list_desc()) else DataFrameFields.UNCLASSIFIED.value for word
+                     ""): DataFrameFields.DISTINCTIVE.value if word in list_dist else DataFrameFields.DESCRIPTIVE.value if any(
+            word in desc_word for desc_word in list_desc) else DataFrameFields.UNCLASSIFIED.value for word
         in
-        service.name_tokens_search_conflict}
-    service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
-
+        list_name}
     return classification_summary
 
 
@@ -224,6 +222,12 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
+    dict_name_words_original = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
+                                                          service.name_tokens)
+    service.set_name_tokens(remove_spaces_list(service.name_tokens))
+    print("Original Classification:")
+    print(dict_name_words_original)
+
     service.set_name_tokens_search_conflict(service.name_tokens)
     service._list_dist_words = remove_misplaced_distinctive(service.get_list_dist(), service.get_list_desc(),
                                                             service.name_tokens)
@@ -235,8 +239,11 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
     service.set_name_tokens_search_conflict(update_elements_list(service.get_list_dist() + service.get_list_desc(),
                                                                  service.name_tokens))
 
-    service._dict_name_words = get_classification_summary(service)
+    service._dict_name_words = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
+                                                          service.name_tokens_search_conflict)
+    service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
 
+    print("Classification for search conflict:")
     print(service.get_dict_name())
 
 
@@ -285,7 +292,7 @@ def update_elements_list(list_desc_dist, list_name):
 
 def get_compound_descriptives(service, syn_svc):
     list_compound = []
-    for i in range(2, len(service.name_tokens)):
+    for i in range(2, len(service.name_tokens)+1):
         list_compound.extend(subsequences(service.name_tokens, i))
 
     desc_compound_dict_validated = get_valid_compound_descriptive(syn_svc, list_compound)

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -202,9 +202,9 @@ def get_conflicts_same_classification(builder, name_tokens, processed_name, list
 
 def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc):
     desc_compound_dict = get_compound_descriptives(service, syn_svc)
-    match = update_compound_tokens(list(desc_compound_dict.keys()), match)
+    service.set_name_tokens(update_compound_tokens(list(desc_compound_dict.keys()), match))
 
-    service.token_classifier = wc_svc.classify_tokens(match)
+    service.token_classifier = wc_svc.classify_tokens(service.name_tokens)
     service._list_dist_words, service._list_desc_words, service._list_none_words = service.word_classification_tokens
 
     if service.get_list_none() and service.get_list_none().__len__() > 0:
@@ -213,16 +213,17 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
                 service.get_list_dist(),
                 service.get_list_desc(),
                 service.get_list_none(),
-                match
+                service.name_tokens
             )
-    service._list_dist_words, service._list_desc_words = check_synonyms(syn_svc,
-                                                                        stand_alone_words,
-                                                                        service.get_list_dist(),
-                                                                        service.get_list_desc())
+    service._list_dist_words, service._list_desc_words, dict_desc = check_synonyms(syn_svc,
+                                                                                   stand_alone_words,
+                                                                                   service.get_list_dist(),
+                                                                                   service.get_list_desc())
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
-    service.set_name_tokens(update_compound_tokens(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
+    service.set_name_tokens(
+        update_compound_tokens(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
 
     dict_name_words_original = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
                                                           service.name_tokens)
@@ -282,25 +283,17 @@ def update_compound_tokens(list_desc_compound, original_list):
 
 
 def update_token_list(list_dist_desc, list_name):
-    list_name_updated= []
+    list_name_updated = []
     for item in list_name:
         if item in list_dist_desc:
             list_name_updated.append(item)
 
     return list_name_updated
 
-def update_elements_list(list_desc_dist, list_name):
-    list_name_search_conflict = []
-    for word in list_name:
-        if word in list_desc_dist:
-            list_name_search_conflict.append(word)
-
-    return list_name_search_conflict
-
 
 def get_compound_descriptives(service, syn_svc):
     list_compound = []
-    for i in range(2, len(service.name_tokens)+1):
+    for i in range(2, len(service.name_tokens) + 1):
         list_compound.extend(subsequences(service.name_tokens, i))
 
     desc_compound_dict_validated = get_valid_compound_descriptive(syn_svc, list_compound)

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -147,15 +147,22 @@ def check_numbers_beginning(syn_svc, tokens):
 
 
 def check_synonyms(syn_svc, stand_alone_words, list_dist_words, list_desc_words):
-    both_list = list(set(list_dist_words) & set(list_desc_words))
-    for word in both_list:
+    list_desc_words_set = frozenset(list_desc_words)
+    list_desc = list(list_desc_words)
+    intersection = [x for x in list_dist_words if x in list_desc_words_set]
+
+    dict_desc = dict()
+
+    for word in list_desc:
         substitution = syn_svc.get_word_synonyms(word=word).data
         if substitution or word.lower() in stand_alone_words:
-            list_dist_words.remove(word)
+            dict_desc[word] = substitution
+            if word in intersection:
+                list_dist_words.remove(word)
         else:
             list_desc_words.remove(word)
 
-    return list_dist_words, list_desc_words
+    return list_dist_words, list_desc_words, dict_desc
 
 
 def update_none_list(list_none_words, list_desc):
@@ -181,8 +188,8 @@ def get_classification_summary(service):
                      ""): DataFrameFields.DISTINCTIVE.value if word in service.get_list_dist() else DataFrameFields.DESCRIPTIVE.value if any(
             word in desc_word for desc_word in service.get_list_desc()) else DataFrameFields.UNCLASSIFIED.value for word
         in
-        service.name_tokens}
-    service.set_name_tokens(remove_spaces_list(service.name_tokens))
+        service.name_tokens_search_conflict}
+    service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
 
     return classification_summary
 
@@ -197,7 +204,7 @@ def get_conflicts_same_classification(builder, name_tokens, processed_name, list
 
 def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc):
     desc_compound_dict = get_compound_descriptives(service, syn_svc)
-    match = update_list(list(desc_compound_dict.keys()), match)
+    match = update_token_list(list(desc_compound_dict.keys()), match)
 
     service.token_classifier = wc_svc.classify_tokens(match)
     service._list_dist_words, service._list_desc_words, service._list_none_words = service.word_classification_tokens
@@ -217,7 +224,16 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
-    service.set_name_tokens(update_list(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
+    service.set_name_tokens_search_conflict(service.name_tokens)
+    service._list_dist_words = remove_misplaced_distinctive(service.get_list_dist(), service.get_list_desc(),
+                                                            service.name_tokens)
+
+    service._list_desc_words = remove_descriptive_same_category(dict_desc)
+
+    service.set_name_tokens(update_token_list(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
+
+    service.set_name_tokens_search_conflict(update_elements_list(service.get_list_dist() + service.get_list_desc(),
+                                                                 service.name_tokens))
 
     service._dict_name_words = get_classification_summary(service)
 
@@ -247,7 +263,7 @@ def search_word(d, search_item):
     return None
 
 
-def update_list(list_desc_compound, original_list):
+def update_token_list(list_desc_compound, original_list):
     list_compound = list_desc_compound + original_list
     str_original = " ".join(original_list)
 
@@ -256,6 +272,15 @@ def update_list(list_desc_compound, original_list):
     compound_name = regex.findall(str_original)
 
     return compound_name
+
+
+def update_elements_list(list_desc_dist, list_name):
+    list_name_search_conflict = []
+    for word in list_name:
+        if word in list_desc_dist:
+            list_name_search_conflict.append(word)
+
+    return list_name_search_conflict
 
 
 def get_compound_descriptives(service, syn_svc):
@@ -270,3 +295,26 @@ def get_compound_descriptives(service, syn_svc):
 
 def remove_spaces_list(lst):
     return [x.replace(' ', '') for x in lst]
+
+
+def remove_misplaced_distinctive(list_dist, list_desc, list_name):
+    for word in list_name[list_name.index(list_desc[0]) + 1:]:
+        if word in list_dist:
+            list_dist.remove(word)
+    return list_dist
+
+
+def remove_descriptive_same_category(dict_desc):
+    list_d = list(dict_desc.keys())
+    desc_list = list(list_d)
+    base_keys = list_d[1:]
+    for base_key in base_keys:
+        c = 0
+        for key, values in dict_desc.items():
+            if base_key in values:
+                c += 1
+            if c > 1:
+                desc_list.remove(base_key)
+                break
+
+    return desc_list

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -48,7 +48,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
             check_conflicts = builder.search_conflicts(
                 [self.get_list_dist()],
                 [self.get_list_desc()],
-                self.name_tokens,
+                self.name_tokens_search_conflict,
                 self.processed_name
             )
 
@@ -58,7 +58,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         check_conflicts_queue = builder.search_conflicts(
             [self.get_list_dist()],
             [self.get_list_desc()],
-            self.name_tokens,
+            self.name_tokens_search_conflict,
             self.processed_name,
             False,
             True

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -150,7 +150,7 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
         check_conflicts = builder.search_conflicts(
             [self.get_list_dist()],
             [self.get_list_desc()],
-            self.name_tokens,
+            self.name_tokens_search_conflict,
             self.processed_name
         )
 
@@ -160,7 +160,7 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
         check_conflicts_queue = builder.search_conflicts(
             [self.get_list_dist()],
             [self.get_list_desc()],
-            self.name_tokens,
+            self.name_tokens_search_conflict,
             self.processed_name,
             False,
             True

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -37,9 +37,11 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         result = ProcedureResult()
         result.is_valid = True
 
-        first_classification = next(iter(name_dict.values()))
-        first_word = next(iter(name_dict))
-        name_dict.pop(first_word)
+        first_classification = None
+        if name_dict:
+            first_classification = next(iter(name_dict.values()))
+            first_word = next(iter(name_dict))
+            name_dict.pop(first_word)
 
         if first_classification == DataFrameFields.DISTINCTIVE.value:
             valid = self.check_descriptive(name_dict)

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -766,7 +766,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_compound_distinctive_hybrid(self, dist_substitution_dict, dict_descriptive, list_name):
         dict_compound_dist, dict_desc = {}, {}
 
-        if dict_descriptive.__len__() > 1 and dist_substitution_dict.__len__() >1:
+        if dict_descriptive.__len__() > 1 and dist_substitution_dict.__len__() > 0:
             dict_desc = dict(dict_descriptive)
             for key_dist, value in sorted(list(dist_substitution_dict.items()), key=lambda x: x[0].lower(),
                                           reverse=True):

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -766,7 +766,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_compound_distinctive_hybrid(self, dist_substitution_dict, dict_descriptive, list_name):
         dict_compound_dist, dict_desc = {}, {}
 
-        if dict_descriptive.__len__() > 1:
+        if dict_descriptive.__len__() > 1 and dist_substitution_dict.__len__() >1:
             dict_desc = dict(dict_descriptive)
             for key_dist, value in sorted(list(dist_substitution_dict.items()), key=lambda x: x[0].lower(),
                                           reverse=True):

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_descriptive_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_descriptive_request.py
@@ -28,7 +28,7 @@ from ...common import token_header, claims
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
-def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, name, expected):
+def test_corporate_name_conflict_compound_descriptive_response(client, jwt, app, name, expected):
     words_list_classification = [{'word': 'WESTWOOD', 'classification': 'DIST'},
                                  {'word': 'WESTWOOD', 'classification': 'DESC'},
                                  {'word': 'GARY', 'classification': 'DIST'},

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_distinctive_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_distinctive_request.py
@@ -19,7 +19,7 @@ from ...common import token_header, claims
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
-def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, name, expected):
+def test_corporate_name_conflict_compound_distinctive_request_response(client, jwt, app, name, expected):
     words_list_classification = [{'word': 'SOUTH', 'classification': 'DIST'},
                                  {'word': 'SOUTH', 'classification': 'DESC'},
                                  {'word': 'LAND', 'classification': 'DIST'},


### PR DESCRIPTION
*4978 #, Add Rules for DIST DESC DIST DESC Patterns and DIST DESC DIST Pattern:*

*Description of changes:*
- Remove Distinctive after Descriptive
- Remove Descriptive if it is synonym of previous Descriptives
- Fix word classification to avoid duplicates. Avoid getting duplicates such as ` ENGINEERING` DIST and ` ENGINEERING` DIST.
- Create a new list_name which updates its tokens based on pattern dist-desc-dist and dist-desc-dist-desc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
