### PR TITLE
5678 modify duplicated letters

### DIFF
--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -324,7 +324,7 @@ def remove_spaces_list(lst):
 
 
 def remove_double_letters(name):
-    return re.sub(r'([a-zA-Z])\1+', r'\1', name)
+    return re.sub(r'\b(([a-zA-Z])\2+)\b|([a-zA-Z])\3+', r'\1\3', name)
 
 
 def list_to_string(lst):

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -24,7 +24,9 @@ from ...common import token_header, claims
                              ("LE BLUE CAFE LTD.", "LE BLUE FOX CAFE INC."),
                              ("SWIFT EDUCATION SERVICES LTD", "CANADA SWIFT INTERNATIONAL EDUCATION CORP."),
                              ("CANDID CONSULTING SERVICES LTD.","CANDID COMMUNITY CONSULTING CORP."),
-                             ("SMART SUPPLY LTD.", "COASTAL SMART SUPPLIES LTD.")
+                             ("SMART SUPPLY LTD.", "COASTAL SMART SUPPLIES LTD."),
+                             ("AAA POWER WASHING LTD.", "AAA STREAMLINE POWER WASHING TRUCKING LTD."),
+                             ("AAA POWER WASHING LTD.", "AAA STREAMLINE POWER WASHING TRUCKING LTD.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
@@ -84,6 +86,13 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                                  {'word': 'SERVICES', 'classification': 'DESC'},
                                  {'word': 'COMMUNITY', 'classification': 'DIST'},
                                  {'word': 'COMMUNITY', 'classification': 'DESC'},
+                                 {'word': 'AAA', 'classification': 'DIST'},
+                                 {'word': 'POWER', 'classification': 'DIST'},
+                                 {'word': 'POWER', 'classification': 'DESC'},
+                                 {'word': 'WASHING', 'classification': 'DESC'},
+                                 {'word': 'STREAMLINE', 'classification': 'DIST'},
+                                 {'word': 'TRUCKING', 'classification': 'DIST'},
+                                 {'word': 'TRUCKING', 'classification': 'DESC'},
                                  ]
     save_words_list_classification(words_list_classification)
 
@@ -95,7 +104,8 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                         'PACIFIC BLUE ENTERPRISES LTD.', 'PACIFIC ENGINEERING LTD.', 'PACIFIC HOLDINGS LTD.',
                         'BLUE PETER HOLDINGS INC.', 'BLUE WATER VENTURES LTD.', 'LE BLUE FOX CAFE INC.',
                         'LE BLUE RESTAURANT LTD.','CANADA SWIFT INTERNATIONAL EDUCATION CORP.',
-                        'COASTAL SMART SUPPLIES LTD.', 'CANDID COMMUNITY CONSULTING CORP.']
+                        'COASTAL SMART SUPPLIES LTD.', 'CANDID COMMUNITY CONSULTING CORP.',
+                        'AAA STREAMLINE POWER WASHING TRUCKING LTD.']
     save_words_list_name(conflict_list_db)
 
     # create JWT & setup header with a Bearer Token using the JWT


### PR DESCRIPTION
*bcgov/entity#5678*

*Description of changes:*
Do not remove duplicated letters when all token contains the same letter. For instance, `AAA` should be kept as it is instead of transforming to just `A`.

Added corresponding test cases:
![image](https://user-images.githubusercontent.com/10526131/99602862-100d6780-29b7-11eb-9c3a-237ef1bb2250.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).