### PR TITLE
5527: Sole Props/DBAs, LLP, BC LP/GP apply expro rules

### DIFF
--- a/api/namex/resources/auto_analyse/analysis_options.py
+++ b/api/namex/resources/auto_analyse/analysis_options.py
@@ -1,5 +1,6 @@
 from .response_objects.setup import Setup
 from string import Template
+from .utils import join_list_words
 
 
 class HelpfulHintSetup(Setup):
@@ -120,7 +121,8 @@ def assumed_name_setup():
     return AssumedNameSetup(
         type="assumed_name",
         header=Template("Assume a Name"),
-        line1=Template("If the name of an extraprovincial business is too similar to an existing BC business, you must use (assume) a different name in BC. Assumed names must be reviewed Registries staff."),
+        line1=Template(
+            "If the name of an extraprovincial business is too similar to an existing BC business, you must use (assume) a different name in BC. Assumed names must be reviewed Registries staff."),
         action=Template("I want to assume a name in BC"),
         # checkbox=Template("I want to send my name to be examined as an Assumed Name.")
     )
@@ -198,6 +200,20 @@ def replace_designation_setup():
     )
 
 
+class RemoveDesignationSetup(Setup):
+    pass
+
+
+def remove_designation_setup(all_designations_user):
+    return ReplaceDesignationSetup(
+        type="remove_designation",
+        header=Template("Remove Designation"),
+        line1=Template(
+            "Remove the designation(s) from your name: " + join_list_words([element.upper() for element in all_designations_user])),
+        line2=Template("")
+    )
+
+
 class AddDesignationSetup(Setup):
     pass
 
@@ -251,3 +267,6 @@ def two_designations_order_setup():
         line1=Template("Please select one of the designations listed here:"),
         line2=Template("")
     )
+
+
+

--- a/api/namex/resources/auto_analyse/analysis_response.py
+++ b/api/namex/resources/auto_analyse/analysis_response.py
@@ -8,6 +8,7 @@ from ..auto_analyse.analysis_issues import \
     AddDescriptiveWordIssue, \
     ContainsWordsToAvoidIssue, \
     DesignationMismatchIssue, \
+    DesignationRemovalIssue,\
     TooManyWordsIssue, \
     NameRequiresConsentIssue, \
     ContainsUnclassifiableWordIssue, \
@@ -37,6 +38,7 @@ def response_issues(issue_code):
         AnalysisIssueCodes.NAME_REQUIRES_CONSENT: NameRequiresConsentIssue,
         AnalysisIssueCodes.DESIGNATION_NON_EXISTENT: DesignationNonExistentIssue,
         AnalysisIssueCodes.DESIGNATION_MISMATCH: DesignationMismatchIssue,
+        AnalysisIssueCodes.DESIGNATION_REMOVAL: DesignationRemovalIssue,
         AnalysisIssueCodes.END_DESIGNATION_MORE_THAN_ONCE: EndDesignationMoreThanOnceIssue,
         AnalysisIssueCodes.DESIGNATION_MISPLACED: DesignationMisplacedIssue,
         AnalysisIssueCodes.CORPORATE_CONFLICT: CorporateNameConflictIssue,
@@ -137,6 +139,10 @@ class AnalysisResponse:
         return None
 
     @abc.abstractmethod
+    def build_designation_removal_issue(self, procedure_result, issue_count, issue_idx):
+        return None
+
+    @abc.abstractmethod
     def build_end_designation_more_than_once_issue(self, procedure_result, issue_count, issue_idx):
         return None
 
@@ -203,6 +209,9 @@ class AnalysisResponse:
 
                     if procedure_result.result_code == AnalysisIssueCodes.DESIGNATION_MISMATCH:
                         issue = self.build_designation_mismatch_issue(procedure_result, issue_count, issue_idx)
+
+                    if procedure_result.result_code == AnalysisIssueCodes.DESIGNATION_REMOVAL:
+                        issue = self.build_designation_removal_issue(procedure_result, issue_count, issue_idx)
 
                     if procedure_result.result_code == AnalysisIssueCodes.END_DESIGNATION_MORE_THAN_ONCE:
                         issue = self.build_end_designation_more_than_once_issue(procedure_result,issue_count, issue_idx)

--- a/api/namex/resources/auto_analyse/issues/__init__.py
+++ b/api/namex/resources/auto_analyse/issues/__init__.py
@@ -8,6 +8,7 @@ from .contains_words_to_avoid import ContainsWordsToAvoidIssue
 from .corporate_name_conflict import CorporateNameConflictIssue
 from .queue_name_conflict import QueueNameConflictIssue
 from .designation_mismatch import DesignationMismatchIssue
+from .designation_removal import DesignationRemovalIssue
 from .end_designation_more_than_once import EndDesignationMoreThanOnceIssue
 from .designation_misplaced import DesignationMisplacedIssue
 from .designation_non_existent import DesignationNonExistentIssue

--- a/api/namex/resources/auto_analyse/issues/abstract/analysis_response_issue.py
+++ b/api/namex/resources/auto_analyse/issues/abstract/analysis_response_issue.py
@@ -161,7 +161,8 @@ class AnalysisResponseIssue:
 
         return False, 0, 0, current_processed_token
 
