### PR TITLE
5117/assets causes strange behaviour

### DIFF
--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -149,7 +149,7 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
         self.name_as_submitted_tokenized = regex.findall(name.lower())
 
     def _clean_name_words(self, name, stop_words=[], designation_all=[], prefix_list=[], number_list=[]):
-        if not name or not stop_words or not prefix_list and not number_list:
+        if not name or not stop_words or not designation_all or not prefix_list or not number_list:
             warnings.warn("Parameters in clean_name_words function are not set.", Warning)
 
         syn_svc = self.synonym_service

--- a/api/namex/services/name_processing/name_processing.py
+++ b/api/namex/services/name_processing/name_processing.py
@@ -154,13 +154,11 @@ class NameProcessingService(GetSynonymListsMixin, GetDesignationsListsMixin):
 
         syn_svc = self.synonym_service
         # vwc_svc = self.virtual_word_condition_service
-
-        all_designations = self._designated_all_words
-        all_designations.sort(key=len, reverse=True)
-        designation_alternators = '|'.join(map(re.escape, all_designations))
+        designation_all.sort(key=len, reverse=True)
+        designation_alternators = '|'.join(map(re.escape, designation_all))
 
         exception_designation = self.exception_designation(name)
-        exception_stop_words_designation = list(set(self.exception_designation_stop_word(stop_words, all_designations)))
+        exception_stop_words_designation = list(set(self.exception_designation_stop_word(stop_words, designation_all)))
         exception_stop_words_designation.sort(key=len, reverse=True)
 
         name_original_tokens = [x for x in [x.strip() for x in re.split('([ &/-])', name.lower())] if x]

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -171,13 +171,12 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
     def get_conflicts(self, dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed, queue):
         dist_substitution_dict, desc_synonym_dict, dist_substitution_compound_dict, desc_synonym_compound_dict = {}, {}, {}, {}
+        desc_synonym_dict = self.get_substitutions_descriptive(w_desc)
         # Need to check if the name is well formed?
         if check_name_is_well_formed:
             dist_substitution_dict = self.get_dictionary(dist_substitution_dict, w_dist)
-            desc_synonym_dict = self.get_dictionary(desc_synonym_dict, w_desc)
         else:
             dist_substitution_dict = self.get_substitutions_distinctive(w_dist)
-            desc_synonym_dict = self.get_substitutions_descriptive(w_desc)
 
         list_conflict_details = list()
 


### PR DESCRIPTION
*/bcgov/entity#5117*

*Description of changes:*
- Modified the parameters in the descriptive to include the different synonyms when searching conflicts from well-formed names
- Fix for designations in Quart Services.

Tests:
![image](https://user-images.githubusercontent.com/10526131/98310058-ee58bd00-1f80-11eb-82e1-df86650a67b7.png)

![image](https://user-images.githubusercontent.com/10526131/98310235-4a234600-1f81-11eb-8b3b-64ce3678de7a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
