### PR TITLE
5391/double corp designations send to examination

### DIFF
--- a/api/namex/resources/auto_analyse/issues/abstract/analysis_response_issue.py
+++ b/api/namex/resources/auto_analyse/issues/abstract/analysis_response_issue.py
@@ -160,9 +160,10 @@ class AnalysisResponseIssue:
 
     def adjust_word_index(self, original_name_str, name_original_tokens, name_tokens, word_idx, offset_designations=True):
         all_designations = self.analysis_response.analysis_service.get_all_designations()
+        list_original = self._lc_list_items(name_original_tokens)
         # all_designations_user = self.analysis_response.analysis_service.get_all_designations_user()
 
-        original_tokens = deque(name_original_tokens)
+        original_tokens = deque(list_original)
         processed_tokens = deque(name_tokens)
         processed_token_idx = 0
 

--- a/api/namex/resources/auto_analyse/issues/end_designation_more_than_once.py
+++ b/api/namex/resources/auto_analyse/issues/end_designation_more_than_once.py
@@ -21,7 +21,7 @@ class EndDesignationMoreThanOnceIssue(AnalysisResponseIssue):
             consenting_body=None,
             designations=None,
             show_reserve_button=False,
-            show_examination_button=False,
+            show_examination_button=True,
             conflicts=None,
             setup=None,
             name_actions=[]
@@ -37,10 +37,9 @@ class EndDesignationMoreThanOnceIssue(AnalysisResponseIssue):
         list_name_incl_designation_lc = self._lc_list_items(list_name_incl_designation)
 
         issue = self.create_issue()
-        issue.line1 = "There can be only one designation. You must choose either " + self._join_list_words(
-            correct_end_designations_lc, "</b>  or  <b>")
+        issue.line1 = "You are including multiple corporate designations which will need to be examined. "
 
-        issue.designations = correct_end_designations_lc
+        # issue.designations = correct_end_designations_lc
 
         # Loop over the list_name words, we need to decide to do with each word
         for word in list_name_incl_designation_lc:

--- a/api/namex/resources/auto_analyse/issues/end_designation_more_than_once.py
+++ b/api/namex/resources/auto_analyse/issues/end_designation_more_than_once.py
@@ -39,8 +39,6 @@ class EndDesignationMoreThanOnceIssue(AnalysisResponseIssue):
         issue = self.create_issue()
         issue.line1 = "You are including multiple corporate designations which will need to be examined. "
 