-    def adjust_word_index(self, original_name_str, name_original_tokens, name_tokens, word_idx, offset_designations=True):
+    def adjust_word_index(self, original_name_str, name_original_tokens, name_tokens, word_idx,
+                          offset_designations=True):
         # remove punctuations
         name_original_tokens = [re.sub(r'(?<=[a-zA-Z\.])\'[Ss]', '', x) for x in name_original_tokens]
         name_original_tokens = [re.sub(r'[^A-Za-z0-9.]+', ' ', x) for x in name_original_tokens]
@@ -220,7 +221,8 @@ class AnalysisResponseIssue:
                         if offset_designations:
                             # Does the current word have any punctuation associated with?
                             next_char = ''
-                            if len(unprocessed_name_string) > 0 and len(original_tokens) > 0 and unprocessed_name_string[0] == original_tokens[0]:
+                            if len(unprocessed_name_string) > 0 and len(original_tokens) > 0 and \
+                                    unprocessed_name_string[0] == original_tokens[0]:
                                 next_char = original_tokens[0]
 
                             token_is_designation = (current_original_token + next_char) in all_designations

--- a/api/namex/resources/auto_analyse/issues/designation_removal.py
+++ b/api/namex/resources/auto_analyse/issues/designation_removal.py
@@ -1,0 +1,9 @@
+from namex.services.name_request.auto_analyse import AnalysisIssueCodes
+# Import DTOs
+from namex.resources.auto_analyse.issues import DesignationMismatchIssue
+
+
+class DesignationRemovalIssue(DesignationMismatchIssue):
+    issue_type = AnalysisIssueCodes.DESIGNATION_REMOVAL
+    status_text = "Further Action Required"
+    issue = None

--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/bc_name_analysis_response.py
@@ -33,10 +33,13 @@ from ...analysis_options import \
     replace_designation_setup, \
     change_entity_type_setup, \
     change_designation_order_setup, \
-    add_designation_setup, two_designations_order_setup
+    add_designation_setup, two_designations_order_setup, remove_designation_setup
 
 
 # Execute analysis returns a response strategy code
+from ...issues.designation_removal import DesignationRemovalIssue
+
+
 def response_issues(issue_code):
     issue_types = {
         AnalysisIssueCodes.CHECK_IS_VALID: CheckIsValidIssue,
@@ -50,6 +53,7 @@ def response_issues(issue_code):
         AnalysisIssueCodes.NAME_REQUIRES_CONSENT: NameRequiresConsentIssue,
         AnalysisIssueCodes.DESIGNATION_NON_EXISTENT: DesignationNonExistentIssue,
         AnalysisIssueCodes.DESIGNATION_MISMATCH: DesignationMismatchIssue,
+        AnalysisIssueCodes.DESIGNATION_REMOVAL: DesignationRemovalIssue,
         AnalysisIssueCodes.END_DESIGNATION_MORE_THAN_ONCE: EndDesignationMoreThanOnceIssue,
         AnalysisIssueCodes.DESIGNATION_MISPLACED: DesignationMisplacedIssue,
         AnalysisIssueCodes.CORPORATE_CONFLICT: CorporateNameConflictIssue,
@@ -256,6 +260,21 @@ class BcAnalysisResponse(AnalysisResponse):
 
     def build_designation_mismatch_issue(self, procedure_result, issue_count, issue_idx):
         option1 = replace_designation_setup()
+
+        option2 = change_entity_type_setup()
+
+        issue = response_issues(procedure_result.result_code)(self, [
+            option1,
+            option2
+        ])
+
+        # Add the procedure to the stack of executed_procedures so we know what issues have been set up
+        self.executed_procedures.append(procedure_result.result_code)
+
+        return issue
+
+    def build_designation_removal_issue(self, procedure_result, issue_count, issue_idx):
+        option1 = remove_designation_setup(procedure_result.values.get('incorrect_designations',[]))
 
         option2 = change_entity_type_setup()
 

--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/issues/__init__.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/issues/__init__.py
@@ -7,6 +7,7 @@ from .contains_words_to_avoid import BcContainsWordsToAvoidIssue
 from .corporate_name_conflict import BcCorporateNameConflictIssue
 from .queue_name_conflict import BcQueueNameConflictIssue
 from .designation_mismatch import BcDesignationMismatchIssue
+from .designation_removal import  BcDesignationRemovalIssue
 from .designation_misplaced import BcDesignationMisplacedIssue
 from .designation_non_existent import BcDesignationNonExistentIssue
 from .end_designation_more_than_once import BcEndDesignationMoreThanOnceIssue

--- a/api/namex/resources/auto_analyse/paths/bc_name_analysis/issues/designation_removal.py
+++ b/api/namex/resources/auto_analyse/paths/bc_name_analysis/issues/designation_removal.py
@@ -1,0 +1,5 @@
+from namex.resources.auto_analyse.issues import DesignationRemovalIssue
+
+
+class BcDesignationRemovalIssue(DesignationRemovalIssue):
+    pass

--- a/api/namex/resources/auto_analyse/utils.py
+++ b/api/namex/resources/auto_analyse/utils.py
@@ -1,0 +1,3 @@
+
+def join_list_words(list_words, separator=", "):
+    return "<b>" + separator.join(list_words) + "</b>"

--- a/api/namex/services/name_request/auto_analyse/__init__.py
+++ b/api/namex/services/name_request/auto_analyse/__init__.py
@@ -78,6 +78,7 @@ class AnalysisIssueCodes(str, Enum):
     DESIGNATION_MISMATCH = 'designation_mismatch'
     END_DESIGNATION_MORE_THAN_ONCE = 'end_designation_more_than_once'
     DESIGNATION_MISPLACED = 'designation_misplaced'
+    DESIGNATION_REMOVAL = 'designation_removal'
     NAME_REQUIRES_CONSENT = 'consent_required'
     DESIGNATION_NON_EXISTENT = 'designation_non_existent'
 

--- a/api/namex/services/name_request/auto_analyse/name_analysis_director.py
+++ b/api/namex/services/name_request/auto_analyse/name_analysis_director.py
@@ -1,3 +1,4 @@
+from namex.constants import BCUnprotectedNameEntityTypes
 from .mixins.get_synonyms_lists import GetSynonymsListsMixin
 from .mixins.get_designations_lists import GetDesignationsListsMixin
 from .mixins.get_word_classification_lists import GetWordClassificationListsMixin
@@ -295,6 +296,7 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
             )
             if check_name_is_well_formed.result_code in (
                     AnalysisIssueCodes.ADD_DISTINCTIVE_WORD, AnalysisIssueCodes.ADD_DESCRIPTIVE_WORD) and \
