### PR TITLE
feature/5224-Session-Timer

### DIFF
--- a/api/namex/resources/name_requests/name_request.py
+++ b/api/namex/resources/name_requests/name_request.py
@@ -10,7 +10,7 @@ from namex.models import Request, State, Event
 
 from namex.services import EventRecorder
 from namex.services.name_request.name_request_state import get_nr_state_actions
-from namex.services.name_request.utils import get_mapped_entity_and_action_code
+from namex.services.name_request.utils import get_mapped_entity_and_action_code, is_temp_nr_num
 from namex.services.name_request.exceptions import \
     NameRequestException, InvalidInputError
 
@@ -376,9 +376,10 @@ class NameRequestRollback(NameRequestResource):
 
         # This handles updates if the NR state is 'patchable'
         nr_model = self.update_nr_fields(nr_model, State.CANCELLED)
-
-        # This handles the updates for NRO and Solr, if necessary
-        self.update_records_in_network_services(nr_model)
+        # Only update the record in NRO if it's a real NR, otherwise the record won't exist
+        if not is_temp_nr_num(nr_model.nrNum):
+            # This handles the updates for NRO and Solr, if necessary
+            self.update_records_in_network_services(nr_model)
 
         # Record the event
         EventRecorder.record(nr_svc.user, Event.PATCH, nr_model, nr_svc.request_data)

--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -16,10 +16,12 @@ from namex.models import Request as RequestDAO, Payment as PaymentDAO, State, Ev
 
 from namex.resources.name_requests.abstract_nr_resource import AbstractNameRequestResource
 
-from namex.services import EventRecorder
+# TODO: There are places to add this!
+# from namex.services import EventRecorder
 from namex.services.name_request.name_request_state import get_nr_state_actions
 from namex.services.payment.exceptions import SBCPaymentException, SBCPaymentError, PaymentServiceError
-from namex.services.payment.invoices import get_invoices
+# TODO: We may need this, code that uses this import is commented out
+# from namex.services.payment.invoices import get_invoices
 from namex.services.payment.payments import get_payment, create_payment, update_payment
 from namex.services.name_request.utils import has_active_payment, get_active_payment
 
@@ -228,7 +230,7 @@ class CreateNameRequestPayment(AbstractNameRequestResource):
 
             if valid_payment_action and valid_nr_state:
                 if payment_action in [NameRequestActions.COMPLETE.value]:
-                    # Save back to NRO to get the updated NR Number
+                    # Save the record to NRO, which swaps the NR-L Number for a real NR
                     update_solr = True
                     nr_model = self.add_records_to_network_services(nr_model, update_solr)
 

--- a/api/namex/services/name_request/utils.py
+++ b/api/namex/services/name_request/utils.py
@@ -30,6 +30,20 @@ def normalize_nr_num(nr_num_str):
     return None
 
 
+def is_temp_nr_num(nr_num_str):
+    matches = re.findall(nr_regex, nr_num_str, flags=re.IGNORECASE)
+    # If there's a match and the match has a second capturing group (valid NR digits) then proceed
+    if len(matches) == 1 and matches[0][1]:
+        # Get the first capturing group if it exists, convert to upper case, and remove any spaces
+        nr_type = str(matches[0][0]).upper().replace(' ', '') if matches[0][
+            0] else 'NR'  # Default to NR if not supplied
+
+        if nr_type in ['NRL', 'L']:
+            return True
+
+    return False
+
+
 def has_active_payment(nr, payment_id=None):
     payments = nr.payments.all()
     if payments and payment_id:


### PR DESCRIPTION
Add util to check if an NR number is a temp NR or a real NR number. Use that in handle_patch_rollback to make sure we only cancel records in NRO if there is a real NR (don't update temp NRs they won't have corresponding records.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
