### PR TITLE
add dataclasses module for python < 3.7

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,6 +16,7 @@ chardet==3.0.4
 click==7.1.2
 cmudict==0.4.5
 cx-Oracle==8.0.1
+dataclasses==0.8
 ecdsa==0.14.1
 flask-jwt-oidc==0.1.5
 flask-marshmallow==0.11.0

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -22,5 +22,4 @@ lxml
 inflect
 werkzeug==0.16.1
 pysolr
-
-git+https://github.com/bcgov/namex-synonyms-api-py-client.git#egg=swagger_client
+dataclasses


### PR DESCRIPTION
 *Description of changes:*
- add dataclasses for python < 3.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
