### PR TITLE
5687 stem distinctive

### DIFF
--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -357,6 +357,7 @@ def remove_double_letters_list_dist_words(list_dist, name_tokens, dist_substitut
             name_tokens))
         if dist_substitution_dict:
             dist_substitution_dict[not_double_letters_item] = dist_substitution_dict.pop(item)
-            dist_substitution_dict[not_double_letters_item].append(not_double_letters_item)
+            if not dist_substitution_dict.get(not_double_letters_item):
+                dist_substitution_dict[not_double_letters_item].append(not_double_letters_item)
 
     return list_dist_final, name_tokens, dist_substitution_dict

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -198,7 +198,7 @@ def get_conflicts_same_classification(builder, name_tokens, processed_name, stan
     list_dist, list_desc = \
         list_distinctive_descriptive(name_tokens, list_dist, list_desc)
     # Search conflicts coming from check_name_is_well_formed analysis
-    check_conflicts = builder.search_conflicts(list_dist, list_desc, name_tokens, processed_name, stand_alone_words,
+    check_conflicts = builder.search_conflicts(list_dist, list_desc, list_desc, name_tokens, processed_name, stand_alone_words,
                                                check_name_is_well_formed=True)
 
     return check_conflicts

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -262,7 +262,7 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
                                                                            service.name_tokens_search_conflict)
     service.set_name_tokens_search_conflict(remove_spaces_list(service.name_tokens_search_conflict))
 
-    print("Classification for search conflict:")
+    print("Classification for searching conflicts in NameX DB:")
     print(service.get_dict_name_search_conflicts())
 
 

--- a/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/protected_name_analysis.py
@@ -75,7 +75,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
                 check_conflicts = builder.search_conflicts(
                     [self.get_list_dist_search_conflicts()],
                     [self.get_list_desc_search_conflicts()],
-                    self.name_tokens_search_conflict,
+                    [self.get_list_desc()],
+                    self.name_tokens,
                     self.processed_name,
                     np_svc.get_stand_alone_words()
                 )
@@ -92,7 +93,8 @@ class ProtectedNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMix
         check_conflicts_queue = builder.search_conflicts(
             [self.get_list_dist_search_conflicts()],
             [self.get_list_desc_search_conflicts()],
-            self.name_tokens_search_conflict,
+            [self.get_list_desc()],
+            self.name_tokens,
             self.processed_name,
             np_svc.get_stand_alone_words(),
             check_name_is_well_formed=False,

--- a/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
+++ b/api/namex/services/name_request/auto_analyse/xpro_name_analysis.py
@@ -172,7 +172,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
                 check_conflicts = builder.search_conflicts(
                     [self.get_list_dist_search_conflicts()],
                     [self.get_list_desc_search_conflicts()],
-                    self.name_tokens_search_conflict,
+                    [self.get_list_desc()],
+                    self.name_tokens,
                     self.processed_name,
                     np_svc.get_stand_alone_words()
                 )
@@ -189,7 +190,8 @@ class XproNameAnalysisService(NameAnalysisDirector, SetDesignationsListsMixin):
         check_conflicts_queue = builder.search_conflicts(
             [self.get_list_dist_search_conflicts()],
             [self.get_list_desc_search_conflicts()],
-            self.name_tokens_search_conflict,
+            [self.get_list_desc()],
+            self.name_tokens,
             self.processed_name,
             np_svc.get_stand_alone_words(),
             check_name_is_well_formed=False,

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -8,7 +8,7 @@ import requests
 from . import EXACT_MATCH, HIGH_CONFLICT_RECORDS, HIGH_SIMILARITY, CURRENT_YEAR, LOWER_LIMIT_TIME, \
     UPPER_LIMIT_TIME, EXCEPTION_YEARS, CURRENT_MONTH, CURRENT_DAY
 from ..auto_analyse.abstract_name_analysis_builder import AbstractNameAnalysisBuilder, ProcedureResult
-from ..auto_analyse import AnalysisIssueCodes, MAX_LIMIT, MAX_MATCHES_LIMIT
+from ..auto_analyse import AnalysisIssueCodes, MAX_LIMIT, MAX_MATCHES_LIMIT, porter
 from ..auto_analyse.name_analysis_utils import get_conflicts_same_classification, \
     get_all_dict_substitutions, subsequences, remove_double_letters, remove_double_letters_list_dist_words
 
@@ -559,6 +559,9 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
         dist_substitution_dict = parse_dict_of_lists(all_dist_substitutions_synonyms)
 
         for key, value in dist_substitution_dict.items():
+            stem_w = porter.stem(key)
+            if stem_w not in value:
+                value.append(stem_w)
             if key not in value:
                 value.append(key)
 
@@ -587,7 +590,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 value.extend(stand_alone)
 
         return desc_synonym_dict
-
 
     def check_name_is_well_formed_response(self, list_original_name, list_name, list_dist, result_code):
         result = ProcedureResult()

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -26,7 +26,9 @@ from ...common import token_header, claims
                              ("CANDID CONSULTING SERVICES LTD.","CANDID COMMUNITY CONSULTING CORP."),
                              ("SMART SUPPLY LTD.", "COASTAL SMART SUPPLIES LTD."),
                              ("AAA POWER WASHING LTD.", "AAA STREAMLINE POWER WASHING TRUCKING LTD."),
-                             ("AAA POWER WASHING LTD.", "AAA STREAMLINE POWER WASHING TRUCKING LTD.")
+                             ("AAA POWER WASHING LTD.", "AAA STREAMLINE POWER WASHING TRUCKING LTD."),
+                             ("PIONEERS OF FLOORING LTD.", "PIONEER FLOOR COVERING LTD."),
+                             ("CHAMPIONS OF FLOORING LTD.", "CHAMPION HARDWOOD FLOORS LTD.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)
@@ -93,6 +95,20 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                                  {'word': 'STREAMLINE', 'classification': 'DIST'},
                                  {'word': 'TRUCKING', 'classification': 'DIST'},
                                  {'word': 'TRUCKING', 'classification': 'DESC'},
+                                 {'word': 'PIONEERS', 'classification': 'DIST'},
+                                 {'word': 'FLOORING', 'classification': 'DIST'},
+                                 {'word': 'FLOORING', 'classification': 'DESC'},
+                                 {'word': 'FLOOR', 'classification': 'DIST'},
+                                 {'word': 'FLOOR', 'classification': 'DESC'},
+                                 {'word': 'FLOORS', 'classification': 'DIST'},
+                                 {'word': 'FLOORS', 'classification': 'DESC'},
+                                 {'word': 'COVERING', 'classification': 'DESC'},
+                                 {'word': 'CHAMPIONS', 'classification': 'DIST'},
+                                 {'word': 'CHAMPIONS', 'classification': 'DESC'},
+                                 {'word': 'CHAMPION', 'classification': 'DIST'},
+                                 {'word': 'CHAMPION', 'classification': 'DESC'},
+                                 {'word': 'HARDWOOD', 'classification': 'DIST'},
+                                 {'word': 'HARDWOOD', 'classification': 'DESC'},
                                  ]
     save_words_list_classification(words_list_classification)
 
@@ -105,7 +121,8 @@ def test_corporate_name_conflict_request_response(client, jwt, app, name, expect
                         'BLUE PETER HOLDINGS INC.', 'BLUE WATER VENTURES LTD.', 'LE BLUE FOX CAFE INC.',
                         'LE BLUE RESTAURANT LTD.','CANADA SWIFT INTERNATIONAL EDUCATION CORP.',
                         'COASTAL SMART SUPPLIES LTD.', 'CANDID COMMUNITY CONSULTING CORP.',
-                        'AAA STREAMLINE POWER WASHING TRUCKING LTD.']
+                        'AAA STREAMLINE POWER WASHING TRUCKING LTD.','PIONEER FLOOR COVERING LTD.',
+                        'CHAMPION HARDWOOD FLOORS LTD.']
     save_words_list_name(conflict_list_db)
 
     # create JWT & setup header with a Bearer Token using the JWT

--- a/services/auto-analyze/src/auto_analyze/analyzer.py
+++ b/services/auto-analyze/src/auto_analyze/analyzer.py
@@ -29,7 +29,6 @@ from namex.services.name_request.builders.name_analysis_builder import NameAnaly
 from nltk.stem import PorterStemmer
 from swagger_client import SynonymsApi as SynonymService
 
-
 porter = PorterStemmer()
 
 synonym_service = SynonymService()
@@ -85,7 +84,7 @@ async def auto_analyze(name: str,  # pylint: disable=too-many-locals, too-many-a
                                                                                         match_list)
 
         desc_tmp_synonym_dict = builder.get_substitutions_descriptive(service.get_list_desc())
-        dict_synonyms = remove_extra_value(desc_tmp_synonym_dict, dict_synonyms)
+        desc_tmp_synonym_dict = remove_extra_value(desc_tmp_synonym_dict, dict_synonyms)
 
         # Update key in desc_db_synonym_dict
         desc_db_synonym_dict = update_dictionary_key(desc_tmp_synonym_dict, dict_synonyms)
@@ -261,17 +260,16 @@ def remove_extra_value(d1, d2):
                     break
                 except ValueError:
                     pass
-            elif (len(set(v1) ^ set(v2)) == 1 and k1 in v2) or len(set(v1) ^ set(v2)) == 0:
-                d1[k2] = d1.pop(k1)
-                break
     return d1
 
 
-def update_dictionary_key(user, db):
-    """Return updates key weights."""
-    user_keys = tuple(user.keys())
-    user_values = tuple(user.values())
-
-    new_db = {user_keys[user_values.index(value)] if value in user_values else key: value for key, value in db.items()}
-
-    return new_db
+def update_dictionary_key(d1, d2):
+    """Update key dictionary in d1 with key in d2."""
+    d3 = {}
+    for k2, v2 in d2.items():
+        for k1, v1 in d1.items():
+            if (len(set(v1) ^ set(v2)) == 1 and k1 in v2) or len(set(v1) ^ set(v2)) == 0:
+                d3[k2] = v1
+            else:
+                d3[k1] = v1
+    return d3

--- a/solr-synonyms-api/requirements/prod.txt
+++ b/solr-synonyms-api/requirements/prod.txt
@@ -24,3 +24,4 @@ eventlet
 
 werkzeug==0.16.1
 nltk
+pyinflect

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -86,9 +86,6 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
             results = self.find_word_synonyms(word, filters, category, stem=True)
         flattened = list(map(str.strip, (list(filter(None, self.flatten_synonyms_text(results))))))
 
-        gerund = self.get_gerund_word(word)
-        flattened.append(gerund) if gerund.__len__() > 0 and gerund not in flattened else flattened
-
         return flattened
 
     def get_substitutions(self, word=None):
@@ -353,6 +350,10 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
         return exceptions_ws
 
-    def get_gerund_word(self, word):
-        gerund = getInflection(word, 'VBG')
-        return gerund[0] if gerund is not None else ''
+    def get_gerund_word(self, word, syn=False):
+        gerund = None
+        if syn and getInflection(word, 'VB'):
+            gerund = getInflection(word, 'VBG')
+        else:
+            gerund = getInflection(word, 'VBG')
+        return [gerund[0]] if gerund is not None else ''

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -350,10 +350,6 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
 
         return exceptions_ws
 
-    def get_gerund_word(self, word, syn=False):
-        gerund = None
-        if syn and getInflection(word, 'VB'):
-            gerund = getInflection(word, 'VBG')
-        else:
-            gerund = getInflection(word, 'VBG')
+    def get_gerund_word(self, word):
+        gerund = getInflection(word, 'VBG')
         return [gerund[0]] if gerund is not None else ''


### PR DESCRIPTION
*bcgov/entity#5687:*

*Description of changes:*
- Stemming distinctives and descriptives in dictionaries
- Search in synonyms for original word, if no result stemming word
- Adding gerund form for distinctives
- Deleted additional_dist_desc function, it is not longer needed after name examination session with Genevieve.
- Added test cases.

Regression Test:
![image](https://user-images.githubusercontent.com/10526131/100185207-24aa9d80-2e98-11eb-9e48-5d558bcdf5ca.png)

Test 1 (plurals):
![image](https://user-images.githubusercontent.com/10526131/100185222-2d02d880-2e98-11eb-8ced-108c1222fb75.png)

Test 2 (original distinctive - Mechanical in the same category as plumbing):
![image](https://user-images.githubusercontent.com/10526131/100185234-33915000-2e98-11eb-9831-e9182f619341.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
