### PR TITLE
5919/Removed Assumed Name from corporate and queue conflicts for XPRO

### DIFF
--- a/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
+++ b/api/namex/resources/auto_analyse/paths/xpro_name_analysis/xpro_name_analysis_response.py
@@ -178,19 +178,19 @@ class XproAnalysisResponse(AnalysisResponse):
         :param issue_idx:
         :return:
         """
-        option1 = assumed_name_setup() if self.entity_type in (
-            EntityTypes.XPRO_CORPORATION.value, EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY.value,
-            EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
-            else alternative_assumed_name_setup()
+        # option1 = assumed_name_setup() if self.entity_type in (
+        #     EntityTypes.XPRO_CORPORATION.value, EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY.value,
+        #     EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
+        #     else alternative_assumed_name_setup()
 
-        option2 = send_to_examiner_setup()
+        option1 = send_to_examiner_setup()
 
-        option3 = obtain_consent_setup()
+        option2 = obtain_consent_setup()
 
         issue = response_issues(procedure_result.result_code)(self, [
             option1,
             option2,
-            option3
+            #option3
         ])
 
 
@@ -210,19 +210,19 @@ class XproAnalysisResponse(AnalysisResponse):
         return issue
 
     def build_queue_conflict_issue(self, procedure_result, issue_count, issue_idx):
-        option1 = assumed_name_setup() if self.entity_type in (
-            EntityTypes.XPRO_CORPORATION.value, EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY.value,
-            EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
-            else alternative_assumed_name_setup()
+        # option1 = assumed_name_setup() if self.entity_type in (
+        #     EntityTypes.XPRO_CORPORATION.value, EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY.value,
+        #     EntityTypes.XPRO_LIMITED_LIABILITY_COMPANY.value) \
+        #     else alternative_assumed_name_setup()
 
-        option2 = send_to_examiner_setup()
+        option1 = send_to_examiner_setup()
 
-        option3 = obtain_consent_setup()
+        option2 = obtain_consent_setup()
 
         issue = response_issues(procedure_result.result_code)(self, [
             option1,
             option2,
-            option3
+            #option3
         ])
 
         # Add the procedure to the stack of executed_procedures so we know what issues have been set up


### PR DESCRIPTION
*bcgov/entity#5919*

*Description of changes:*
Removed assumed name Option in search conflict for approved and queue conflicts.
![corp_conflict](https://user-images.githubusercontent.com/10526131/102152289-87ed7700-3e29-11eb-962d-76d68b1cc802.png)

![image](https://user-images.githubusercontent.com/10526131/102152331-9f2c6480-3e29-11eb-8683-42241ecae306.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
