### PR TITLE
Add dataclasses package

### DIFF
--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -22,5 +22,6 @@ lxml
 inflect
 werkzeug==0.16.1
 pysolr
+dataclasses
 
 git+https://github.com/bcgov/namex-synonyms-api-py-client.git#egg=swagger_client

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -22,6 +22,6 @@ lxml
 inflect
 werkzeug==0.16.1
 pysolr
-dataclasses
+dataclasses==0.8
 
 git+https://github.com/bcgov/namex-synonyms-api-py-client.git#egg=swagger_client


### PR DESCRIPTION
*Issue #, if available:*
No issue yet, can we create one?

*Description of changes:*
Add backport of dataclasses for Python 3.6 until namex is moved to Python 3.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
