### PR TITLE
REAPPLY is not needed for MVP

### DIFF
--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -435,7 +435,7 @@ class NameRequestActiveActions(AbstractEnum):
     EDIT = NameRequestActions.EDIT.value
     CANCEL = NameRequestActions.CANCEL.value  # TODO: Ensure there is NO refund for this!
     RECEIPT = NameRequestActions.RECEIPT.value
-    REAPPLY = NameRequestActions.REAPPLY.value
+    # REAPPLY = NameRequestActions.REAPPLY.value
     # RESEND = NameRequestActions.RESEND.value
 
 

--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -453,7 +453,6 @@ class NameRequestInProgressActions(AbstractEnum):
     Define these separately.
     """
     RECEIPT = NameRequestActions.RECEIPT.value
-    REQUEST_REFUND = NameRequestActions.REQUEST_REFUND.value
 
 
 class NameRequestExpiredActions(AbstractEnum):

--- a/api/namex/services/name_request/name_request_state.py
+++ b/api/namex/services/name_request/name_request_state.py
@@ -78,7 +78,7 @@ def display_reapply_action(nr_model=None):
                 expiry_date = nr_model.expirationDate.date()
 
                 delta = expiry_date - todays_date
-                if delta.days <= 5:
+                if delta.days <= 5 and delta.days > 0:
                     return True
         return False
     except Exception as err:


### PR DESCRIPTION
*Issue /bcgov/entity#5746

*Description of changes:*
 - REAPPLY is not needed for MVP
 - Removed Refund from Inprogress


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
