### PR TITLE
5086/correct compound dist

### DIFF
--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -153,16 +153,18 @@ def check_synonyms(syn_svc, stand_alone_words, list_dist_words, list_desc_words)
 
     dict_desc = dict()
 
-    for word in list_desc:
+    for word in list_desc_words:
         substitution = syn_svc.get_word_synonyms(word=word).data
         if substitution or word.lower() in stand_alone_words:
             dict_desc[word] = substitution
             if word in intersection:
                 list_dist_words.remove(word)
+        elif word in intersection:
+            list_desc.remove(word)
         else:
-            list_desc_words.remove(word)
+            dict_desc[word] = word
 
-    return list_dist_words, list_desc_words, dict_desc
+    return list_dist_words, list_desc, dict_desc
 
 
 def update_none_list(list_none_words, list_desc):
@@ -272,7 +274,7 @@ def search_word(d, search_item):
 
 
 def update_compound_tokens(list_desc_compound, original_list):
-    list_compound = list_desc_compound + original_list
+    list_compound = sorted(list_desc_compound + original_list, key=len, reverse=True)
     str_original = " ".join(original_list)
 
     compound_alternators = '|'.join(map(re.escape, list_compound))

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -791,6 +791,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def check_compound_dist(self, vector_dist_dict, original_class_list,class_subs_dict):
         vector_dist = {}
+        entropy_dist = 0.0
         list_dist = list(vector_dist_dict.keys())
         for i in range(2, len(list_dist) + 1):
             compound = [x.replace(' ','') for x in subsequences(list_dist, i)]

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -472,6 +472,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
                     vector2_dist, entropy_dist = self.get_vector(service.get_list_dist(), list_dist,
                                                                  dist_substitution_dict)
+
+                    if all(value == OTHER_W for value in vector2_dist.values()):
+                        vector2_dist, entropy_dist = self.check_compound_dist(vector2_dist, list_dist,dist_substitution_dict)
+
                     similarity_dist = round(self.get_similarity(vector1_dist, vector2_dist, entropy_dist), 2)
 
                     vector2_desc, entropy_desc = self.get_vector(remove_spaces_list(service.get_list_desc()), list_desc,
@@ -739,8 +743,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_compound_distinctives(self, dict_dist):
         list_dict = list(dict_dist.keys())
 
-        list_dist_compound = list()
-        for i in range(2, len(list_dict)):
+        list_dist_compound= list()
+        for i in range(2, len(list_dict)+1):
             list_dist_compound.extend(subsequences(list_dict, i))
 
         dist_compound_dict = self.add_substitutions(list_dist_compound, dict_dist)
@@ -784,3 +788,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                         del dict_desc[list_name[idx + 1]]
 
         return dict_compound_dist, dict_desc
+
+    def check_compound_dist(self, vector_dist_dict, original_class_list,class_subs_dict):
+        vector_dist = {}
+        list_dist = list(vector_dist_dict.keys())
+        for i in range(2, len(list_dist) + 1):
+            compound = [x.replace(' ','') for x in subsequences(list_dist, i)]
+            vector_dist, entropy_dist = self.get_vector(compound, original_class_list, class_subs_dict)
+
+        return vector_dist, entropy_dist

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
@@ -16,7 +16,9 @@ from ...common import token_header, claims
                              ("J-J BULK TRANSPORT INC.", "J & J BULK TRANSPORT LTD."),
                              ("MAPLE BAY PRESCHOOL LTD.", "MAPLE BAY PRE-SCHOOL LTD."),
                              ("THUNDERROAD INVESTMENTS LTD.", "THUNDERROAD.ORG INVESTMENTS INC."),
-                             ('J & J HARDWOOD FLOORS AND FLOWERS LTD.', "J.J.'S HARDWOOD FLOORS AND DECORATING LTD."),
+                             # No longer valid: FLOWERS AND DECORATING are in different categories,
+                             # then the name is approved
+                             # ('J & J HARDWOOD FLOORS AND FLOWERS LTD.', "J.J.'S HARDWOOD FLOORS AND DECORATING LTD."),
                              ('TRADEPRO PHOENIX ENTERPRISES LTD.', 'TRADEPRO/PHOENIX ENTERPRISES INC.'),
                              ("TEANOOK JOHNSON HOLDINGS INC.", "TEANOOK / JOHNSON HOLDINGS INC."),
                              ('BIG MIKE FUN FARM INC.', "BIG MIKE'S FUN FARM INC."),

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -17,7 +17,10 @@ from ...common import token_header, claims
                              # # ("ABC CONSULTING LTD.", "ABC INTERNATIONAL CONSULTING LTD."), #Under evaluation
                              ("NO. 001 CATHEDRAL MINING LTD.", "CATHEDRAL MINING LTD."),
                              ("ARMSTRONG PLUMBING & CAFE INC.", "ARMSTRONG PLUMBING & HEATING LTD."),
-                             # ("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."), #Failure related to stand-alone to be fixed with 4844: Fixes from UAT Rejection Testing
+                             # Stand-alone names are approved as long as they have an additional distinctive or descriptive.
+                             # The only way to be rejected is to have an exact match. We need to implement an exact match for
+                             # Stand-alone names to avoid comparing with many names, just exact matches should be returned.
+                             # ("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."),
                              ("LE BLUE CAFE LTD.", "LE BLUE RESTAURANT LTD.")
                          ]
                          )


### PR DESCRIPTION
*5086 #, Correct Compound Dist:*

*Description of changes:*
Find correct similarity for compound distinctives. For instance, vector would compress distinctive to compare `DONMANN` vs `DONMANN`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
