### PR TITLE
5189/Error-on-company-with-multi-word-province

### DIFF
--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -75,6 +75,14 @@ class NameProcessingService(GetSynonymListsMixin):
         self._name_tokens = val
 
     @property
+    def compound_descriptive_name_tokens(self):
+        return self._compound_descriptive_name_tokens
+
+    @compound_descriptive_name_tokens.setter
+    def compound_descriptive_name_tokens(self, val):
+        self._compound_descriptive_name_tokens = val
+
+    @property
     def name_tokens_search_conflict(self):
         return self._name_tokens_search_conflict
 
@@ -120,6 +128,7 @@ class NameProcessingService(GetSynonymListsMixin):
         self.name_original_tokens = None
         self.processed_name = None
         self.name_tokens = None
+        self._compound_descriptive_name_tokens = None
         self.name_tokens_search_conflict = None
         self.distinctive_word_tokens = None
         self.descriptive_word_tokens = None

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -93,6 +93,11 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         return self.name_processing_service.name_tokens if np_svc else ''
 
     @property
+    def compound_descriptive_name_tokens(self):
+        np_svc = self.name_processing_service
+        return self.name_processing_service.compound_descriptive_name_tokens if np_svc else ''
+
+    @property
     def name_tokens_search_conflict(self):
         np_svc = self.name_processing_service
         return self.name_processing_service.name_tokens_search_conflict if np_svc else ''
@@ -199,6 +204,14 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         self.name_processing_service.name_tokens = name_tokens
 
     # API for extending implementations
+    def get_compound_descriptive_name_tokens(self):
+        return self.compound_descriptive_name_tokens
+
+    # API for extending implementations
+    def set_compound_descriptive_name_tokens(self, name_tokens):
+        self.name_processing_service.compound_descriptive_name_tokens = name_tokens
+
+    # API for extending implementations
     def get_name_tokens_search_conflict(self):
         return self.name_tokens_search_conflict
 
@@ -274,7 +287,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 self._dict_name_words,
                 self._list_dist_words,
                 self._list_desc_words,
-                self.name_tokens,
+                self.compound_descriptive_name_tokens,
                 self.processed_name,
                 self.name_original_tokens
             )

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -197,16 +197,18 @@ def get_classification_summary(list_dist, list_desc, list_name):
 def get_conflicts_same_classification(builder, name_tokens, processed_name, list_dist, list_desc):
     list_dist, list_desc = \
         list_distinctive_descriptive(name_tokens, list_dist, list_desc)
-    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name, True)
+    # Search conflicts coming from check_name_is_well_formed analysis
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name,
+                                               check_name_is_well_formed=True)
 
     return check_conflicts
 
 
 def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc):
     desc_compound_dict = get_compound_descriptives(service, syn_svc)
-    service.set_name_tokens(update_compound_tokens(list(desc_compound_dict.keys()), match))
+    service.set_compound_descriptive_name_tokens(update_compound_tokens(list(desc_compound_dict.keys()), match))
 
-    service.token_classifier = wc_svc.classify_tokens(service.name_tokens)
+    service.token_classifier = wc_svc.classify_tokens(service.compound_descriptive_name_tokens)
     service._list_dist_words, service._list_desc_words, service._list_none_words = service.word_classification_tokens
 
     if service.get_list_none() and service.get_list_none().__len__() > 0:
@@ -215,26 +217,27 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
                 service.get_list_dist(),
                 service.get_list_desc(),
                 service.get_list_none(),
-                service.name_tokens
+                service.compound_descriptive_name_tokens
             )
     service._list_dist_words, service._list_desc_words, dict_desc = check_synonyms(syn_svc,
                                                                                    stand_alone_words,
                                                                                    service.get_list_dist(),
                                                                                    service.get_list_desc(),
-                                                                                   service.name_tokens)
+                                                                                   service.compound_descriptive_name_tokens)
 
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
-    service.set_name_tokens(
-        update_compound_tokens(service.get_list_dist() + service.get_list_desc(), service.name_tokens))
+    service.set_compound_descriptive_name_tokens(
+        update_compound_tokens(service.get_list_dist() + service.get_list_desc(),
+                               service.compound_descriptive_name_tokens))
 
     dict_name_words_original = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
-                                                          service.name_tokens)
+                                                          service.compound_descriptive_name_tokens)
     # service.set_name_tokens(remove_spaces_list(service.name_tokens))
     print("Original Classification:")
     print(dict_name_words_original)
 
-    service.set_name_tokens_search_conflict(service.name_tokens)
+    service.set_name_tokens_search_conflict(service.compound_descriptive_name_tokens)
     service._list_dist_words_search_conflicts = remove_misplaced_distinctive(list(service.get_list_dist()),
                                                                              service.get_list_desc(),
                                                                              service.name_tokens_search_conflict)

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -51,8 +51,10 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
 
         # Return any combination of these checks
         if not self.skip_search_conflicts:
