### PR TITLE
5336 quart service move preparation tasks

### DIFF
--- a/api/namex/models/virtual_word_condition.py
+++ b/api/namex/models/virtual_word_condition.py
@@ -34,8 +34,10 @@ class VirtualWordCondition(db.Model):
         query = cls.query.with_entities(*criteria.fields) \
             .filter(and_(*criteria.filters))
 
+        results = query.all()
+        cls.close_session()
         # print(query.statement)
-        return query.all()
+        return results
 
     def save_to_db(self):
         db.session.add(self)
@@ -43,6 +45,10 @@ class VirtualWordCondition(db.Model):
 
     def save_to_session(self):
         db.session.add(self)
+
+    @classmethod
+    def close_session(cls):
+        db.session.close()
 
 
 class VirtualWordConditionSchema(ma.ModelSchema):

--- a/api/namex/models/word_classification.py
+++ b/api/namex/models/word_classification.py
@@ -49,6 +49,7 @@ class WordClassification(db.Model):
             .filter(cls.end_dt.is_(None)) \
             .filter(cls.start_dt <= date.today()) \
             .filter(cls.approved_dt <= date.today()).all()
+        cls.close_session()
         return results
 
     @classmethod
@@ -59,11 +60,13 @@ class WordClassification(db.Model):
             .filter(cls.end_dt.is_(None)) \
             .filter(cls.start_dt <= date.today()) \
             .filter(cls.approved_dt <= date.today()).all()
+        cls.close_session()
         return results
 
     def save_to_db(self):
         db.session.add(self)
         db.session.commit()
+        db.session.close()
 
     def save_to_session(self):
         db.session.add(self)
@@ -71,6 +74,11 @@ class WordClassification(db.Model):
     def delete_from_db(self):
         db.session.delete(self)
         db.session.commit()
+        db.session.close()
+
+    @classmethod
+    def close_session(cls):
+        db.session.close()
 
 
 class WordClassificationSchema(ma.ModelSchema):

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -2,6 +2,7 @@ import re
 import warnings
 
 from . import LanguageCodes
+from ..name_request.auto_analyse.mixins.get_designations_lists import GetDesignationsListsMixin
 from ..name_request.auto_analyse.name_analysis_utils import remove_french, remove_stop_words, check_numbers_beginning
 
 # from namex.services.synonyms.synonym import SynonymService
@@ -25,7 +26,7 @@ Setting the name using NameProcessingService.set_name will clean the name and se
 '''
 
 
-class NameProcessingService(GetSynonymListsMixin):
+class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
     @property
     def name_as_submitted(self):
         return self._name_as_submitted
@@ -242,7 +243,7 @@ class NameProcessingService(GetSynonymListsMixin):
 
         return exception_stopword_designation
 
-    def _prepare_data(self):
+    def prepare_data(self):
         syn_svc = self.synonym_service
 
         # Query database for word designations
@@ -273,7 +274,7 @@ class NameProcessingService(GetSynonymListsMixin):
     def _process_name(self):
         try:
             # Prepare any data that we need to pre-process the name
-            self._prepare_data()
+            # self._prepare_data()
 
             # Clean the provided name and tokenize the string
             self.name_tokens = self._clean_name_words(

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -4,8 +4,6 @@ import warnings
 from . import LanguageCodes
 from ..name_request.auto_analyse.mixins.get_designations_lists import GetDesignationsListsMixin
 from ..name_request.auto_analyse.name_analysis_utils import remove_french, remove_stop_words, check_numbers_beginning
-
-# from namex.services.synonyms.synonym import SynonymService
 from namex.services.word_classification.word_classification import WordClassificationService
 
 from .mixins.get_synonym_lists import GetSynonymListsMixin
@@ -139,22 +137,9 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
     Set and process a submitted name string using the process_name class method.
     '''
 
-    def set_name(self, name):
-        # syn_svc = SynonymService()
+    def set_name(self, name, np_svc_prep_data):
         self.name_as_submitted = name  # Store the user's submitted name string
-
-        # self._prefixes = syn_svc.get_prefixes().data
-        # prefixes = '|'.join(self._prefixes)
-        # name = syn_svc.get_regex_prefixes(
-        #     text=name,
-        #     prefixes_str=prefixes
-        # ).data
-        #
-        # self.name_first_part = remove_french(name)
-        # # self.name_original_tokens = name.lower().split()
-        # self.name_original_tokens = [x for x in [x.strip() for x in re.split('([ &/-])', name.lower())] if x]
-
-        self._process_name()
+        self._process_name(np_svc_prep_data)
 
     def set_name_tokenized(self, name):
         all_designations = self._designated_all_words
