### PR TITLE
feature/5062 remove double letters

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -412,19 +412,20 @@ class Request(db.Model):
 
         if queue:
             criteria.append(RequestConditionCriteria(
-                fields=[Name.name, sqlalchemy.null().label('consumptionDate'), cls.submittedDate,
+                fields=[sqlalchemy.func.regexp_replace(Name.name, '(.)\1{1,}', '\1', 'g').label('name'), sqlalchemy.null().label('consumptionDate'), cls.submittedDate,
                         sqlalchemy.null().label('corpNum'), cls.nrNum],
                 filters=[basic_filter, queue_request_state_filter]
             ))
         else:
             criteria.append(RequestConditionCriteria(
-                fields=[Name.name, Name.consumptionDate, sqlalchemy.null().label('submittedDate'),
+                fields=[sqlalchemy.func.regexp_replace(Name.name, '(.)\1{1,}', '\1', 'g').label('name'), Name.consumptionDate,
+                        sqlalchemy.null().label('submittedDate'),
                         Name.corpNum,
                         sqlalchemy.null().label('nrNum')],
                 filters=[basic_filter, corp_request_state_filter, name_state_filter, consumed_filter]
             ))
             criteria.append(RequestConditionCriteria(
-                fields=[Name.name, sqlalchemy.null().label('consumptionDate'), cls.submittedDate,
+                fields=[sqlalchemy.func.regexp_replace(Name.name, '(.)\1{1,}', '\1', 'g').label('name'), sqlalchemy.null().label('consumptionDate'), cls.submittedDate,
                         sqlalchemy.null().label('corpNum'), cls.nrNum],
                 filters=[basic_filter, corp_request_state_filter, name_state_filter, not_consumed_filter]
             ))

--- a/api/namex/services/name_request/auto_analyse/mixins/get_word_classification_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_word_classification_lists.py
@@ -3,6 +3,7 @@ class GetWordClassificationListsMixin(object):
     _list_dist_words = []
     _list_desc_words = []
     _list_none_words = []
+    _list_processed_names = []
     _list_incorrect_classification = []
     _dict_name_words = {}
 
@@ -23,3 +24,6 @@ class GetWordClassificationListsMixin(object):
 
     def get_dict_name(self):
         return self._dict_name_words
+
+    def get_processed_names(self):
+        return self._list_processed_names

--- a/api/namex/services/name_request/auto_analyse/mixins/get_word_classification_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_word_classification_lists.py
@@ -2,6 +2,7 @@ class GetWordClassificationListsMixin(object):
     _list_name_words = []
     _list_dist_words = []
     _list_desc_words = []
+    _list_dist_words_search_conflicts = []
     _list_none_words = []
     _list_processed_names = []
     _list_incorrect_classification = []
@@ -15,6 +16,9 @@ class GetWordClassificationListsMixin(object):
 
     def get_list_desc(self):
         return self._list_desc_words
+
+    def get_list_dist_search_conflicts(self):
+        return self._list_dist_words_search_conflicts
 
     def get_list_none(self):
         return self._list_none_words

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -146,23 +146,23 @@ def check_numbers_beginning(syn_svc, tokens):
     return tokens
 
 
-def check_synonyms(syn_svc, stand_alone_words, list_dist_words, list_desc_words):
+def check_synonyms(syn_svc, stand_alone_words, list_dist_words, list_desc_words, list_name):
     list_desc_words_set = frozenset(list_desc_words)
-    list_desc = list(list_desc_words)
+    list_desc = []
     intersection = [x for x in list_dist_words if x in list_desc_words_set]
-
     dict_desc = dict()
 
-    for word in list_desc_words:
-        substitution = syn_svc.get_word_synonyms(word=word).data
-        if substitution or word.lower() in stand_alone_words:
-            dict_desc[word] = substitution
-            if word in intersection:
-                list_dist_words.remove(word)
-        elif word in intersection:
-            list_desc.remove(word)
-        else:
-            dict_desc[word] = word
+    for word in list_name:
+        if word in list_desc_words:
+            substitution = syn_svc.get_word_synonyms(word=word).data
+            if substitution or word.lower() in stand_alone_words:
+                dict_desc[word] = substitution
+                list_desc.append(word)
+                if word in intersection:
+                    list_dist_words.remove(word)
+            elif word not in intersection:
+                dict_desc[word] = word
+                list_desc.append(word)
 
     return list_dist_words, list_desc, dict_desc
 
@@ -220,7 +220,8 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
     service._list_dist_words, service._list_desc_words, dict_desc = check_synonyms(syn_svc,
                                                                                    stand_alone_words,
                                                                                    service.get_list_dist(),
-                                                                                   service.get_list_desc())
+                                                                                   service.get_list_desc(),
+                                                                                   service.name_tokens)
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
@@ -237,16 +238,16 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
     service._list_dist_words = remove_misplaced_distinctive(service.get_list_dist(), service.get_list_desc(),
                                                             service.name_tokens_search_conflict)
 
-    service._list_dist_words, updated_name_tokens = remove_double_letters_list_dist_words(service.get_list_dist(),
+    service._list_dist_words_search_conflicts, updated_name_tokens = remove_double_letters_list_dist_words(service.get_list_dist(),
                                                                                           service.name_tokens_search_conflict)
     service.set_name_tokens_search_conflict(updated_name_tokens)
 
     service._list_desc_words = remove_descriptive_same_category(dict_desc)
 
-    service.set_name_tokens_search_conflict(update_token_list(service.get_list_dist() + service.get_list_desc(),
+    service.set_name_tokens_search_conflict(update_token_list(service.get_list_dist_search_conflicts() + service.get_list_desc(),
                                                               service.name_tokens_search_conflict))
 
-    service._dict_name_words = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
+    service._dict_name_words = get_classification_summary(service.get_list_dist_search_conflicts(), service.get_list_desc(),
                                                           service.name_tokens_search_conflict)
     service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -238,16 +238,19 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
     service._list_dist_words = remove_misplaced_distinctive(service.get_list_dist(), service.get_list_desc(),
                                                             service.name_tokens_search_conflict)
 
-    service._list_dist_words_search_conflicts, updated_name_tokens = remove_double_letters_list_dist_words(service.get_list_dist(),
-                                                                                          service.name_tokens_search_conflict)
+    service._list_dist_words_search_conflicts, updated_name_tokens = remove_double_letters_list_dist_words(
+        service.get_list_dist(),
+        service.name_tokens_search_conflict)
     service.set_name_tokens_search_conflict(updated_name_tokens)
 
     service._list_desc_words = remove_descriptive_same_category(dict_desc)
 
-    service.set_name_tokens_search_conflict(update_token_list(service.get_list_dist_search_conflicts() + service.get_list_desc(),
-                                                              service.name_tokens_search_conflict))
+    service.set_name_tokens_search_conflict(
+        update_token_list(service.get_list_dist_search_conflicts() + service.get_list_desc(),
+                          service.name_tokens_search_conflict))
 
-    service._dict_name_words = get_classification_summary(service.get_list_dist_search_conflicts(), service.get_list_desc(),
+    service._dict_name_words = get_classification_summary(service.get_list_dist_search_conflicts(),
+                                                          service.get_list_desc(),
                                                           service.name_tokens_search_conflict)
     service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
 
@@ -349,6 +352,9 @@ def remove_double_letters_list_dist_words(list_dist, name_tokens):
     for item in list_dist:
         not_double_letters_item = remove_double_letters(item)
         list_dist_final.append(not_double_letters_item)
-        name_tokens = list(map(lambda x: str.replace(x, item, not_double_letters_item), name_tokens))
+        name_tokens = list(map(
+            lambda x, value=item, singular_letter_value=not_double_letters_item: str.replace(x, value,
+                                                                                             singular_letter_value),
+            name_tokens))
 
     return list_dist_final, name_tokens

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -337,3 +337,11 @@ def remove_descriptive_same_category(dict_desc):
                 break
 
     return desc_list
+
+
+def remove_doble_letters(list_dist):
+    list_dist_final=[]
+    for item in list_dist:
+        list_dist_final.append(remove_double_letters(item))
+
+    return list_dist_final

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -237,6 +237,10 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
     service._list_dist_words = remove_misplaced_distinctive(service.get_list_dist(), service.get_list_desc(),
                                                             service.name_tokens_search_conflict)
 
+    service._list_dist_words, updated_name_tokens = remove_double_letters_list_dist_words(service.get_list_dist(),
+                                                                                          service.name_tokens_search_conflict)
+    service.set_name_tokens_search_conflict(updated_name_tokens)
+
     service._list_desc_words = remove_descriptive_same_category(dict_desc)
 
     service.set_name_tokens_search_conflict(update_token_list(service.get_list_dist() + service.get_list_desc(),
@@ -339,9 +343,11 @@ def remove_descriptive_same_category(dict_desc):
     return desc_list
 
 
-def remove_doble_letters(list_dist):
-    list_dist_final=[]
+def remove_double_letters_list_dist_words(list_dist, name_tokens):
+    list_dist_final = []
     for item in list_dist:
-        list_dist_final.append(remove_double_letters(item))
+        not_double_letters_item = remove_double_letters(item)
+        list_dist_final.append(not_double_letters_item)
+        name_tokens = list(map(lambda x: str.replace(x, item, not_double_letters_item), name_tokens))
 
-    return list_dist_final
+    return list_dist_final, name_tokens

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -311,6 +311,10 @@ def remove_double_letters(name):
     return re.sub(r'([a-zA-Z])\1+', r'\1', name)
 
 
+def list_to_string(lst):
+    return ' '.join(map(str, lst))
+
+
 def remove_misplaced_distinctive(list_dist, list_desc, list_name):
     if list_desc.__len__() > 0 and list_dist.__len__() > 0:
         for word in list_name[list_name.index(list_desc[0]) + 1:]:

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -307,6 +307,10 @@ def remove_spaces_list(lst):
     return [x.replace(' ', '') for x in lst]
 
 
+def remove_double_letters(name):
+    return re.sub(r'([a-zA-Z])\1+', r'\1', name)
+
+
 def remove_misplaced_distinctive(list_dist, list_desc, list_name):
     if list_desc.__len__() > 0 and list_dist.__len__() > 0:
         for word in list_name[list_name.index(list_desc[0]) + 1:]:

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -46,7 +46,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         # Return any combination of these checks
         if not self.skip_search_conflicts:
             check_conflicts = builder.search_conflicts(
-                [self.get_list_dist()],
+                [self.get_list_dist_search_conflicts()],
                 [self.get_list_desc()],
                 self.name_tokens_search_conflict,
                 self.processed_name
@@ -56,7 +56,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
                 results.append(check_conflicts)
 
         check_conflicts_queue = builder.search_conflicts(
-            [self.get_list_dist()],
+            [self.get_list_dist_search_conflicts()],
             [self.get_list_desc()],
             self.name_tokens_search_conflict,
             self.processed_name,

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -148,7 +148,7 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
 
         # Return any combination of these checks
         check_conflicts = builder.search_conflicts(
-            [self.get_list_dist()],
+            [self.get_list_dist_search_conflicts()],
             [self.get_list_desc()],
             self.name_tokens_search_conflict,
             self.processed_name
@@ -158,7 +158,7 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
             results.append(check_conflicts)
 
         check_conflicts_queue = builder.search_conflicts(
-            [self.get_list_dist()],
+            [self.get_list_dist_search_conflicts()],
             [self.get_list_desc()],
             self.name_tokens_search_conflict,
             self.processed_name,

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -9,7 +9,8 @@ from ..auto_analyse.abstract_name_analysis_builder import AbstractNameAnalysisBu
 
 from ..auto_analyse import AnalysisIssueCodes, MAX_LIMIT, MAX_MATCHES_LIMIT
 from ..auto_analyse.name_analysis_utils import get_flat_list, get_conflicts_same_classification, \
-    get_classification, get_all_dict_substitutions, remove_spaces_list, subsequences, remove_double_letters
+    get_classification, get_all_dict_substitutions, remove_spaces_list, subsequences, remove_double_letters, \
+    list_to_string
 
 from namex.models.request import Request
 from ..auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
@@ -171,13 +172,19 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def get_conflicts(self, dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed, queue):
         dist_substitution_dict, desc_synonym_dict, dist_substitution_compound_dict, desc_synonym_compound_dict = {}, {}, {}, {}
+        dist = list_to_string(w_dist)
+        desc = list_to_string(w_desc)
 
         if check_name_is_well_formed:
             dist_substitution_dict = self.get_dictionary(dist_substitution_dict, w_dist)
+            dist_substitution_dict[dist].append(remove_double_letters(w_dist))
             desc_synonym_dict = self.get_dictionary(desc_synonym_dict, w_desc)
+            desc_synonym_dict[desc].append(remove_double_letters(w_desc))
         else:
             dist_substitution_dict = self.get_subsitutions_distinctive(w_dist)
+            dist_substitution_dict[dist].append(remove_double_letters(w_dist))
             desc_synonym_dict = self.get_substitutions_descriptive(w_desc)
+            desc_synonym_dict[desc].append(remove_double_letters(w_desc))
 
         list_conflict_details = list()
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -177,14 +177,14 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         if check_name_is_well_formed:
             dist_substitution_dict = self.get_dictionary(dist_substitution_dict, w_dist)
-            dist_substitution_dict[dist].append(remove_double_letters(w_dist))
+            dist_substitution_dict[dist].append(remove_double_letters(dist))
             desc_synonym_dict = self.get_dictionary(desc_synonym_dict, w_desc)
-            desc_synonym_dict[desc].append(remove_double_letters(w_desc))
+            desc_synonym_dict[desc].append(remove_double_letters(desc))
         else:
             dist_substitution_dict = self.get_subsitutions_distinctive(w_dist)
-            dist_substitution_dict[dist].append(remove_double_letters(w_dist))
+            dist_substitution_dict[dist].append(remove_double_letters(dist))
             desc_synonym_dict = self.get_substitutions_descriptive(w_desc)
-            desc_synonym_dict[desc].append(remove_double_letters(w_desc))
+            desc_synonym_dict[desc].append(remove_double_letters(desc))
 
         list_conflict_details = list()
 

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -472,7 +472,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                     match_list = np_svc.name_tokens
                     get_classification(service, stand_alone_words, syn_svc, match_list, wc_svc, token_svc)
 
-                    vector2_dist, entropy_dist = self.get_vector(service.get_list_dist(), list_dist,
+                    vector2_dist, entropy_dist = self.get_vector(service.get_list_dist_search_conflicts(), list_dist,
                                                                  dist_substitution_dict)
 
                     if all(value == OTHER_W for value in vector2_dist.values()):

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -824,12 +824,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def skip_name_matches_processed(self, matches):
         unique_matches = []
         for match in matches:
-            if not self._list_processed_names:
+            if match.name not in self._list_processed_names:
                 self._list_processed_names.append(match.name)
                 unique_matches.append(match)
-            else:
-                if match.name not in self._list_processed_names:
-                    self._list_processed_names.append(match.name)
-                    unique_matches.append(match)
 
         return unique_matches

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -9,7 +9,7 @@ from ..auto_analyse.abstract_name_analysis_builder import AbstractNameAnalysisBu
 
 from ..auto_analyse import AnalysisIssueCodes, MAX_LIMIT, MAX_MATCHES_LIMIT
 from ..auto_analyse.name_analysis_utils import get_flat_list, get_conflicts_same_classification, \
-    get_classification, get_all_dict_substitutions, remove_spaces_list, subsequences
+    get_classification, get_all_dict_substitutions, remove_spaces_list, subsequences, remove_double_letters
 
 from namex.models.request import Request
 from ..auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
@@ -754,8 +754,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_compound_distinctives(self, dict_dist):
         list_dict = list(dict_dist.keys())
 
-        list_dist_compound= list()
-        for i in range(2, len(list_dict)+1):
+        list_dist_compound = list()
+        for i in range(2, len(list_dict) + 1):
             list_dist_compound.extend(subsequences(list_dict, i))
 
         dist_compound_dict = self.add_substitutions(list_dist_compound, dict_dist)

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -754,8 +754,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_compound_distinctives(self, dict_dist):
         list_dict = list(dict_dist.keys())
 
-        list_dist_compound = list()
-        for i in range(2, len(list_dict) + 1):
+        list_dist_compound= list()
+        for i in range(2, len(list_dict)+1):
             list_dist_compound.extend(subsequences(list_dict, i))
 
         dist_compound_dict = self.add_substitutions(list_dist_compound, dict_dist)


### PR DESCRIPTION
*5062 #, Remove double letters:*

*Description of changes:*
Remove double letters on input name and conflict names. This applies just for search conflicts.
- Creation of new list of distinctives to remove duplicate letters.
- Remove double letters in distinctives for name provided by user and names coming from db
- New list of distinctive is taken for calculating similarity
- Extra: Discard names from the query result when name was already analyzed.
- Regression tests executed
- XPRO name tests executed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
