### PR TITLE
5593 change query search distinctives

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -498,10 +498,10 @@ class Request(db.Model):
             substitutions = '|'.join(map(str, special_characters_dist))
             if not check_name_is_well_formed:
                 e.filters.insert(len(e.filters), [func.lower(Name.name).op('~')(
-                    r'^(no.?)*\s*\d*\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions))])
+                    r'(no.?)*\s*\d*\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions))])
             else:
                 e.filters.insert(len(e.filters), [func.lower(Name.name).op('~')(
-                    r'^\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions))])
+                    r'\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions))])
 
         return criteria
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -250,11 +250,6 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
                                                                              service.get_list_desc(),
                                                                              service.name_tokens_search_conflict)
 
-    service._list_dist_words_search_conflicts, updated_name_tokens = remove_double_letters_list_dist_words(
-        service.get_list_dist_search_conflicts(),
-        service.name_tokens_search_conflict)
-    service.set_name_tokens_search_conflict(updated_name_tokens)
-
     service._list_desc_words_search_conflicts, service._dict_desc_words_search_conflicts = remove_descriptive_same_category(
         dict_desc)
 
@@ -351,7 +346,7 @@ def remove_descriptive_same_category(dict_desc):
     return list(dict_desc_unique_category.keys()), dict_desc_unique_category
 
 
-def remove_double_letters_list_dist_words(list_dist, name_tokens):
+def remove_double_letters_list_dist_words(list_dist, name_tokens, dist_substitution_dict=None):
     list_dist_final = []
     for item in list_dist:
         not_double_letters_item = remove_double_letters(item)
@@ -360,5 +355,8 @@ def remove_double_letters_list_dist_words(list_dist, name_tokens):
             lambda x, value=item, singular_letter_value=not_double_letters_item: str.replace(x, value,
                                                                                              singular_letter_value),
             name_tokens))
+        if dist_substitution_dict:
+            dist_substitution_dict[not_double_letters_item] = dist_substitution_dict.pop(item)
+            dist_substitution_dict[not_double_letters_item].append(not_double_letters_item)
 
-    return list_dist_final, name_tokens
+    return list_dist_final, name_tokens, dist_substitution_dict

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -194,11 +194,11 @@ def get_classification_summary(list_dist, list_desc, list_name):
     return classification_summary
 
 
-def get_conflicts_same_classification(builder, name_tokens, processed_name, list_dist, list_desc):
+def get_conflicts_same_classification(builder, name_tokens, processed_name, stand_alone_words, list_dist, list_desc):
     list_dist, list_desc = \
         list_distinctive_descriptive(name_tokens, list_dist, list_desc)
     # Search conflicts coming from check_name_is_well_formed analysis
-    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name,
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name, stand_alone_words,
                                                check_name_is_well_formed=True)
 
     return check_conflicts

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -76,7 +76,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
                     [self.get_list_dist_search_conflicts()],
                     [self.get_list_desc_search_conflicts()],
                     self.name_tokens_search_conflict,
-                    self.processed_name
+                    self.processed_name,
+                    np_svc.get_stand_alone_words()
                 )
 
             if not check_conflicts.is_valid:
@@ -93,6 +94,7 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
                 [self.get_list_desc_search_conflicts()],
                 self.name_tokens_search_conflict,
                 self.processed_name,
+                np_svc.get_stand_alone_words(),
                 check_name_is_well_formed=False,
                 queue=True
             )

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -173,7 +173,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
                     [self.get_list_dist_search_conflicts()],
                     [self.get_list_desc_search_conflicts()],
                     self.name_tokens_search_conflict,
-                    self.processed_name
+                    self.processed_name,
+                    np_svc.get_stand_alone_words()
                 )
 
             if not check_conflicts.is_valid:
@@ -190,6 +191,7 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
                 [self.get_list_desc_search_conflicts()],
                 self.name_tokens_search_conflict,
                 self.processed_name,
