### PR TITLE
Check NR state before request and refund

### DIFF
--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -598,6 +598,8 @@ class NameRequestPaymentAction(AbstractNameRequestResource):
             PaymentState.COMPLETED.value,
             PaymentState.PARTIAL.value
         ]
+        if nr_model.stateCd not in [State.DRAFT]:
+            raise PaymentServiceError(message='Invalid NR state for cancel and refund')
         # Cancel any payments associated with the NR
         for payment in nr_model.payments.all():
             if payment.payment_status_code in valid_states and payment.payment_id == payment_id:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Validate the NR state before cancel and refund. Cancel and Refund should happen only for NRs in DRAFT state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