@@ -193,15 +178,15 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
         name = remove_french(words, designation_alternators)
         self.name_first_part = name
 
-        exceptions_ws = syn_svc.get_exception_regex(text=name).data
-        exceptions_ws.extend(self.exception_virtual_word_condition(name, vwc_svc))
+        #exceptions_ws = syn_svc.get_exception_regex(text=name).data
+        #exceptions_ws.extend(self.exception_virtual_word_condition(name, vwc_svc))
 
         tokens = syn_svc.get_transform_text(
             text=name,
             designation_all=designation_all,
             prefix_list=prefix_list,
             number_list=number_list,
-            exceptions_ws=exceptions_ws
+            exceptions_ws=[]
         ).data
 
         tokens = tokens.split()
@@ -271,20 +256,17 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
     @:param string:name
     '''
 
-    def _process_name(self):
+    def _process_name(self, np_svc_prep_data):
         try:
-            # Prepare any data that we need to pre-process the name
-            # self._prepare_data()
-
             # Clean the provided name and tokenize the string
             self.name_tokens = self._clean_name_words(
                 self.name_as_submitted,
                 # These properties are mixed in via GetSynonymListsMixin
                 # See the class constructor
-                self._stop_words,
-                self._designated_all_words,
-                self._prefixes,
-                self._number_words
+                np_svc_prep_data.get_stop_words(),
+                np_svc_prep_data.get_designated_all_words(),
+                np_svc_prep_data.get_prefixes(),
+                np_svc_prep_data.get_number_words()
             )
 
             # Store clean, processed name to instance

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -153,7 +153,7 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
             warnings.warn("Parameters in clean_name_words function are not set.", Warning)
 
         syn_svc = self.synonym_service
-        vwc_svc = self.virtual_word_condition_service
+        # vwc_svc = self.virtual_word_condition_service
 
         all_designations = self._designated_all_words
         all_designations.sort(key=len, reverse=True)
@@ -178,8 +178,8 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
         name = remove_french(words, designation_alternators)
         self.name_first_part = name
 
-        #exceptions_ws = syn_svc.get_exception_regex(text=name).data
-        #exceptions_ws.extend(self.exception_virtual_word_condition(name, vwc_svc))
+        # exceptions_ws = syn_svc.get_exception_regex(text=name).data
+        # exceptions_ws.extend(self.exception_virtual_word_condition(name, vwc_svc))
 
         tokens = syn_svc.get_transform_text(
             text=name,

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -3,6 +3,8 @@ class GetDesignationsListsMixin(object):
     _designated_end_words = []
     _designated_any_words = []
 
+    _designated_all_words = []
+
     _eng_designated_end_words = []
     _eng_designated_any_words = []
 
@@ -53,6 +55,9 @@ class GetDesignationsListsMixin(object):
 
     def get_designated_any_words(self):
         return self._designated_any_words
+
+    def get_designated_all_words(self):
+        return self._designated_all_words
 
     def get_eng_designated_end_words(self):
         return self._eng_designated_end_words

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -247,6 +247,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
         np_svc = self.name_processing_service
         wc_svc = self.word_classification_service
 
+        np_svc.prepare_data()
         np_svc.set_name(name)
         np_svc.set_name_tokenized(np_svc.name_first_part)
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -245,10 +245,11 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
 
     def set_name(self, name):
         np_svc = self.name_processing_service
+        np_svc_prep_data = self.name_processing_service
         wc_svc = self.word_classification_service
 
-        np_svc.prepare_data()
-        np_svc.set_name(name)
+        np_svc_prep_data.prepare_data()
+        np_svc.set_name(name, np_svc_prep_data)
         np_svc.set_name_tokenized(np_svc.name_first_part)
 
         self._list_name_words = np_svc.name_tokens


### PR DESCRIPTION
*5336 #, Quart Service move preparation tasks:*

*Description of changes:*

- Move a level up prepare data function to decouple from set_name function, we are just passing the values collected from prepare_data.
- Close sessions to avoid timeout in database
- Add logging in auto-analyze service

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
