### PR TITLE
5798- Review enhacements 20201203

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -507,7 +507,7 @@ class Request(db.Model):
     def get_descriptive_query(cls, desc, criteria, name_criteria):
         special_characters_descriptive = Request.set_special_characters_descriptive(desc)
         for e in criteria:
-            substitutions = r's\W* ?| '.join(map(str, special_characters_descriptive)) + 's\W* ?'
+            substitutions = r' ?| '.join(map(str, special_characters_descriptive))
             name_criteria += r'.*({})\y'.format(substitutions)
             e.filters.insert(len(e.filters), [func.lower(Name.name).op('~')(name_criteria)])
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -496,9 +496,9 @@ class Request(db.Model):
         special_characters_dist = Request.set_special_characters_distinctive(dist)
         substitutions = '|'.join(map(str, special_characters_dist))
         if not check_name_is_well_formed:
-            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*\y({1}s?)\W*\s*\y'.format(stop_words, substitutions)
         else:
-            dist_criteria = r'\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'\s*\W*({0})?\W*\y*({1}s?)\W*\s*\y'.format(stop_words, substitutions)
 
         return dist_criteria
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -104,8 +104,8 @@ class Request(db.Model):
 
     # Check-In / Check-Out (for INPROGRESS)
     # A UUID granted to the user that checks out the Name Request
-    checkedOutBy = db.Column('checked_out_by', db.String(64),index=True)
-    checkedOutDt = db.Column('checked_out_dt', db.DateTime(timezone=True),index=True)
+    checkedOutBy = db.Column('checked_out_by', db.String(64), index=True)
+    checkedOutDt = db.Column('checked_out_dt', db.DateTime(timezone=True), index=True)
 
     # MRAS fields
     homeJurisNum = db.Column('home_juris_num', db.String(40))
@@ -463,7 +463,8 @@ class Request(db.Model):
             elif word in list_desc:
                 name.extend(Request.set_special_characters_descriptive([word]))
             else:
-                raise Exception('Invalid classification for the word {0}. Cannot be included in exact match query.'.format(word))
+                raise Exception(
+                    'Invalid classification for the word {0}. Cannot be included in exact match query.'.format(word))
 
         criteria = cls.get_designations_in_name(criteria, name, any_designation_list, end_designation_list, stop_words)
 
@@ -496,9 +497,9 @@ class Request(db.Model):
         special_characters_dist = Request.set_special_characters_distinctive(dist)
         substitutions = '|'.join(map(str, special_characters_dist))
         if not check_name_is_well_formed:
-            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*\y({1}s?)\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*\y({1})\W*\s*\y'.format(stop_words, substitutions)
         else:
-            dist_criteria = r'\s*\W*({0})?\W*\y*({1}s?)\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'\s*\W*({0})?\W*\y*({1})\W*\s*\y'.format(stop_words, substitutions)
 
         return dist_criteria
 
@@ -506,7 +507,7 @@ class Request(db.Model):
     def get_descriptive_query(cls, desc, criteria, name_criteria):
         special_characters_descriptive = Request.set_special_characters_descriptive(desc)
         for e in criteria:
-            substitutions = ' ?| '.join(map(str, special_characters_descriptive)) + ' ?'
+            substitutions = r's\W* ?| '.join(map(str, special_characters_descriptive)) + 's\W* ?'
             name_criteria += r'.*({})\y'.format(substitutions)
             e.filters.insert(len(e.filters), [func.lower(Name.name).op('~')(name_criteria)])
 
@@ -555,7 +556,7 @@ class Request(db.Model):
         list_special_characters = []
         for element in list_d:
             list_special_characters.append(
-                r'\W*'.join(element[i:i + 1] + element[i:i + 1] + '?' for i in range(0, len(element), 1)))
+                r'\W*'.join(element[i:i + 1] + element[i:i + 1] + '?' for i in range(0, len(element), 1))+ r'\W*s?')
 
         return list_special_characters
 
@@ -563,7 +564,7 @@ class Request(db.Model):
     def set_special_characters_descriptive(cls, list_d):
         list_special_characters = []
         for element in list_d:
