### PR TITLE
keep classification in well-formed name.

### DIFF
--- a/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_utils.py
@@ -204,7 +204,7 @@ def get_conflicts_same_classification(builder, name_tokens, processed_name, stan
     return check_conflicts
 
 
-def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc):
+def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token_svc, conflict=False):
     desc_compound_dict = get_compound_descriptives(service, syn_svc)
     service.set_compound_descriptive_name_tokens(update_compound_tokens(list(desc_compound_dict.keys()), match))
 
@@ -228,12 +228,13 @@ def get_classification(service, stand_alone_words, syn_svc, match, wc_svc, token
     service._list_none_words = update_none_list(service.get_list_none(), service.get_list_desc())
 
     # Check if words are in the same category
-    if 2 < service.get_list_dist().__len__() == match.__len__():
-        service._list_desc_words = [service.get_list_dist().pop()]
-        dict_desc.update({service.get_list_desc()[0]: service.get_list_desc()})
-    elif 2 < service.get_list_desc().__len__() == match.__len__():
-        service._list_dist_words = [service.get_list_desc().pop(0)]
-        dict_desc.pop(service.get_list_dist()[0], None)
+    if conflict:
+        if 2 < service.get_list_dist().__len__() == match.__len__():
+            service._list_desc_words = [service.get_list_dist().pop()]
+            dict_desc.update({service.get_list_desc()[0]: service.get_list_desc()})
+        elif 2 < service.get_list_desc().__len__() == match.__len__():
+            service._list_dist_words = [service.get_list_desc().pop(0)]
+            dict_desc.pop(service.get_list_dist()[0], None)
 
     service.set_compound_descriptive_name_tokens(
         update_compound_tokens(service.get_list_dist() + service.get_list_desc(),

--- a/services/auto-analyze/src/auto_analyze/analyzer.py
+++ b/services/auto-analyze/src/auto_analyze/analyzer.py
@@ -77,7 +77,7 @@ async def auto_analyze(name: str,  # pylint: disable=too-many-locals, too-many-a
         similarity = EXACT_MATCH
     else:
         match_list = np_svc.name_tokens
-        get_classification(service, stand_alone_words, syn_svc, match_list, wc_svc, token_svc)
+        get_classification(service, stand_alone_words, syn_svc, match_list, wc_svc, token_svc, True)
 
         dist_db_substitution_dict = builder.get_substitutions_distinctive(service.get_list_dist())
         service._list_dist_words, match_list, _ = remove_double_letters_list_dist_words(service.get_list_dist(),


### PR DESCRIPTION
*bcgov/entity#5820*

*Description of changes:*
Get back the original behavior of check_well_formed name while getting the classification logic for conflict names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
