### PR TITLE
Update for deprecating set-env command of GHA.

### DIFF
--- a/.github/workflows/auto-analyze-cd.yml
+++ b/.github/workflows/auto-analyze-cd.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set env by input
         run: |
-          echo "::set-env name=TAG_NAME::${{ github.event.inputs.environement }}"
+          echo "TAG_NAME=${{ github.event.inputs.environement }}" >> $GITHUB_ENV
 
       - name: Set env by master branch
         if: env.TAG_NAME == '' && github.ref == 'refs/heads/master'
         run: |
-          echo "::set-env name=TAG_NAME::dev"
+          echo "TAG_NAME=dev" >> $GITHUB_ENV
 
       - uses: pwei1018/bcrs-cd-action@latest
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update for deprecating set-env command of GHA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