-            list_special_characters.append(r'\W*'.join(element[i:i + 1] for i in range(0, len(element), 1)))
+            list_special_characters.append(r'\W*'.join(element[i:i + 1] for i in range(0, len(element), 1)) + r'\W*s?')
 
         return list_special_characters
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -104,8 +104,8 @@ class Request(db.Model):
 
     # Check-In / Check-Out (for INPROGRESS)
     # A UUID granted to the user that checks out the Name Request
-    checkedOutBy = db.Column('checked_out_by', db.String(64), index=True)
-    checkedOutDt = db.Column('checked_out_dt', db.DateTime(timezone=True), index=True)
+    checkedOutBy = db.Column('checked_out_by', db.String(64),index=True)
+    checkedOutDt = db.Column('checked_out_dt', db.DateTime(timezone=True),index=True)
 
     # MRAS fields
     homeJurisNum = db.Column('home_juris_num', db.String(40))
@@ -463,8 +463,7 @@ class Request(db.Model):
             elif word in list_desc:
                 name.extend(Request.set_special_characters_descriptive([word]))
             else:
-                raise Exception(
-                    'Invalid classification for the word {0}. Cannot be included in exact match query.'.format(word))
+                raise Exception('Invalid classification for the word {0}. Cannot be included in exact match query.'.format(word))
 
         criteria = cls.get_designations_in_name(criteria, name, any_designation_list, end_designation_list, stop_words)
 
@@ -497,9 +496,9 @@ class Request(db.Model):
         special_characters_dist = Request.set_special_characters_distinctive(dist)
         substitutions = '|'.join(map(str, special_characters_dist))
         if not check_name_is_well_formed:
-            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*\y({1})\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions)
         else:
-            dist_criteria = r'\s*\W*({0})?\W*\y*({1})\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions)
 
         return dist_criteria
 
@@ -507,7 +506,7 @@ class Request(db.Model):
     def get_descriptive_query(cls, desc, criteria, name_criteria):
         special_characters_descriptive = Request.set_special_characters_descriptive(desc)
         for e in criteria:
-            substitutions = r' ?| '.join(map(str, special_characters_descriptive))
+            substitutions = ' ?| '.join(map(str, special_characters_descriptive)) + ' ?'
             name_criteria += r'.*({})\y'.format(substitutions)
             e.filters.insert(len(e.filters), [func.lower(Name.name).op('~')(name_criteria)])
 
@@ -556,7 +555,7 @@ class Request(db.Model):
         list_special_characters = []
         for element in list_d:
             list_special_characters.append(
-                r'\W*'.join(element[i:i + 1] + element[i:i + 1] + '?' for i in range(0, len(element), 1))+ r'\W*s?')
+                r'\W*'.join(element[i:i + 1] + element[i:i + 1] + '?' for i in range(0, len(element), 1)) + r'\W*s?')
 
         return list_special_characters
 

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -496,9 +496,9 @@ class Request(db.Model):
         special_characters_dist = Request.set_special_characters_distinctive(dist)
         substitutions = '|'.join(map(str, special_characters_dist))
         if not check_name_is_well_formed:
-            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'(no.?)*\s*\d*\s*\W*({0})?\W*\y({1})\W*\s*\y'.format(stop_words, substitutions)
         else:
-            dist_criteria = r'\s*\W*({0})?\W*({1})\W*\s*\y'.format(stop_words, substitutions)
+            dist_criteria = r'\s*\W*({0})?\W*\y({1})\W*\s*\y'.format(stop_words, substitutions)
 
         return dist_criteria
 

--- a/api/namex/models/word_classification.py
+++ b/api/namex/models/word_classification.py
@@ -45,7 +45,7 @@ class WordClassification(db.Model):
     @classmethod
     def find_word_classification(cls, word):
         results = db.session.query(cls.word, cls.classification).distinct(cls.word, cls.classification) \
