### PR TITLE
5117: ASSETS-CausesStrangeBehaviour

### DIFF
--- a/api/namex/services/name_request/auto_analyse/mixins/get_word_classification_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_word_classification_lists.py
@@ -8,6 +8,7 @@ class GetWordClassificationListsMixin(object):
     _list_none_words = []
     _list_processed_names = []
     _list_incorrect_classification = []
+    _dict_name_words_search_conflicts = {}
     _dict_name_words = {}
 
     def get_list_name(self):
@@ -36,6 +37,9 @@ class GetWordClassificationListsMixin(object):
 
     def get_dict_name(self):
         return self._dict_name_words
+
+    def get_dict_name_search_conflicts(self):
+        return self._dict_name_words_search_conflicts
 
     def get_processed_names(self):
         return self._list_processed_names

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -231,11 +231,11 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
         update_compound_tokens(service.get_list_dist() + service.get_list_desc(),
                                service.compound_descriptive_name_tokens))
 
-    dict_name_words_original = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
+    service._dict_name_words = get_classification_summary(service.get_list_dist(), service.get_list_desc(),
                                                           service.compound_descriptive_name_tokens)
     # service.set_name_tokens(remove_spaces_list(service.name_tokens))
     print("Original Classification:")
-    print(dict_name_words_original)
+    print(service.get_dict_name())
 
     service.set_name_tokens_search_conflict(service.compound_descriptive_name_tokens)
     service._list_dist_words_search_conflicts = remove_misplaced_distinctive(list(service.get_list_dist()),
@@ -254,13 +254,13 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
         update_token_list(service.get_list_dist_search_conflicts() + service.get_list_desc_search_conflicts(),
                           service.name_tokens_search_conflict))
 
-    service._dict_name_words = get_classification_summary(service.get_list_dist_search_conflicts(),
-                                                          service.get_list_desc_search_conflicts(),
-                                                          service.name_tokens_search_conflict)
+    service._dict_name_words_search_conflicts = get_classification_summary(service.get_list_dist_search_conflicts(),
+                                                                           service.get_list_desc_search_conflicts(),
+                                                                           service.name_tokens_search_conflict)
     service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
 
     print("Classification for search conflict:")
-    print(service.get_dict_name())
+    print(service.get_dict_name_search_conflicts())
 
 
 def subsequences(iterable, length):


### PR DESCRIPTION
*5117 #, ASSETS Causes Strange Behaviour:*

*Description of changes:*
When checking for well formed names, the dictionary passed containing the classification needs to be the original one, not the one processed for search conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
