### PR TITLE
Fix/5590 change similarity iteration searching conflicts

### DIFF
--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -21,7 +21,7 @@ from ...common import token_header, claims
                              # The only way to be rejected is to have an exact match. We need to implement an exact match for
                              # Stand-alone names to avoid comparing with many names, just exact matches should be returned.
                              # ("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."),
-                             ("LE BLUE CAFE LTD.", "LE BLUE RESTAURANT LTD.")
+                             ("LE BLUE CAFE LTD.", "LE BLUE FOX CAFE INC.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
@@ -21,7 +21,7 @@ from ...common import token_header, claims
                              # Stand alone names with additional distinctive or descriptive have to be approved.
                              # Test case no longer valid
                              #("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."),
-                             ("LE BLUE CAFE LTD.", "LE BLUE RESTAURANT LTD.")
+                             ("LE BLUE CAFE LTD.", "LE BLUE FOX CAFE INC.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
*bcgov/entity#5590*

*Description of changes:*
Change in logic to assign weight to tokens for names provided by user.

Regression test:
![image](https://user-images.githubusercontent.com/10526131/98574641-05dbc280-226d-11eb-91e4-b675da1380dd.png)

Test 1 (CANDID CONSULTING SERVICES LTD.):
![image](https://user-images.githubusercontent.com/10526131/98574662-0ecc9400-226d-11eb-902c-d9aa7e5da22e.png)

Test 2 (STRAIGHT EDGE HOLDINGS LTD.):
![image](https://user-images.githubusercontent.com/10526131/98576475-6e2ba380-226f-11eb-8a2b-0ddc32f3b171.png)

Test 3 (NATIONWIDE HOLDINGS INC.):
![image](https://user-images.githubusercontent.com/10526131/98576868-01fd6f80-2270-11eb-92c2-e877b4c2f0b3.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