-            .filter(func.lower(cls.word).op('~')(r"(^{0}(''[a-zA-Z])?\y)".format(word.lower()))) \
+            .filter(func.lower(cls.word).op('~')(r"(^{0}(''[a-zA-Z])?(?=$))".format(word.lower()))) \
             .filter(cls.end_dt.is_(None)) \
             .filter(cls.start_dt <= date.today()) \
             .filter(cls.approved_dt <= date.today()).all()

--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -357,7 +357,7 @@ def remove_double_letters_list_dist_words(list_dist, name_tokens, dist_substitut
             name_tokens))
         if dist_substitution_dict:
             dist_substitution_dict[not_double_letters_item] = dist_substitution_dict.pop(item)
-            if not dist_substitution_dict.get(not_double_letters_item):
+            if not_double_letters_item not in dist_substitution_dict.get(not_double_letters_item):
                 dist_substitution_dict[not_double_letters_item].append(not_double_letters_item)
 
     return list_dist_final, name_tokens, dist_substitution_dict

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -602,7 +602,6 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def get_stand_alone_substitutions(self, desc_synonym_dict, stand_alone):
         for key, value in desc_synonym_dict.items():
             if key in stand_alone:
-                value.pop()
                 value.extend(stand_alone)
 
         return desc_synonym_dict

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -498,7 +498,7 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
                 all_subs_dict = get_all_dict_substitutions(dist_substitution_dict, desc_synonym_dict, list_name)
                 # Get  N highest score (values) and shortest names (key)
                 dict_highest_counter.update({k: v for k, v in
-                                             sorted(dict_matches_counter.items(), key=lambda item: (-item[1], item[0]))[
+                                             sorted(dict_matches_counter.items(), key=lambda item: (-item[1], len(item[0])))[
                                              0:MAX_MATCHES_LIMIT]})
                 list_details = self.get_details_higher_score(dict_highest_counter, selected_matches, all_subs_dict)
                 forced = True if any(value == EXACT_MATCH for value in dict_highest_counter.values()) else False

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_descriptive_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_descriptive_request.py
@@ -22,9 +22,9 @@ from ...common import token_header, claims
                              ('VANCOUVER ISLAND AUTOSPA LTD.','VANCOUVER ISLAND CAR WASH LTD.'),
                              ('VANCOUVER ISLAND AUTO SPA LTD.','VANCOUVER ISLAND CAR WASH LTD.'),
                              ('WESTWOOD PRE-SCHOOL DEVELOPMENT LTD.', 'WESTWOOD EARLY CHILDHOOD DEVELOPMENT LTD.'),
-                             ('WESTWOOD BIOFUEL LTD.','WESTWOOD LIQUIFIED NATURAL GAS LTD.'),
-                             ('WESTWOOD BIO FUEL LTD.','WESTWOOD LIQUIFIED NATURAL GAS LTD.'),
-                             ('WESTWOOD BIO FUELING LTD.', 'WESTWOOD LIQUIFIED NATURAL GAS LTD.')
+                             ('WESTWOOD BIOFUEL LTD.','WESTWOOD NATURAL GAS PRODUCTS LTD.'),
+                             ('WESTWOOD BIO FUEL LTD.','WESTWOOD NATURAL GAS PRODUCTS LTD.'),
+                             ('WESTWOOD BIO FUELING LTD.', 'WESTWOOD NATURAL GAS PRODUCTS LTD.')
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_strip_out_numbers_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_strip_out_numbers_request.py
@@ -13,23 +13,16 @@ from ...common import token_header, claims
 
 @pytest.mark.parametrize("name, expected",
                          [
-                             # ("NO. 295 CATHEDRAL VENTURES LTD.", "CATHEDRAL HOLDINGS LTD."), # To be fixed with 4844:FixesFromUATRejectionTesting
-                             # ("NO. 295 SCS NO. 003 VENTURES LTD.", "SCS SOLUTIONS INC."), # To be fixed with 4844:FixesFromUATRejectionTesting
-                             # Incorrect Year in name
-                             # ("2000 ARMSTRONG -- PLUMBING 2020 LTD.", "ARMSTRONG PLUMBING & HEATING LTD."),
-                             ("ABC TWO PLUMBING ONE INC.", "ABC PLUMBING & HEATING LTD."),
-                             # ("SCS HOLDINGS INC.", "SCS SOLUTIONS INC."), # To be fixed with 4844:FixesFromUATRejectionTesting
-                             # NO LONGER VALID TEST SCENARIO, LUMBY IS NOT SYNONYM, THEN IT IS DISTINCTIVE AND IT
-                             # DOES NOT PASS WELL FORMED NAME DUE TO <DIST><DIST>
+                             ("NO. 295 CATHEDRAL VENTURES LTD.", "CATHEDRAL VENTURES TRADING LTD."),
+                             # ("NO. 295 SCS VENTURES LTD.", "SCS SOLUTIONS INC."),
+                             ("1800 ARMSTRONG -- PLUMBING 1900 LTD.", "ARMSTRONG PLUMBING & HEATING LTD."),
+                             ("ABC TWO PLUMBING INC.", "ABC PLUMBING & HEATING LTD."),
+                             ("SCS HOLDINGS INC.", "SCS SOLUTIONS INC."),
                              ("RE/MAX LUMBY INC.", "REMAX LUMBY"),
-                             # NO LONGER VALID TEST SCENARIO, LUMBY IS NOT SYNONYM, THEN IT IS DISTINCTIVE AND IT
-                             # DOES NOT PASS WELL FORMED NAME DUE TO <DIST><DIST>
                              ("RE MAX LUMBY INC.", "REMAX LUMBY"),
                              ("468040 B.C. LTD.", "468040 BC LTD."),
-                             # ("S, C & S HOLDINGS INC.", "SCS SOLUTIONS INC."), # To be fixed with 4844:FixesFromUATRejectionTesting
-                             # ENGINEERING not found in synonyms, then considered a distintive, the only match obtained is
-                             # EQTEC SOLUTIONS LTD. which is not close enough with current similarity score (0.6 vs 0.67 -->threshold)
-                             # ("EQTEC ENGINEERING & SOLUTIONS LTD.", "EQTEC ENGINEERING LTD.") # To be fixed with 4844:FixesFromUATRejectionTesting
+                             ("S, C & S HOLDINGS INC.", "SCS SOLUTIONS INC."),
+                             ("EQTEC ENGINEERING & SOLUTIONS LTD.", "EQTEC ENGINEERING LTD.")
                          ]
                          )
 @pytest.mark.xfail(raises=ValueError)

--- a/services/auto-analyze/src/auto_analyze/analyzer.py
+++ b/services/auto-analyze/src/auto_analyze/analyzer.py
@@ -83,6 +83,7 @@ async def auto_analyze(name: str,  # pylint: disable=too-many-locals, too-many-a
                                                                                         match_list)
 
         desc_tmp_synonym_dict = builder.get_substitutions_descriptive(service.get_list_desc())
+        desc_tmp_synonym_dict = builder.get_stand_alone_substitutions(desc_tmp_synonym_dict, stand_alone_words)
         desc_tmp_synonym_dict = remove_extra_value(desc_tmp_synonym_dict, dict_synonyms)
 
         # Update key in desc_db_synonym_dict

--- a/services/auto-analyze/src/auto_analyze/analyzer.py
+++ b/services/auto-analyze/src/auto_analyze/analyzer.py
@@ -143,12 +143,7 @@ async def auto_analyze(name: str,  # pylint: disable=too-many-locals, too-many-a
         logging.getLogger(__name__).debug('similarity: %s', similarity)
         print("similarity: ", similarity)
 
-    if similarity == EXACT_MATCH or (
-            similarity >= MINIMUM_SIMILARITY and not is_not_real_conflict(list_name,
-                                                                          stand_alone_words,
-                                                                          list_dist,
-                                                                          dict_synonyms,
-                                                                          service)):
+    if similarity >= MINIMUM_SIMILARITY:
         dict_matches_counter.update({name: similarity})
 
     return dict_matches_counter
@@ -227,30 +222,6 @@ def get_cosine(vec1, vec2):
 def get_similarity(vector1, vector2, entropy):
     """Return similarity between two vectors which are either both distinctives or descriptives."""
     return get_cosine(vector1, vector2) * entropy
-
-
-def is_not_real_conflict(list_name, stand_alone_words, list_dist, dict_desc, service):
-    """Return True if the name is not a real conflict. Otherwise, false if the name is a conflict."""
-    list_desc = list(dict_desc.keys())
-    if is_standalone_name(list_name, stand_alone_words):
-        return stand_alone_additional_dist_desc(list_dist, service.get_list_dist(), list_desc,
-                                                service.get_list_desc())
-    return False
-
-
-def is_standalone_name(list_name, stand_alone_words):
-    """Return True if standalone name."""
-    if any(stand_alone in list_name for stand_alone in stand_alone_words):
-        return True
-    return False
-
-
-def stand_alone_additional_dist_desc(lst_dist_name1, lst_dist_name2, lst_desc_name1, lst_desc_name2):
-    """Return True if there is an additional distinctive or descriptive in the stand-alone name."""
-    if lst_dist_name1.__len__() != lst_dist_name2.__len__() or lst_desc_name1.__len__() != lst_desc_name2.__len__():
-        return True
-
-    return False
 
 
 def remove_extra_value(d1, d2):

--- a/services/auto-analyze/src/auto_analyze/analyzer.py
+++ b/services/auto-analyze/src/auto_analyze/analyzer.py
@@ -16,6 +16,8 @@ import itertools
 import logging
 import math
 import re
+import warnings
+
 from collections import Counter
 
 from namex.services.name_processing.name_processing import NameProcessingService
@@ -151,12 +153,12 @@ async def auto_analyze(name: str,  # pylint: disable=too-many-locals, too-many-a
     return dict_matches_counter
 
 
-def get_vector(conflict_class_list, original_class_list, class_subs_dict, dist=False, stand_alone_words=[]):
+def get_vector(conflict_class_list=[], original_class_list=[], class_subs_dict={}, dist=False, stand_alone_words=[]):
     """Return vector of words (or synonyms) found in original_class_list which are in conflict_class_list."""
     vector = dict()
     entropy = list()
-    original_class_list = original_class_list if original_class_list else []
-    class_subs_dict = class_subs_dict if class_subs_dict else {}
+    if not conflict_class_list or not original_class_list or not class_subs_dict:
+        warnings.warn("Parameters in get_vector function are not set.", Warning)
 
     conflict_class_stem = [porter.stem(name.lower()) if
                            name not in stand_alone_words else name.lower() for name in conflict_class_list]
@@ -287,9 +289,7 @@ def remove_descriptive_original(dict_original_desc, dict_conflict_desc):
     d1 = {}
 
     for key, value in dict_original_desc.items():
-        if key in inter_keys:
-            d1.update({key: value})
-        elif list(set(value) & set(inter_values)).__len__() == 0:
+        if key in inter_keys or list(set(value) & set(inter_values)).__len__() == 0:
             d1.update({key: value})
 
     return d1

--- a/solr-synonyms-api/synonyms/services/synonyms/synonym.py
+++ b/solr-synonyms-api/synonyms/services/synonyms/synonym.py
@@ -132,7 +132,7 @@ class SynonymService(SynonymDesignationMixin, SynonymModelMixin):
         model = self.get_model()
 
         filters = [
-            func.lower(model.category).op('~')(r'\y{}\y'.format('stand-alone'))
+            func.lower(model.category).op('~')(r'\y({})\y'.format(r'stand-alone|stand-alone-\d'))
         ]
 
         results = self.find_word_synonyms(None, filters, stand_alone=True)


### PR DESCRIPTION
*bcgov/entity#5798:*

*Description of changes:*
- Adding an optional 's' at the end of distinctive and descriptives.
- Get the smallest length in names for conflicts after score.
- Prefer the descriptive in common between name request and conflict and remove the duplicated categories.
- Do not remove values from descriptive list when stand alone list is added.
- Get stand alone for analyzed conflict as well.
- Fixes in searching word_classification table.
- Do not stem stand-alone words.
- Updated test cases.

Regression test successful:
![image](https://user-images.githubusercontent.com/10526131/101193501-8219b980-3611-11eb-9e9d-c4a1d91bffab.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
