### PR TITLE
6047 - handle unexpected status case

### DIFF
--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -308,6 +308,12 @@ class CreateNameRequestPayment(AbstractNameRequestResource):
 
                 response = make_response(data, 201)
                 return response
+            # something went wrong with status code above
+            else:
+                # log actual status code
+                print('Error with status code. Actual status code: ' + payment_response.statusCode)
+                # return generic error status to the front end
+                return jsonify(message='Name Request {nr_id} encountered an error'.format(nr_id=nr_id)), 500
 
         except PaymentServiceError as err:
             return handle_exception(err, err.message, 500)

--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -311,9 +311,9 @@ class CreateNameRequestPayment(AbstractNameRequestResource):
             # something went wrong with status code above
             else:
                 # log actual status code
-                print('Error with status code. Actual status code: ' + payment_response.statusCode)
+                current_app.logger.debug('Error with status code. Actual status code: ' + payment_response.statusCode)
                 # return generic error status to the front end
-                return jsonify(message='Name Request {nr_id} encountered an error'.format(nr_id=nr_id)), 500
+                return jsonify(message='Name Request {nr_id} encountered an error'.format(nr_id=nr_id)), 402
 
         except PaymentServiceError as err:
             return handle_exception(err, err.message, 500)


### PR DESCRIPTION
*Issue #6047

*Description of changes:*

UI was receiving a response code of 0 from the api... I followed the path, and found this path where there was no exception thrown, but the api didn't receive an expected status code. In this case I print the status code, and return an error to the UI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
