### PR TITLE
added send to exmaination option to assumed name, add dist, add desc …

### DIFF
--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
@@ -116,10 +116,15 @@ class BcAnalysisResponse(AnalysisResponse):
     def build_add_distinctive_word_issue(self, procedure_result, issue_count, issue_idx):
         option1 = add_distinctive_setup()
         # Tweak the header
-        option1.header = "Helpful Tip"
+        option1.header = "Option 1"
+
+        option2 = send_to_examiner_setup()
+        # Tweak the header
+        option2.header = "Option 2"
 
         issue = response_issues(procedure_result.result_code)(self, [
-            option1
+            option1,
+            option2
         ])
 
         # Add the procedure to the stack of executed_procedures so we know what issues have been set up
@@ -130,10 +135,15 @@ class BcAnalysisResponse(AnalysisResponse):
     def build_add_descriptive_word_issue(self, procedure_result, issue_count, issue_idx):
         option1 = add_descriptive_setup()
         # Tweak the header
-        option1.header = "Helpful Tip"
+        option1.header = "Option 1"
+
+        option2 = send_to_examiner_setup()
+        # Tweak the header
+        option2.header = "Option 2"
 
         issue = response_issues(procedure_result.result_code)(self, [
-            option1
+            option1,
+            option2
         ])
 
         # Add the procedure to the stack of executed_procedures so we know what issues have been set up

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/too_many_words.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/issues/too_many_words.py
@@ -14,7 +14,7 @@ class XproTooManyWordsIssue(TooManyWordsIssue):
             designations=None,
             show_reserve_button=False,
             # Set the show_examination_button to TRUE for all Xpro issues
-            show_examination_button=False,
+            show_examination_button=True,
             conflicts=None,
             setup=None,
             name_actions=None

--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
@@ -210,11 +210,17 @@ class XproAnalysisResponse(AnalysisResponse):
             EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
             else alternative_assumed_name_setup()
         # Tweak the header
-        option1.header = "Helpful Hint"
+        option1.header = "Option 1"
+
+        option2 = send_to_examiner_setup()
+        # Tweak the header
+        option2.header = "Option 2"
 
         issue = response_issues(procedure_result.result_code)(self, [
-            option1
+            option1,
+            option2
         ])
+
 
         '''
         # Quick tests for overriding button behavior


### PR DESCRIPTION
…and too many words for xpro

*Issue #, if available:*

4816 - show send to examination button for xpro too many words.  A bug.
4913- add send to examination button for missing distinctive and missing descriptive show stoppers.
5100 - allow assumed name workflow to get send to examination in the event they can get consent and dont want an assumed name.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
