### PR TITLE
Disable exact match for queue conflicts

### DIFF
--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -83,21 +83,21 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
             if not check_conflicts.is_valid:
                 results.append(check_conflicts)
 
-        check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
-                                                           self.compound_descriptive_name_tokens, True,
-                                                           self.get_designation_end_list_all(),
-                                                           self.get_designation_any_list_all(), stop_words_list)
+        # check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
+        #                                                    self.compound_descriptive_name_tokens, True,
+        #                                                    self.get_designation_end_list_all(),
+        #                                                    self.get_designation_any_list_all(), stop_words_list)
 
-        if check_conflicts_queue.is_valid:
-            check_conflicts_queue = builder.search_conflicts(
-                [self.get_list_dist_search_conflicts()],
-                [self.get_list_desc_search_conflicts()],
-                self.name_tokens_search_conflict,
-                self.processed_name,
-                np_svc.get_stand_alone_words(),
-                check_name_is_well_formed=False,
-                queue=True
-            )
+        # if check_conflicts_queue.is_valid:
+        check_conflicts_queue = builder.search_conflicts(
+            [self.get_list_dist_search_conflicts()],
+            [self.get_list_desc_search_conflicts()],
+            self.name_tokens_search_conflict,
+            self.processed_name,
+            np_svc.get_stand_alone_words(),
+            check_name_is_well_formed=False,
+            queue=True
+        )
 
         if not check_conflicts_queue.is_valid:
             results.append(check_conflicts_queue)

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -180,21 +180,21 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
             if not check_conflicts.is_valid:
                 results.append(check_conflicts)
 
-        check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
-                                                           self.compound_descriptive_name_tokens,
-                                                           True, self.get_designation_end_list_all(),
-                                                           self.get_designation_any_list_all(), stop_words_list)
+        # check_conflicts_queue = builder.search_exact_match(self.get_list_dist(), self.get_list_desc(),
+        #                                                    self.compound_descriptive_name_tokens,
+        #                                                    True, self.get_designation_end_list_all(),
+        #                                                    self.get_designation_any_list_all(), stop_words_list)
 
-        if check_conflicts_queue.is_valid:
-            check_conflicts_queue = builder.search_conflicts(
-                [self.get_list_dist_search_conflicts()],
-                [self.get_list_desc_search_conflicts()],
-                self.name_tokens_search_conflict,
-                self.processed_name,
-                np_svc.get_stand_alone_words(),
-                check_name_is_well_formed=False,
-                queue=True
-            )
+        # if check_conflicts_queue.is_valid:
+        check_conflicts_queue = builder.search_conflicts(
+            [self.get_list_dist_search_conflicts()],
+            [self.get_list_desc_search_conflicts()],
+            self.name_tokens_search_conflict,
+            self.processed_name,
+            np_svc.get_stand_alone_words(),
+            check_name_is_well_formed=False,
+            queue=True
+        )
 
         if not check_conflicts_queue.is_valid:
             results.append(check_conflicts_queue)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Running NameX testing requires to disable code invoking search exact match for queue conflicts. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
