### PR TITLE
Fix solr cancel

### DIFF
--- a/api/namex/resources/name_requests/abstract_solr_resource.py
+++ b/api/namex/resources/name_requests/abstract_solr_resource.py
@@ -65,7 +65,7 @@ class AbstractSolrResource(Resource):
 
         # Only update solr for corp entity types
         # TODO: Use the actual codes from the constants file...
-        if nr_model.stateCd in [State.COND_RESERVE, State.RESERVED, State.CONDITIONAL, State.APPROVED] and \
+        if nr_model.stateCd in [State.COND_RESERVE, State.RESERVED, State.CONDITIONAL, State.APPROVED, State.CANCELLED] and \
                 nr_model.entity_type_cd in ['CR', 'UL', 'BC', 'CP', 'PA', 'XCR', 'XUL', 'XCP', 'CC', 'FI', 'XCR', 'XUL', 'XCP']:
 
             cls.create_solr_nr_doc(SOLR_CORE, nr_model)

--- a/api/namex/resources/name_requests/name_request.py
+++ b/api/namex/resources/name_requests/name_request.py
@@ -379,8 +379,11 @@ class NameRequestRollback(NameRequestResource):
         # Only update the record in NRO if it's a real NR, otherwise the record won't exist
         if not is_temp_nr_num(nr_model.nrNum):
             # This handles the updates for NRO and Solr, if necessary
-            self.update_records_in_network_services(nr_model, True)
-
+            self.update_records_in_network_services(nr_model, update_solr=True)
+        else:
+            temp_nr_num = nr_model.nrNum
+            # Update SOLR
+            self.update_solr_service(nr_model, temp_nr_num)
         # Record the event
         EventRecorder.record(nr_svc.user, Event.PATCH, nr_model, nr_svc.request_data)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes the bug.  When a TEMP_NR is cancelled it must also be cancelled in solr.  It does not have anything in oracle but does in sorl for cancelled cond-reserve and reserved NRs that are a corp entity type.  The timeout on the front-end when the user sits on the screen to complete applicant info and does not click Continue & Pay.  They have 5 mins and then it all gets cancelled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
