### PR TITLE
remove Priority from getting the oldest Draft.

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -279,7 +279,7 @@ class Request(db.Model):
             filter(
                 Request.stateCd.in_([State.DRAFT]),
                 Request.nrNum.notlike('NR L%')). \
-            order_by(Request.priorityCd.desc(), Request.submittedDate.asc()). \
+            order_by(Request.submittedDate.asc()). \
             first()
 
     @classmethod


### PR DESCRIPTION
*Issue #, bcgov/entity#6082

*Description of changes:*
removed the Priority code from the sort order of the select.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