-        # issue.designations = correct_end_designations_lc
-
         # Loop over the list_name words, we need to decide to do with each word
         for word in list_name_incl_designation_lc:
             offset_idx, word_idx, word_idx_offset, composite_token_offset = self.adjust_word_index(

--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
@@ -316,7 +316,7 @@ class BcAnalysisResponse(AnalysisResponse):
         return issue
 
     def build_end_designation_more_than_once_issue(self, procedure_result, issue_count, issue_idx):
-        option1 = two_designations_order_setup()
+        option1 = send_to_examiner_setup()
         # Tweak the header
         option1.header = "Option 1"
 

--- a/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/get_designations_lists.py
@@ -25,7 +25,7 @@ class GetDesignationsListsMixin(object):
     _fr_designation_all_list_correct = []
 
     _all_designations_user = []
-    #_all_designations_user_no_periods = []
+    # _all_designations_user_no_periods = []
 
     # All designations for entity type typed bu user
     designations_entity_type_user = []
@@ -46,6 +46,9 @@ class GetDesignationsListsMixin(object):
 
     # All possible entity types found related to company name.
     _all_entity_type = []
+
+    _designation_any_list_all = []
+    _designation_end_list_all = []
 
     _entity_end_designation_dict = {}
     _entity_any_designation_dict = {}
@@ -107,7 +110,7 @@ class GetDesignationsListsMixin(object):
     def get_all_designations_user(self):
         return self._all_designations_user
 
-    #def get_all_designations_user_no_periods(self):
+    # def get_all_designations_user_no_periods(self):
     #    return self._all_designations_user_no_periods
 
     def get_all_designations(self):
@@ -118,3 +121,9 @@ class GetDesignationsListsMixin(object):
 
     def get_designation_end_list(self):
         return self._designation_end_list
+
+    def get_designation_any_list_all(self):
+        return self._designation_any_list_all
+
+    def get_designation_end_list_all(self):
+        return self._designation_end_list_all

--- a/api/namex/services/name_request/auto_analyse/mixins/set_designation_lists.py
+++ b/api/namex/services/name_request/auto_analyse/mixins/set_designation_lists.py
@@ -69,7 +69,8 @@ class SetDesignationsListsMixin(object):
         elif XproUnprotectedNameEntityTypes.has_value(entity_type) and XproUnprotectedNameEntityTypes(entity_type):
             entity_type_code = XproUnprotectedNameEntityTypes(entity_type)
         else:
-            raise Exception('Could not set entity type user designations - entity type [' + entity_type + '] was not found in BC or XPRO entity types!')
+            raise Exception(
+                'Could not set entity type user designations - entity type [' + entity_type + '] was not found in BC or XPRO entity types!')
 
         self._eng_designation_any_list_correct = syn_svc.get_designations(entity_type_code=entity_type_code.value,
                                                                           position_code=DesignationPositionCodes.ANY.value,
@@ -141,19 +142,19 @@ class SetDesignationsListsMixin(object):
 
         for key, value in request_type_list_dict.items():
             if DesignationPositionCodes.END.value in value:
-                self._designation_end_list.extend(syn_svc.get_designations(entity_type_code=key,
-                                                                           position_code=DesignationPositionCodes.END.value,
-                                                                           lang=LanguageCodes.ENG.value).data)
-                self._designation_end_list.extend(syn_svc.get_designations(entity_type_code=key,
-                                                                           position_code=DesignationPositionCodes.END.value,
-                                                                           lang=LanguageCodes.FR.value).data)
+                self._designation_end_list_all.extend(syn_svc.get_designations(entity_type_code=key,
+                                                                               position_code=DesignationPositionCodes.END.value,
+                                                                               lang=LanguageCodes.ENG.value).data)
+                self._designation_end_list_all.extend(syn_svc.get_designations(entity_type_code=key,
+                                                                               position_code=DesignationPositionCodes.END.value,
+                                                                               lang=LanguageCodes.FR.value).data)
             if DesignationPositionCodes.ANY.value in value:
-                self._designation_any_list.extend(syn_svc.get_designations(entity_type_code=key,
-                                                                           position_code=DesignationPositionCodes.ANY.value,
-                                                                           lang=LanguageCodes.ENG.value).data)
-                self._designation_any_list.extend(syn_svc.get_designations(entity_type_code=key,
-                                                                           position_code=DesignationPositionCodes.ANY.value,
-                                                                           lang=LanguageCodes.FR.value).data)
+                self._designation_any_list_all.extend(syn_svc.get_designations(entity_type_code=key,
+                                                                               position_code=DesignationPositionCodes.ANY.value,
+                                                                               lang=LanguageCodes.ENG.value).data)
+                self._designation_any_list_all.extend(syn_svc.get_designations(entity_type_code=key,
+                                                                               position_code=DesignationPositionCodes.ANY.value,
+                                                                               lang=LanguageCodes.FR.value).data)
 
-        self._designation_end_list = sorted(set(self._designation_end_list), key=len, reverse= True)
-        self._designation_any_list = sorted(set(self._designation_any_list), key=len, reverse= True)
+        self._designation_end_list_all = sorted(set(self._designation_end_list_all), key=len, reverse=True)
+        self._designation_any_list_all = sorted(set(self._designation_any_list_all), key=len, reverse=True)

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -49,6 +49,20 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
 
         self._get_designations(request_types)
 
+        # Set designations and run our check
+        self._set_designations()
+
+        check_designation_more_than_one = builder.check_end_designation_more_than_once(
+            self.get_original_name_tokenized(),
+            self.get_designation_end_list(),
+            self.get_all_designations_user(),
+            self.get_misplaced_designation_end()
+        )
+
+        if not check_designation_more_than_one.is_valid:
+            results.append(check_designation_more_than_one)
+            return results
+
         # Return any combination of these checks
         if not self.skip_search_conflicts:
             check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
@@ -95,9 +109,6 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         if not check_words_requiring_consent.is_valid:
             results.append(check_words_requiring_consent)
 
-        # Set designations and run our check
-        self._set_designations()
-
         check_designation_existence = builder.check_designation_existence(
             self.get_original_name_tokenized(),
             self.get_all_designations(),
@@ -118,23 +129,13 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
             if not check_designation_mismatch.is_valid:
                 results.append(check_designation_mismatch)
 
-            check_designation_more_than_one = builder.check_end_designation_more_than_once(
+            check_designation_misplaced = builder.check_designation_misplaced(
                 self.get_original_name_tokenized(),
-                self.get_designation_end_list(),
-                self.get_all_designations_user(),
                 self.get_misplaced_designation_end()
             )
 
-            if not check_designation_more_than_one.is_valid:
-                results.append(check_designation_more_than_one)
-            else:
-                check_designation_misplaced = builder.check_designation_misplaced(
-                    self.get_original_name_tokenized(),
-                    self.get_misplaced_designation_end()
-                )
-
-                if not check_designation_misplaced.is_valid:
-                    results.append(check_designation_misplaced)
+            if not check_designation_misplaced.is_valid:
+                results.append(check_designation_misplaced)
 
         check_special_words = builder.check_word_special_use(
             self.name_tokens,

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -67,8 +67,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         if not self.skip_search_conflicts:
             check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
                                                          self.compound_descriptive_name_tokens,
-                                                         False, self.get_designation_end_list(),
-                                                         self.get_designation_any_list(),
+                                                         False, self.get_designation_end_list_all(),
+                                                         self.get_designation_any_list_all(),
                                                          stop_words_list)
 
             if check_conflicts.is_valid:
@@ -84,8 +84,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
 
         check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
                                                            self.compound_descriptive_name_tokens, True,
-                                                           self.get_designation_end_list(),
-                                                           self.get_designation_any_list(), stop_words_list)
+                                                           self.get_designation_end_list_all(),
+                                                           self.get_designation_any_list_all(), stop_words_list)
 
         if check_conflicts_queue.is_valid:
             check_conflicts_queue = builder.search_conflicts(
@@ -146,10 +146,3 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
             results.append(check_special_words)
 
         return results
-
-    def get_designations_search_conflict(self):
-        designations = {
-            DesignationPositionCodes.END.value: self.get_designation_end_list_correct()} if self.get_designation_end_list_correct() else {
-            DesignationPositionCodes.ANY.value: self.get_designation_any_list()}
-
-        return designations

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -165,8 +165,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
         if not self.skip_search_conflicts:
             check_conflicts = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
                                                          self.compound_descriptive_name_tokens,
-                                                         False, self.get_designation_end_list(),
-                                                         self.get_designation_any_list(), stop_words_list)
+                                                         False, self.get_designation_end_list_all(),
+                                                         self.get_designation_any_list_all(), stop_words_list)
 
             if check_conflicts.is_valid:
                 check_conflicts = builder.search_conflicts(
@@ -181,8 +181,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
 
         check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
                                                            self.compound_descriptive_name_tokens,
-                                                           True, self.get_designation_end_list(),
-                                                           self.get_designation_any_list(), stop_words_list)
+                                                           True, self.get_designation_end_list_all(),
+                                                           self.get_designation_any_list_all(), stop_words_list)
 
         if check_conflicts_queue.is_valid:
             check_conflicts_queue = builder.search_conflicts(


### PR DESCRIPTION
*5391 #, Double Corp Designations Send to Examination:*

*Description of changes:*
Fixed highlighting in FE words
Names with double end designations for protected name  is sent to examination before searching for exact matches or conflicts.

Regression tests passed:
![image](https://user-images.githubusercontent.com/10526131/97931294-244c3600-1d22-11eb-9de7-ec79bf30cf0c.png)

Test 1:
![image](https://user-images.githubusercontent.com/10526131/97931680-fb787080-1d22-11eb-9a42-6661d35f4781.png)

Test 2:
![image](https://user-images.githubusercontent.com/10526131/97931767-39759480-1d23-11eb-81ea-77ad56fc60a0.png)

Test 3:
![image](https://user-images.githubusercontent.com/10526131/97931854-6f1a7d80-1d23-11eb-8bb6-95db908eca19.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