+                    self.entity_type not in (BCUnprotectedNameEntityTypes.list()) and \
                     not check_name_is_well_formed.is_valid:
                 analysis.append(check_name_is_well_formed)
             elif check_name_is_well_formed.result_code == AnalysisIssueCodes.CORPORATE_CONFLICT:
@@ -380,7 +382,8 @@ class NameAnalysisDirector(GetSynonymsListsMixin, GetDesignationsListsMixin, Get
                 AnalysisIssueCodes.DESIGNATION_NON_EXISTENT,
                 AnalysisIssueCodes.END_DESIGNATION_MORE_THAN_ONCE,
                 AnalysisIssueCodes.DESIGNATION_MISPLACED,
-                AnalysisIssueCodes.DESIGNATION_MISMATCH
+                AnalysisIssueCodes.DESIGNATION_MISMATCH,
+                AnalysisIssueCodes.DESIGNATION_REMOVAL
             ]
 
             analysis = analysis + self.do_analysis()

--- a/api/namex/services/name_request/builders/name_analysis_builder.py
+++ b/api/namex/services/name_request/builders/name_analysis_builder.py
@@ -363,20 +363,29 @@ class NameAnalysisBuilder(AbstractNameAnalysisBuilder):
     def check_designation_mismatch(self, list_name, entity_type_user, all_designations, all_designations_user):
         result = ProcedureResult()
         result.is_valid = True
-
         mismatch_entity_designation_list = []
-        for idx, token in enumerate(list_name):
-            if token in all_designations and token not in all_designations_user:
-                mismatch_entity_designation_list.append(token)
 
-        if mismatch_entity_designation_list:
+        if not all_designations_user and all_designations:
             result.is_valid = False
-            result.result_code = AnalysisIssueCodes.DESIGNATION_MISMATCH
+            result.result_code = AnalysisIssueCodes.DESIGNATION_REMOVAL
             result.values = {
                 'list_name': list_name,
-                'incorrect_designations': mismatch_entity_designation_list,
+                'incorrect_designations': all_designations,
                 'correct_designations': all_designations_user,
             }
+        else:
+            for idx, token in enumerate(list_name):
+                if token in all_designations and token not in all_designations_user:
+                    mismatch_entity_designation_list.append(token)
+
+            if mismatch_entity_designation_list:
+                result.is_valid = False
+                result.result_code = AnalysisIssueCodes.DESIGNATION_MISMATCH
+                result.values = {
+                    'list_name': list_name,
+                    'incorrect_designations': mismatch_entity_designation_list,
+                    'correct_designations': all_designations_user,
+                }
 
         return result
 


### PR DESCRIPTION
*bcgov/entity#5527:*

*Description of changes:*
- Unprotected names are asked to remove designations when entity type is one of the following:
    Sole Propietorship
    Doing Business As
    General Partnership

![image](https://user-images.githubusercontent.com/10526131/101964316-d4387d00-3bc5-11eb-8d2e-29f9039cb58f.png)


- The following unprotected entity types are checked for correct designation:
    Limited Partnership
    Limited Liability Partnership

![image](https://user-images.githubusercontent.com/10526131/101964531-95ef8d80-3bc6-11eb-99ea-ece5deb23491.png)


- Well formed name analysis not showing missing distinctive or descriptive for Unprotected Entity Types. When just one word, search conflicts does not have to run.
![image](https://user-images.githubusercontent.com/10526131/101964612-cc2d0d00-3bc6-11eb-99d2-66561bc25b46.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