-            check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(), self.name_tokens,
-                                                         False, self.get_designation_end_list(), self.get_designation_any_list(),
+            check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
+                                                         self.compound_descriptive_name_tokens,
+                                                         False, self.get_designation_end_list(),
+                                                         self.get_designation_any_list(),
                                                          stop_words_list)
 
             if check_conflicts.is_valid:
@@ -67,7 +69,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
                 results.append(check_conflicts)
 
         check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
-                                                           self.name_tokens, True, self.get_designation_end_list(),
+                                                           self.compound_descriptive_name_tokens, True,
+                                                           self.get_designation_end_list(),
                                                            self.get_designation_any_list(), stop_words_list)
 
         if check_conflicts_queue.is_valid:
@@ -76,8 +79,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
                 [self.get_list_desc_search_conflicts()],
                 self.name_tokens_search_conflict,
                 self.processed_name,
-                False,
-                True
+                check_name_is_well_formed=False,
+                queue=True
             )
 
         if not check_conflicts_queue.is_valid:

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -163,7 +163,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
 
         # Return any combination of these checks
         if not self.skip_search_conflicts:
-            check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(), self.name_tokens,
+            check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
+                                                         self.compound_descriptive_name_tokens,
                                                          False, self.get_designation_end_list(),
                                                          self.get_designation_any_list(), stop_words_list)
 
@@ -178,7 +179,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
             if not check_conflicts.is_valid:
                 results.append(check_conflicts)
 
-        check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(), self.name_tokens,
+        check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
+                                                           self.compound_descriptive_name_tokens,
                                                            True, self.get_designation_end_list(),
                                                            self.get_designation_any_list(), stop_words_list)
 
@@ -188,8 +190,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
                 [self.get_list_desc_search_conflicts()],
                 self.name_tokens_search_conflict,
                 self.processed_name,
-                False,
-                True
+                check_name_is_well_formed=False,
+                queue=True
             )
 
         if not check_conflicts_queue.is_valid:

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -288,7 +288,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                         self.get_position_word_consent(words_consent.lower().replace(" ", ""), name_sin_plural))
                     word_consent_original_list.append(words_consent)
                     break
-
+        word_consent_original_list = list(set(word_consent_original_list))
         words_consent_list_response = []
         for key in sorted(words_consent_dict):
             words_consent_list_response.append(list_name[key])

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -170,7 +170,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def get_conflicts(self, dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed, queue):
         dist_substitution_dict, desc_synonym_dict, dist_substitution_compound_dict, desc_synonym_compound_dict = {}, {}, {}, {}
-
+        # Need to check if the name is well formed?
         if check_name_is_well_formed:
             dist_substitution_dict = self.get_dictionary(dist_substitution_dict, w_dist)
             desc_synonym_dict = self.get_dictionary(desc_synonym_dict, w_desc)
@@ -276,10 +276,16 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         word_consent_original_list = []
         name_singular_plural_list = list(set(get_plural_singular_name(name)))
 
-        for words_consent in all_words_consent_list:
-            for name_sin_plural in name_singular_plural_list:
-                if re.search(r'\b{}\b'.format(re.escape(words_consent.lower())), name_sin_plural.lower()):
+        for name_sin_plural in name_singular_plural_list:
+            for words_consent in all_words_consent_list:
+                if re.search(r'\b{0}\b'.format(re.escape(words_consent.lower())), name_sin_plural.lower()):
                     words_consent_dict.update(self.get_position_word_consent(words_consent, name_sin_plural))
+                    word_consent_original_list.append(words_consent)
+                    break
+                elif re.search(r'\b{0}\b'.format(re.escape(words_consent.lower().replace(" ", ""))),
+                               name_sin_plural.lower()):
+                    words_consent_dict.update(
+                        self.get_position_word_consent(words_consent.lower().replace(" ", ""), name_sin_plural))
                     word_consent_original_list.append(words_consent)
                     break
 

--- a/api/namex/utils/common.py
+++ b/api/namex/utils/common.py
@@ -74,9 +74,12 @@ def get_plural_singular_name(name):
     for word in name.split():
         val = []
         singular = p.singular_noun(word)
-        if singular is not False:
-            val.extend([singular])
-        val.extend([word.lower()])
+        plural = p.plural_noun(word)
+        if singular:
+            val.append(singular.lower())
+        if plural:
+            val.append(plural.lower())
+        val.append(word.lower())
         d[word] = (list(set(val)))
 
     name_list = []


### PR DESCRIPTION
*5189 #, Error on Company with Multi Word province:*

*Description of changes:*
- Created a new version of name_tokens which before was storing the clean name tokenized. This got affected when classifying the words and updated name_tokens for compound descriptives as one token. This affected the further analysis when issues were arised. Now, we keep the original name_tokens and use in further analysis.
- Handle word requiring consent with no space such as NEWBRUNSWICK which was not recognized before. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