+                np_svc.get_stand_alone_words(),
                 check_name_is_well_formed=False,
                 queue=True
             )

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -148,14 +148,14 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     @return ProcedureResult
     '''
 
-    def search_conflicts(self, list_dist_words, list_desc_words, list_name, name, check_name_is_well_formed=False,
+    def search_conflicts(self, list_dist_words, list_desc_words, list_name, name, stand_alone_words, check_name_is_well_formed=False,
                          queue=False):
         list_conflicts, most_similar_names = [], []
         dict_highest_counter, response = {}, {}
         self._list_processed_names = list()
         for w_dist, w_desc in zip(list_dist_words, list_desc_words):
             if w_dist and w_desc:
-                list_details, forced = self.get_conflicts(dict_highest_counter, w_dist, w_desc, list_name,
+                list_details, forced = self.get_conflicts(dict_highest_counter, w_dist, w_desc, list_name, stand_alone_words,
                                                           check_name_is_well_formed, queue)
                 list_conflicts.extend(list_details)
                 list_conflicts = [i for n, i in enumerate(list_conflicts) if
@@ -169,9 +169,13 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
 
         return self.prepare_response(most_similar_names, queue, list_name, list_dist_words, list_desc_words)
 
-    def get_conflicts(self, dict_highest_counter, w_dist, w_desc, list_name, check_name_is_well_formed, queue):
+    def get_conflicts(self, dict_highest_counter, w_dist, w_desc, list_name, stand_alone_words, check_name_is_well_formed, queue):
         dist_substitution_dict, desc_synonym_dict, dist_substitution_compound_dict, desc_synonym_compound_dict = {}, {}, {}, {}
         desc_synonym_dict = self.get_substitutions_descriptive(w_desc)
+
+        # Check if a token is stand-alone word
+        desc_synonym_dict = self.get_stand_alone_substitutions(desc_synonym_dict, stand_alone_words)
+
         # Need to check if the name is well formed?
         if check_name_is_well_formed:
             dist_substitution_dict = self.get_dictionary(dist_substitution_dict, w_dist)
@@ -572,6 +576,15 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 value.append(key)
 
         return desc_synonym_dict
+
+    def get_stand_alone_substitutions(self, desc_synonym_dict, stand_alone):
+        for key, value in desc_synonym_dict.items():
+            if key in stand_alone:
+                value.pop()
+                value.extend(stand_alone)
+
+        return desc_synonym_dict
+
 
     def check_name_is_well_formed_response(self, list_original_name, list_name, list_dist, result_code):
         result = ProcedureResult()

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -36,6 +36,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                                   processed_name, list_original_name):
         result = ProcedureResult()
         result.is_valid = True
+        self.name_processing_service
 
         first_classification = None
         if name_dict:
@@ -599,7 +600,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         return result
 
     def check_conflict_well_formed_response(self, processed_name, list_original_name, list_name, list_dist, issue):
-        check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, list_name,
+        np_svc = self.name_processing_service
+        check_conflicts = get_conflicts_same_classification(self, list_name, processed_name, np_svc.get_stand_alone_words(), list_name,
                                                             list_name)
         if check_conflicts.is_valid:
             return self.check_name_is_well_formed_response(list_original_name, list_name, list_dist,

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -10,7 +10,7 @@ from . import EXACT_MATCH, HIGH_CONFLICT_RECORDS, HIGH_SIMILARITY, CURRENT_YEAR,
 from ..auto_analyse.abstract_name_analysis_builder import AbstractNameAnalysisBuilder, ProcedureResult
 from ..auto_analyse import AnalysisIssueCodes, MAX_LIMIT, MAX_MATCHES_LIMIT
 from ..auto_analyse.name_analysis_utils import get_conflicts_same_classification, \
-    get_all_dict_substitutions, subsequences, remove_double_letters
+    get_all_dict_substitutions, subsequences, remove_double_letters, remove_double_letters_list_dist_words
 
 from namex.models.request import Request
 
@@ -182,6 +182,8 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
             dist_substitution_dict = self.get_dictionary(dist_substitution_dict, w_dist)
         else:
             dist_substitution_dict = self.get_substitutions_distinctive(w_dist)
+
+        w_dist, list_name, dist_substitution_dict = remove_double_letters_list_dist_words(w_dist, list_name, dist_substitution_dict)
 
         list_conflict_details = list()
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -95,7 +95,7 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                         'PACIFIC BLUE ENTERPRISES LTD.', 'PACIFIC ENGINEERING LTD.', 'PACIFIC HOLDINGS LTD.',
                         'BLUE PETER HOLDINGS INC.', 'BLUE WATER VENTURES LTD.', 'LE BLUE FOX CAFE INC.',
                         'LE BLUE RESTAURANT LTD.','CANADA SWIFT INTERNATIONAL EDUCATION CORP.',
-                        'COASTAL SMART SUPPLIES LTD.','CANDID CONSULTING SERVICES']
+                        'COASTAL SMART SUPPLIES LTD.', 'CANDID COMMUNITY CONSULTING CORP.']
     save_words_list_name(conflict_list_db)
 
     # create JWT & setup header with a Bearer Token using the JWT

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -21,7 +21,10 @@ from ...common import token_header, claims
                              # The only way to be rejected is to have an exact match. We need to implement an exact match for
                              # Stand-alone names to avoid comparing with many names, just exact matches should be returned.
                              # ("PACIFIC BLUE ENGINEERING & ENTERPRISES LTD.", "PACIFIC BLUE ENTERPRISES LTD."),
-                             ("LE BLUE CAFE LTD.", "LE BLUE FOX CAFE INC.")
+                             ("LE BLUE CAFE LTD.", "LE BLUE FOX CAFE INC."),
+                             ("SWIFT EDUCATION SERVICES LTD", "CANADA SWIFT INTERNATIONAL EDUCATION CORP."),
+                             ("CANDID CONSULTING SERVICES LTD.","CANDID COMMUNITY CONSULTING CORP."),
+                             ("SMART SUPPLY LTD.", "COASTAL SMART SUPPLIES LTD.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
@@ -56,6 +59,31 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                                  {'word': 'PETER', 'classification': 'DIST'},
                                  {'word': 'LE', 'classification': 'DIST'},
                                  {'word': 'LE', 'classification': 'DESC'},
+                                 {'word': 'SWIFT', 'classification': 'DIST'},
+                                 {'word': 'SWIFT', 'classification': 'DESC'},
+                                 {'word': 'EDUCATION', 'classification': 'DIST'},
+                                 {'word': 'EDUCATION', 'classification': 'DESC'},
+                                 {'word': 'SERVICES', 'classification': 'DIST'},
+                                 {'word': 'SERVICES', 'classification': 'DESC'},
+                                 {'word': 'CANADA', 'classification': 'DIST'},
+                                 {'word': 'CANADA', 'classification': 'DESC'},
+                                 {'word': 'INTERNATIONAL', 'classification': 'DIST'},
+                                 {'word': 'INTERNATIONAL', 'classification': 'DESC'},
+                                 {'word': 'SMART', 'classification': 'DIST'},
+                                 {'word': 'SMART', 'classification': 'DESC'},
+                                 {'word': 'SUPPLY', 'classification': 'DIST'},
+                                 {'word': 'SUPPLY', 'classification': 'DESC'},
+                                 {'word': 'COASTAL', 'classification': 'DIST'},
+                                 {'word': 'COASTAL', 'classification': 'DESC'},
+                                 {'word': 'SUPPLIES', 'classification': 'DIST'},
+                                 {'word': 'SUPPLIES', 'classification': 'DESC'},
+                                 {'word': 'CANDID', 'classification': 'DIST'},
+                                 {'word': 'CONSULTING', 'classification': 'DIST'},
+                                 {'word': 'CONSULTING', 'classification': 'DESC'},
+                                 {'word': 'SERVICES', 'classification': 'DIST'},
+                                 {'word': 'SERVICES', 'classification': 'DESC'},
+                                 {'word': 'COMMUNITY', 'classification': 'DIST'},
+                                 {'word': 'COMMUNITY', 'classification': 'DESC'},
                                  ]
     save_words_list_classification(words_list_classification)
 
@@ -66,7 +94,8 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                         'ABC CREDIT BUREAU COLLECTIONS LIMITED', 'ABC JEWELLERY & LOAN PAWNBROKERS LTD.',
                         'PACIFIC BLUE ENTERPRISES LTD.', 'PACIFIC ENGINEERING LTD.', 'PACIFIC HOLDINGS LTD.',
                         'BLUE PETER HOLDINGS INC.', 'BLUE WATER VENTURES LTD.', 'LE BLUE FOX CAFE INC.',
-                        'LE BLUE RESTAURANT LTD.']
+                        'LE BLUE RESTAURANT LTD.','CANADA SWIFT INTERNATIONAL EDUCATION CORP.',
+                        'COASTAL SMART SUPPLIES LTD.','CANDID CONSULTING SERVICES']
     save_words_list_name(conflict_list_db)
 
     # create JWT & setup header with a Bearer Token using the JWT

--- a/services/auto-analyze/auto_analyze/analyzer.py
+++ b/services/auto-analyze/auto_analyze/analyzer.py
@@ -243,8 +243,11 @@ def remove_extra_value(d1, d2):
     for k2, v2 in d2.items():
         for k1, v1 in d1.items():
             if len(set(v1) ^ set(v2)) == 1 and k1 not in v2:
-                v1.remove(k1)
-                break
+                try:
+                    v1.remove(k1)
+                    break
+                except ValueError:
+                    pass
             elif (len(set(v1) ^ set(v2)) == 1 and k1 in v2) or len(set(v1) ^ set(v2)) == 0:
                 d1[k2] = d1.pop(k1)
                 break

--- a/services/auto-analyze/auto_analyze/analyzer.py
+++ b/services/auto-analyze/auto_analyze/analyzer.py
@@ -240,10 +240,12 @@ def check_additional_dist_desc(list_dist_user_name, list_dist_conflict, dict_des
 def remove_extra_value(d1, d2):
     for k2, v2 in d2.items():
         for k1, v1 in d1.items():
-            if len(set(v1) ^ set(v2)) == 1:
+            if len(set(v1) ^ set(v2)) == 1 and k1 not in v2:
                 v1.remove(k1)
-            elif len(set(v1) ^ set(v2)) == 0:
+                break
+            elif (len(set(v1) ^ set(v2)) == 1 and k1 in v2) or len(set(v1) ^ set(v2)) == 0:
                 d1[k2] = d1.pop(k1)
+                break
     return d1
 
 

--- a/services/auto-analyze/auto_analyze/analyzer.py
+++ b/services/auto-analyze/auto_analyze/analyzer.py
@@ -81,14 +81,12 @@ async def auto_analyze(name: str, list_name: list, list_dist: list,
         dist_db_substitution_dict = builder.get_substitutions_distinctive(service.get_list_dist())
         desc_tmp_synonym_dict = builder.get_substitutions_descriptive(service.get_list_desc())
 
-        dict_synonyms = remove_extra_value(desc_tmp_synonym_dict, dict_synonyms) if desc_tmp_synonym_dict.__len__() > \
-                                                                                    dict_synonyms.__len__() else remove_extra_value(
-            dict_synonyms, desc_tmp_synonym_dict)
+        dict_synonyms = remove_extra_value(desc_tmp_synonym_dict, dict_synonyms)
 
         # Update key in desc_db_synonym_dict
         desc_db_synonym_dict = update_dictionary_key(desc_tmp_synonym_dict, dict_synonyms)
 
-        vector2_dist, entropy_dist = get_vector(service.get_list_dist_search_conflicts(), list_dist,
+        vector2_dist, entropy_dist = get_vector(service.get_list_dist(), list_dist,
                                                 dist_db_substitution_dict, True)
 
         if all(value == OTHER_W_DIST for value in vector2_dist.values()):
@@ -109,7 +107,7 @@ async def auto_analyze(name: str, list_name: list, list_dist: list,
         similarity_dist = round(get_similarity(vector1_dist, vector2_dist, entropy_dist), 2)
 
         vector2_desc, entropy_desc = get_vector(
-            remove_spaces_list(service.get_list_desc_search_conflicts()), list_desc,
+            remove_spaces_list(service.get_list_desc()), list_desc,
             desc_db_synonym_dict)
         similarity_desc = round(
             get_similarity(vector1_desc, vector2_desc, entropy_desc), 2)
@@ -154,8 +152,6 @@ def get_vector(conflict_class_list, original_class_list, class_subs_dict, dist=F
             entropy.append(0.0)
         if counter == 1:
             vector[k] = counter
-        else:
-            vector[word] = counter
 
     # Make sure we don't divide by zero!
     entropy_score = sum(entropy) / len(entropy) if len(entropy) > 0 else 0
@@ -245,10 +241,9 @@ def remove_extra_value(d1, d2):
     for k2, v2 in d2.items():
         for k1, v1 in d1.items():
             if len(set(v1) ^ set(v2)) == 1:
-                try:
-                    v1.remove(k1)
-                except ValueError:
-                    pass
+                v1.remove(k1)
+            elif len(set(v1) ^ set(v2)) == 0:
+                d1[k2] = d1.pop(k1)
     return d1
 
 

--- a/services/auto-analyze/auto_analyze/analyzer.py
+++ b/services/auto-analyze/auto_analyze/analyzer.py
@@ -18,7 +18,7 @@ import math
 
 from nltk.stem import PorterStemmer
 from namex.services.name_request.auto_analyse.name_analysis_utils \
-    import get_classification, subsequences, get_flat_list, remove_spaces_list
+    import get_classification, subsequences, get_flat_list, remove_spaces_list, remove_double_letters_list_dist_words
 
 from namex.services.name_request.builders.name_analysis_builder \
     import NameAnalysisBuilder
@@ -79,8 +79,10 @@ async def auto_analyze(name: str, list_name: list, list_dist: list,
         get_classification(service, stand_alone_words, syn_svc, match_list, wc_svc, token_svc)
 
         dist_db_substitution_dict = builder.get_substitutions_distinctive(service.get_list_dist())
-        desc_tmp_synonym_dict = builder.get_substitutions_descriptive(service.get_list_desc())
+        service._list_dist_words, match_list, _ = remove_double_letters_list_dist_words(service.get_list_dist(),
+                                                                                        match_list)
 
+        desc_tmp_synonym_dict = builder.get_substitutions_descriptive(service.get_list_desc())
         dict_synonyms = remove_extra_value(desc_tmp_synonym_dict, dict_synonyms)
 
         # Update key in desc_db_synonym_dict

--- a/services/auto-analyze/auto_analyze/analyzer.py
+++ b/services/auto-analyze/auto_analyze/analyzer.py
@@ -41,7 +41,7 @@ builder = NameAnalysisBuilder(name_analysis_service)
 STEM_W = 0.85
 SUBS_W = 0.65
 OTHER_W_DESC = 3.0
-OTHER_W_DIST = 1.1
+OTHER_W_DIST = 0.35
 
 EXACT_MATCH = 1.0
 HIGH_SIMILARITY = 0.85

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -71,6 +71,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         filters = [
             ~func.lower(model.category).op('~')(r'\y{}\y'.format('sub')),
             ~func.lower(model.category).op('~')(r'\y{}\y'.format('stop')),
+            ~func.lower(model.category).op('~')(r'\y{}\y'.format('stand'))
         ]
 
         results = self.find_word_synonyms(word, filters, category)


### PR DESCRIPTION
*bcgov/entity#5593*

*Description of changes:*
- Retrieve conflicts that include distinctive as second token followed by descriptive. Before just the first token was considered a valid distinctive.
- When getting synonyms do not include stand-alone words to avoid mixing them with regular synonyms.
- Name analysis was changed to be over the full name instead of dropping synonyms in the same category.
- Removing duplicated letters is done after getting synonyms.
- Added test cases for distinctive after first place

Test 1:
![image](https://user-images.githubusercontent.com/10526131/99106846-c1686380-2599-11eb-82f4-6fc9bf1a6f85.png)

Test 2:
![image](https://user-images.githubusercontent.com/10526131/99106856-c7f6db00-2599-11eb-92e2-315d004f9247.png)

Test 3:
![image](https://user-images.githubusercontent.com/10526131/99106876-cfb67f80-2599-11eb-8b41-2adc8cf72c80.png)

Test 4:
![image](https://user-images.githubusercontent.com/10526131/99106892-d644f700-2599-11eb-9dca-d854aa6faaa0.png)

Test 5:
![image](https://user-images.githubusercontent.com/10526131/99106932-e5c44000-2599-11eb-842f-6010d2f29491.png)

Test 6:
![image](https://user-images.githubusercontent.com/10526131/99106949-eceb4e00-2599-11eb-9eea-713b36a8a05e.png)

Regression test:
![image](https://user-images.githubusercontent.com/10526131/99106961-f5dc1f80-2599-11eb-82cb-50624ff3a360.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
