### PR TITLE
5057 handle h2 everywhere in name

### DIFF
--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -833,10 +833,10 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def check_additional_dist_desc(self, list_dist_user_name, list_dist_conflict, dict_desc_user_name, service):
         for (k, v), (k2, v2) in zip(service.get_dict_desc_search_conflicts().items(), dict_desc_user_name.items()):
             same_synonym_category = porter.stem(k2) in v
-            if (k != k2 and same_synonym_category and list_dist_user_name.__len__() > list_dist_conflict.__len__()) or \
+            if (k != k2 and k2 not in service.get_list_desc() and same_synonym_category and list_dist_user_name.__len__() > list_dist_conflict.__len__()) or \
                     not same_synonym_category:
+                print("Name '{}' is not considered a real conflict.".format(service.get_processed_name()))
                 return True
-
         return False
 
     def is_not_real_conflict(self, list_name, stand_alone_words, list_dist, dict_desc, service):

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -214,7 +214,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         text = self.regex_numbers_lot(text)
         text = self.regex_repeated_strings(text)
         text = self.regex_separated_ordinals(text, ordinal_suffixes)
-        text = self.regex_keep_together_abv(text, exceptions_ws)
+        # text = self.regex_keep_together_abv(text, exceptions_ws)
         text = self.regex_punctuation(text)
         text = self.regex_together_one_letter(text)
         text = self.regex_strip_out_numbers_middle_end(text, ordinal_suffixes, numbers)


### PR DESCRIPTION
*5057 #, Handle H2 everywhere in name:*

*Description of changes:*
- Remove the application of any transformation to abbreviations made of numbers and names
- Additional check for ensuring the different descriptive found in new name is not in the original descriptive list of conflicted name. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
