### PR TITLE
7433 Add submitted start/end date filter to requests search endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 .idea/name-examination.iml
 .idea/vcs.xml
 .idea/workspace.xml
+*.iml
 
 # JS + Node files #
 ######################
@@ -100,6 +101,7 @@ solr/cores/.DS_Store
 **/.pytest_cache
 .coverage
 .hypothesis
+http-client.*
 
 # Solr core data
 #######################

--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -10,6 +10,8 @@ dsg_end = 'Designations_end'
 dsg_any = 'Designations_any'
 stop_w = 'Stop Words'
 
+DATE_FORMAT_NAMEX_SEARCH = '%Y-%m-%d'
+DATE_TIME_FORMAT_SQL = '%Y-%m-%d %H:%M:%S%z'
 
 class AbstractEnum(Enum):
     @classmethod

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -6,9 +6,7 @@ from flask import request, jsonify, g, current_app, get_flashed_messages
 from flask_restx import Namespace, Resource, fields, cors
 from flask_jwt_oidc import AuthError
 
-from pytz import timezone, UTC
-from dateutil import tz
-
+from namex.constants import DATE_TIME_FORMAT_SQL
 from namex.utils.logging import setup_logging
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -297,7 +295,7 @@ class Requests(Resource):
                 '(now() at time zone \'utc\') - INTERVAL \'{hour_offset} HOURS\''.format(hour_offset=current_hour + 24 * 29)))
 
         if submittedInterval and (submittedStartDate or submittedEndDate):
-            return jsonify({"message": "submittedInterval cannot be used in conjuction with submittedStartDate and submittedEndDateTime"}), 400
+            return jsonify({"message": "submittedInterval cannot be used in conjuction with submittedStartDate and submittedEndDate"}), 400
 
         submittedStartDateTimeUtcObj = None
         submittedEndDateTimeUtcObj = None
@@ -306,7 +304,7 @@ class Requests(Resource):
             try:
                 submittedStartDateTimeUtcObj = convert_to_utc_min_date_time(submittedStartDate)
                 # convert date to format db expects
-                submittedStartDateTimeUtc = submittedStartDateTimeUtcObj.strftime('%Y-%m-%d %H:%M:%S%z')
+                submittedStartDateTimeUtc = submittedStartDateTimeUtcObj.strftime(DATE_TIME_FORMAT_SQL)
                 q = q.filter(RequestDAO.submittedDate >=
                              text('\'{submittedStartDateTimeUtc}\''
                               .format(submittedStartDateTimeUtc=submittedStartDateTimeUtc)))
@@ -318,7 +316,7 @@ class Requests(Resource):
             try:
                 submittedEndDateTimeUtcObj = convert_to_utc_max_date_time(submittedEndDate)
                 # convert date to format db expects
-                submittedEndDateTimeUtc = submittedEndDateTimeUtcObj.strftime('%Y-%m-%d %H:%M:%S%z')
+                submittedEndDateTimeUtc = submittedEndDateTimeUtcObj.strftime(DATE_TIME_FORMAT_SQL)
                 q = q.filter(RequestDAO.submittedDate <=
                              text('\'{submittedEndDateTimeUtc}\''
                                   .format(submittedEndDateTimeUtc=submittedEndDateTimeUtc)))

--- a/api/namex/utils/common.py
+++ b/api/namex/utils/common.py
@@ -3,7 +3,8 @@ import inflect
 from itertools import product
 from datetime import  datetime, time
 from dateutil import tz
-from pytz import UTC
+
+from namex.constants import DATE_FORMAT_NAMEX_SEARCH
 
 _parse_csv_line = lambda x: (x.split(','))
 
@@ -99,22 +100,23 @@ def convert_to_ascii(value):
         return value
 
 
+
 def convert_to_utc_min_date_time(date_str: str):
-    date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+    """Convert server date string to UTC datetime with min time."""
+    server_date_time = datetime.strptime(date_str, DATE_FORMAT_NAMEX_SEARCH)
     min_time = time(hour=0, minute=0, second=0, microsecond=0)
-    return datetime.combine(date_obj, min_time, tzinfo=tz.UTC)
+    server_date_time = datetime.combine(server_date_time, min_time, tzinfo=tz.tzlocal())
+    utc_date_time = server_date_time.astimezone(tz.UTC)
+    return utc_date_time
 
 
 def convert_to_utc_max_date_time(date_str: str):
-    date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+    """Convert server date string to UTC datetime with max time."""
+    server_date_time = datetime.strptime(date_str, DATE_FORMAT_NAMEX_SEARCH)
     max_time = time(hour=23, minute=59, second=59, microsecond=999999)
-    return datetime.combine(date_obj, max_time, tzinfo=tz.UTC)
-
-
-# def convert_to_utc_date_time(date_time_str: str):
-#     """Convert datetime string with utc offset to datetime object"""
-#     date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S%z')
-#     return date_time_obj.astimezone(UTC)
+    server_date_time = datetime.combine(server_date_time, max_time, tzinfo=tz.tzlocal())
+    utc_date_time = server_date_time.astimezone(tz.UTC)
+    return utc_date_time
 
 
 # def remove_numbers_list(list_name):

--- a/api/namex/utils/common.py
+++ b/api/namex/utils/common.py
@@ -1,6 +1,8 @@
 import re
 import inflect
 from itertools import product
+import datetime
+from pytz import UTC
 
 _parse_csv_line = lambda x: (x.split(','))
 
@@ -94,6 +96,12 @@ def convert_to_ascii(value):
         return value.encode("ascii", "ignore").decode('ascii')
     except Exception as err:
         return value
+
+
+def convert_to_utc_date_time(date_time_str: str):
+    """Convert datetime string with utc offset to datetime object"""
+    date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S%z')
+    return date_time_obj.astimezone(UTC)
 
 
 # def remove_numbers_list(list_name):

--- a/api/namex/utils/common.py
+++ b/api/namex/utils/common.py
@@ -1,7 +1,8 @@
 import re
 import inflect
 from itertools import product
-import datetime
+from datetime import  datetime, time
+from dateutil import tz
 from pytz import UTC
 
 _parse_csv_line = lambda x: (x.split(','))
@@ -98,10 +99,22 @@ def convert_to_ascii(value):
         return value
 
 
-def convert_to_utc_date_time(date_time_str: str):
-    """Convert datetime string with utc offset to datetime object"""
-    date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S%z')
-    return date_time_obj.astimezone(UTC)
+def convert_to_utc_min_date_time(date_str: str):
+    date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+    min_time = time(hour=0, minute=0, second=0, microsecond=0)
+    return datetime.combine(date_obj, min_time, tzinfo=tz.UTC)
+
+
+def convert_to_utc_max_date_time(date_str: str):
+    date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+    max_time = time(hour=23, minute=59, second=59, microsecond=999999)
+    return datetime.combine(date_obj, max_time, tzinfo=tz.UTC)
+
+
+# def convert_to_utc_date_time(date_time_str: str):
+#     """Convert datetime string with utc offset to datetime object"""
+#     date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S%z')
+#     return date_time_obj.astimezone(UTC)
 
 
 # def remove_numbers_list(list_name):

--- a/api/tests/python/end_points/common/utils.py
+++ b/api/tests/python/end_points/common/utils.py
@@ -1,56 +1,29 @@
-from datetime import datetime, time
+from datetime import datetime
 from dateutil import tz
-import urllib.parse
+
+def get_server_now():
+    return datetime.now()
 
 
-def get_utc_now():
-    return datetime.now(tz=tz.UTC)
-
-
-def get_utc_now_str():
-    utc_now = get_utc_now()
-    return convert_to_utc_date_time_str(utc_now)
-
-
-def get_utc_now_min_time_str():
-    utc_now = get_utc_now()
-    min_time = time(hour=0, minute=0, second=0, microsecond=0)
-    result = datetime.combine(utc_now.date(), min_time, tzinfo=tz.UTC)
-    return convert_to_utc_date_time_str(result)
-
-def get_utc_now_max_time_str():
-    utc_now = get_utc_now()
-    max_time = time(hour=23, minute=59, second=59, microsecond=999999)
-    result = datetime.combine(utc_now.date(), max_time, tzinfo=tz.UTC)
-    return convert_to_utc_date_time_str(result)
-
-def get_utc_now_with_delta(timedelta):
-    utc_date_time = get_utc_now()
-    return utc_date_time + timedelta
-
-
-def get_utc_now_with_delta_str(delta):
-    utc_date_time = get_utc_now_with_delta(delta)
-    return convert_to_utc_date_time_str(utc_date_time)
-
-
-def get_utc_now_with_min_delta_str(delta):
-    utc_date_time = get_utc_now_with_delta(delta)
-    min_time = time(hour=0, minute=0, second=0, microsecond=0)
-    result = datetime.combine(utc_date_time.date(), min_time, tzinfo=tz.UTC)
-    return convert_to_utc_date_time_str(result)
-
-def get_utc_now_with_max_delta_str(delta):
-    utc_date_time = get_utc_now_with_delta(delta)
-    max_time = time(hour=23, minute=59, second=59, microsecond=999999)
-    result = datetime.combine(utc_date_time.date(), max_time, tzinfo=tz.UTC)
-    return convert_to_utc_date_time_str(result)
-
-def convert_to_utc_date_time_str(date_time_obj: datetime):
-    result = date_time_obj.strftime('%Y-%m-%d %H:%M:%S%z')
-    result = urllib.parse.quote(result)
+def get_server_now_str():
+    result = datetime.now().strftime('%Y-%m-%d')
     return result
 
 
-def escape_date_time(utc_date_time: str):
-    return urllib.parse.quote(utc_date_time)
+def get_utc_server_now_with_delta(timedelta):
+    server_now = get_server_now() + timedelta
+    result = server_now.astimezone(tz.UTC)
+    return result
+
+
+def get_utc_server_now_with_delta_str(timedelta):
+    utc_server_now_with_delta = get_utc_server_now_with_delta(timedelta)
+    result = utc_server_now_with_delta.strftime('%Y-%m-%d')
+    return result
+
+
+def get_utc_server_now():
+    server_now = get_server_now()
+    result = server_now.astimezone(tz.UTC)
+    return result
+

--- a/api/tests/python/end_points/common/utils.py
+++ b/api/tests/python/end_points/common/utils.py
@@ -1,0 +1,56 @@
+from datetime import datetime, time
+from dateutil import tz
+import urllib.parse
+
+
+def get_utc_now():
+    return datetime.now(tz=tz.UTC)
+
+
+def get_utc_now_str():
+    utc_now = get_utc_now()
+    return convert_to_utc_date_time_str(utc_now)
+
+
+def get_utc_now_min_time_str():
+    utc_now = get_utc_now()
+    min_time = time(hour=0, minute=0, second=0, microsecond=0)
+    result = datetime.combine(utc_now.date(), min_time, tzinfo=tz.UTC)
+    return convert_to_utc_date_time_str(result)
+
+def get_utc_now_max_time_str():
+    utc_now = get_utc_now()
+    max_time = time(hour=23, minute=59, second=59, microsecond=999999)
+    result = datetime.combine(utc_now.date(), max_time, tzinfo=tz.UTC)
+    return convert_to_utc_date_time_str(result)
+
+def get_utc_now_with_delta(timedelta):
+    utc_date_time = get_utc_now()
+    return utc_date_time + timedelta
+
+
+def get_utc_now_with_delta_str(delta):
+    utc_date_time = get_utc_now_with_delta(delta)
+    return convert_to_utc_date_time_str(utc_date_time)
+
+
+def get_utc_now_with_min_delta_str(delta):
+    utc_date_time = get_utc_now_with_delta(delta)
+    min_time = time(hour=0, minute=0, second=0, microsecond=0)
+    result = datetime.combine(utc_date_time.date(), min_time, tzinfo=tz.UTC)
+    return convert_to_utc_date_time_str(result)
+
+def get_utc_now_with_max_delta_str(delta):
+    utc_date_time = get_utc_now_with_delta(delta)
+    max_time = time(hour=23, minute=59, second=59, microsecond=999999)
+    result = datetime.combine(utc_date_time.date(), max_time, tzinfo=tz.UTC)
+    return convert_to_utc_date_time_str(result)
+
+def convert_to_utc_date_time_str(date_time_obj: datetime):
+    result = date_time_obj.strftime('%Y-%m-%d %H:%M:%S%z')
+    result = urllib.parse.quote(result)
+    return result
+
+
+def escape_date_time(utc_date_time: str):
+    return urllib.parse.quote(utc_date_time)

--- a/api/tests/python/end_points/common/utils.py
+++ b/api/tests/python/end_points/common/utils.py
@@ -1,28 +1,52 @@
 from datetime import datetime
 from dateutil import tz
 
+from namex.constants import DATE_FORMAT_NAMEX_SEARCH
+
+
 def get_server_now():
-    return datetime.now()
+    """Get the server now datetime object with local timezone"""
+    return datetime.now().astimezone(tz.tzlocal())
 
 
 def get_server_now_str():
-    result = datetime.now().strftime('%Y-%m-%d')
+    """Get the server now date as a string"""
+    server_now = get_server_now()
+    result = server_now.strftime(DATE_FORMAT_NAMEX_SEARCH)
     return result
 
 
-def get_utc_server_now_with_delta(timedelta):
-    server_now = get_server_now() + timedelta
+def get_server_now_with_delta(time_delta):
+    """Get the server now datetime object with delta and local timezone"""
+    server_now = get_server_now()
+    result = server_now + time_delta
+    return result
+
+
+def get_server_now_with_delta_str(timedelta):
+    """Get the server now date string with delta"""
+    server_now_with_delta = get_server_now_with_delta(timedelta)
+    result = server_now_with_delta.strftime(DATE_FORMAT_NAMEX_SEARCH)
+    return result
+
+
+def get_utc_server_now_with_delta(time_delta):
+    """Get the server now datetime object with delta as a UTC datetime"""
+    server_now = get_server_now()
+    server_now = server_now + time_delta
     result = server_now.astimezone(tz.UTC)
     return result
 
 
-def get_utc_server_now_with_delta_str(timedelta):
-    utc_server_now_with_delta = get_utc_server_now_with_delta(timedelta)
-    result = utc_server_now_with_delta.strftime('%Y-%m-%d')
+def get_utc_server_now_with_delta_str(time_delta):
+    """Get the server now datetime object with delta as a UTC datetime string"""
+    utc_server_now_with_delta = get_utc_server_now_with_delta(time_delta)
+    result = utc_server_now_with_delta.strftime(DATE_FORMAT_NAMEX_SEARCH)
     return result
 
 
 def get_utc_server_now():
+    """Get the server now datetime object as a UTC datetime"""
     server_now = get_server_now()
     result = server_now.astimezone(tz.UTC)
     return result

--- a/api/tests/python/end_points/test_namex_search.py
+++ b/api/tests/python/end_points/test_namex_search.py
@@ -10,8 +10,8 @@ from tests.python.end_points.services.utils import create_header
 from tests.python.end_points.common.utils import (
     get_utc_server_now_with_delta,
     get_server_now_str,
-    get_utc_server_now,
-    get_utc_server_now_with_delta_str
+    get_server_now_with_delta_str,
+    get_utc_server_now
 )
 
 # TODO: import these helper functions from somewhere shared by the tests
@@ -357,14 +357,14 @@ def test_namex_search_last_name(client, jwt, app, search_name):
 
 
 @pytest.mark.parametrize('submitted_start_date, expected_result_count', [
-    (get_utc_server_now_with_delta_str(timedelta(days=-1)), 9),
-    (get_utc_server_now_with_delta_str(timedelta(days=-2)), 9),
-    (get_utc_server_now_with_delta_str(timedelta(-5*(365)+1)), 11),
-    (get_utc_server_now_with_delta_str(timedelta(-5*(365))), 12),
+    (get_server_now_with_delta_str(timedelta(days=-1)), 9),
+    (get_server_now_with_delta_str(timedelta(days=-2)), 9),
+    (get_server_now_with_delta_str(timedelta(-5*(365)+1)), 11),
+    (get_server_now_with_delta_str(timedelta(-5*(365))), 12),
     (get_server_now_str(), 6),
-    (get_utc_server_now_with_delta_str(timedelta(days=1)), 4),
-    (get_utc_server_now_with_delta_str(timedelta(days=5*(365))), 1),
-    (get_utc_server_now_with_delta_str(timedelta(days=5*(365)+1)), 0),
+    (get_server_now_with_delta_str(timedelta(days=1)), 4),
+    (get_server_now_with_delta_str(timedelta(days=5*(365))), 1),
+    (get_server_now_with_delta_str(timedelta(days=5*(365)+1)), 0),
 ])
 def test_namex_search_submitted_start_date(client, jwt, app, submitted_start_date, expected_result_count):
     """Test searching by submitted start date."""
@@ -401,16 +401,16 @@ def test_namex_search_submitted_start_date(client, jwt, app, submitted_start_dat
 
 
 @pytest.mark.parametrize('submitted_end_date, expected_result_count', [
-    (get_utc_server_now_with_delta_str(timedelta(-5*(365)-1)), 0),
-    (get_utc_server_now_with_delta_str(timedelta(-5*(365))), 1),
-    (get_utc_server_now_with_delta_str(timedelta(days=-105)), 2),
-    (get_utc_server_now_with_delta_str(timedelta(days=-1)), 6),
+    (get_server_now_with_delta_str(timedelta(-5*(365)-1)), 0),
+    (get_server_now_with_delta_str(timedelta(-5*(365))), 1),
+    (get_server_now_with_delta_str(timedelta(days=-105)), 2),
+    (get_server_now_with_delta_str(timedelta(days=-1)), 6),
     (get_server_now_str(), 8),
-    (get_utc_server_now_with_delta_str(timedelta(days=1)), 9),
-    (get_utc_server_now_with_delta_str(timedelta(days=1*(365))), 11),
-    (get_utc_server_now_with_delta_str(timedelta(days=5*(365)-1)), 11),
-    (get_utc_server_now_with_delta_str(timedelta(days=5*(365))), 12),
-    (get_utc_server_now_with_delta_str(timedelta(days=6*(365))), 12),
+    (get_server_now_with_delta_str(timedelta(days=1)), 9),
+    (get_server_now_with_delta_str(timedelta(days=1*(365))), 11),
+    (get_server_now_with_delta_str(timedelta(days=5*(365)-1)), 11),
+    (get_server_now_with_delta_str(timedelta(days=5*(365))), 12),
+    (get_server_now_with_delta_str(timedelta(days=6*(365))), 12),
 ])
 def test_namex_search_submitted_end_date(client, jwt, app, submitted_end_date, expected_result_count):
     """Test searching by submitted end date."""
@@ -446,52 +446,49 @@ def test_namex_search_submitted_end_date(client, jwt, app, submitted_end_date, e
     assert response_count == expected_result_count
 
 
-# @pytest.mark.parametrize('submitted_start_date, submitted_end_date, expected_result_count', [
-#     (get_utc_server_now_with_delta_str(timedelta(days=-5*(365))), get_utc_server_now_with_delta_str(timedelta(days=-5*(365))), 0),
-#     # (get_utc_server_now_with_delta_str(timedelta(days=-5*(365))), get_utc_server_now_with_delta_str(timedelta(days=-100), 12),
-#
-#
-#
-#     # (get_utc_server_now_with_delta_str(timedelta(days=-2)), 9),
-#     # (get_utc_server_now_with_delta_str(timedelta(-5*(365)+1)), 11),
-#     # (get_utc_server_now_with_delta_str(timedelta(-5*(365))), 12),
-#     # (get_server_now_str(), 6),
-#     # (get_utc_server_now_with_delta_str(timedelta(days=1)), 4),
-#     # (get_utc_server_now_with_delta_str(timedelta(days=5*(365))), 1),
-#     # (get_utc_server_now_with_delta_str(timedelta(days=5*(365)+1)), 0),
-# ])
-# def test_namex_search_submitted_start_and_end_date(client, jwt, app, submitted_start_date, submitted_end_date, expected_result_count):
-#     """Test searching by submitted start date."""
-#
-#     submitted = [
-#         get_utc_server_now_with_delta(timedelta(days=-5*(365))),
-#         get_utc_server_now_with_delta(timedelta(days=-1*(365))),
-#         get_utc_server_now_with_delta(timedelta(days=-100)),
-#         get_utc_server_now_with_delta(timedelta(days=-1)),
-#         get_utc_server_now_with_delta(timedelta(days=-1)),
-#         get_utc_server_now_with_delta(timedelta(days=-1)),
-#         get_utc_server_now(),
-#         get_utc_server_now(),
-#         get_utc_server_now_with_delta(timedelta(days=1)),
-#         get_utc_server_now_with_delta(timedelta(days=100)),
-#         get_utc_server_now_with_delta(timedelta(days=1*(365))),
-#         get_utc_server_now_with_delta(timedelta(days=5*(365))),
-#     ]
-#     generate_nrs(len(submitted), [], [], submitted)
-#
-#     # get the resource (this is what we are testing)
-#     rv = client.get(
-#         f'api/v1/requests?submittedStartDate={submitted_start_date}&submittedEndDateTime={submitted_end_date}&rows=1000',
-#         headers=create_header(jwt, [User.VIEWONLY])
-#     )
-#     data = rv.data
-#     assert data
-#     resp = json.loads(data.decode('utf-8'))
-#
-#     assert resp.get('nameRequests') and resp.get('response')
-#     response_count = len(resp['nameRequests'][0])
-#     assert response_count >= 0
-#     assert response_count == expected_result_count
+@pytest.mark.parametrize('submitted_start_date, submitted_end_date, expected_result_count', [
+    (get_server_now_with_delta_str(timedelta(days=-5*(365)-2)), get_server_now_with_delta_str(timedelta(days=-5*(365)-1)), 0),
+    (get_server_now_with_delta_str(timedelta(days=-5*(365)-2)), get_server_now_with_delta_str(timedelta(days=-5*(365))), 1),
+    (get_server_now_with_delta_str(timedelta(days=-5*(365))), get_server_now_with_delta_str(timedelta(days=-100)), 3),
+    (get_server_now_with_delta_str(timedelta(days=-5*(365))), get_server_now_str(), 8),
+    (get_server_now_with_delta_str(timedelta(days=-5*(365))), get_server_now_with_delta_str(timedelta(days=1*(365))), 11),
+    (get_server_now_with_delta_str(timedelta(days=-5*(365))), get_server_now_with_delta_str(timedelta(days=5*(365))), 12),
+    (get_server_now_with_delta_str(timedelta(days=-5*(365))), get_server_now_with_delta_str(timedelta(days=6*(365))), 12),
+    (get_server_now_with_delta_str(timedelta(days=-1)), get_server_now_with_delta_str(timedelta(days=100)), 7),
+    (get_server_now_str(), get_server_now_str(), 2),
+])
+def test_namex_search_submitted_start_and_end_date(client, jwt, app, submitted_start_date, submitted_end_date, expected_result_count):
+    """Test searching by submitted start date and submitted end date."""
+
+    submitted = [
+        get_utc_server_now_with_delta(timedelta(days=-5*(365))),
+        get_utc_server_now_with_delta(timedelta(days=-1*(365))),
+        get_utc_server_now_with_delta(timedelta(days=-100)),
+        get_utc_server_now_with_delta(timedelta(days=-1)),
+        get_utc_server_now_with_delta(timedelta(days=-1)),
+        get_utc_server_now_with_delta(timedelta(days=-1)),
+        get_utc_server_now(),
+        get_utc_server_now(),
+        get_utc_server_now_with_delta(timedelta(days=1)),
+        get_utc_server_now_with_delta(timedelta(days=100)),
+        get_utc_server_now_with_delta(timedelta(days=1*(365))),
+        get_utc_server_now_with_delta(timedelta(days=5*(365))),
+    ]
+    generate_nrs(len(submitted), [], [], submitted)
+
+    # get the resource (this is what we are testing)
+    rv = client.get(
+        f'api/v1/requests?submittedStartDate={submitted_start_date}&submittedEndDate={submitted_end_date}&rows=1000',
+        headers=create_header(jwt, [User.VIEWONLY])
+    )
+    data = rv.data
+    assert data
+    resp = json.loads(data.decode('utf-8'))
+
+    assert resp.get('nameRequests') and resp.get('response')
+    response_count = len(resp['nameRequests'][0])
+    assert response_count >= 0
+    assert response_count == expected_result_count
 
 
 

--- a/api/tests/python/end_points/test_namex_search.py
+++ b/api/tests/python/end_points/test_namex_search.py
@@ -7,8 +7,21 @@ from typing import List
 
 from namex.models import Applicant, Name, Request, State, User
 from tests.python.end_points.services.utils import create_header
+from tests.python.end_points.common.utils import (
+    get_utc_now,
+    get_utc_now_str,
+    get_utc_now_min_time_str,
+    get_utc_now_with_delta,
+    get_utc_now_with_delta_str,
+    get_utc_now_with_min_delta_str,
+    get_utc_now_max_time_str,
+    get_utc_now_with_max_delta_str,
+    escape_date_time
+)
 
 # TODO: import these helper functions from somewhere shared by the tests
+
+
 def create_applicant(first_name: str, last_name: str) -> Applicant:
     """Create new applicant."""
     applicant = Applicant(
@@ -346,3 +359,204 @@ def test_namex_search_last_name(client, jwt, app, search_name):
     # check it returned NRs based on filter
     for nr in resp['nameRequests'][0]:
         assert search_name in nr['applicants'][0]['lastName']
+
+
+@pytest.mark.parametrize('submitted_start_date_time, expected_result_count', [
+    (get_utc_now_min_time_str(), 7),
+    (get_utc_now_with_min_delta_str(timedelta(days=-2)), 10),
+    (get_utc_now_with_min_delta_str(timedelta(days=-32)), 12),
+    (get_utc_now_with_min_delta_str(timedelta(days=-6*(365))), 15),
+    (get_utc_now_with_min_delta_str(timedelta(days=1)), 5),
+    (get_utc_now_with_min_delta_str(timedelta(days=20)), 4),
+    (get_utc_now_with_min_delta_str(timedelta(days=101)), 2),
+    (get_utc_now_with_min_delta_str(timedelta(days=5*(365))), 1),
+    (get_utc_now_with_min_delta_str(timedelta(days=5*(365)+1)), 0),
+    (get_utc_now_with_min_delta_str(timedelta(days=6*(365))), 0)
+])
+def test_namex_search_submitted_start_date_time(client, jwt, app, submitted_start_date_time, expected_result_count):
+    """Test searching by submitted start date."""
+
+    submitted = [
+        get_utc_now_with_delta(timedelta(days=-5*(365))),
+        get_utc_now_with_delta(timedelta(days=-1*(365))),
+        get_utc_now_with_delta(timedelta(days=-100)),
+        get_utc_now_with_delta(timedelta(days=-31)),
+        get_utc_now_with_delta(timedelta(days=-15)),
+        get_utc_now_with_delta(timedelta(days=-1)),
+        get_utc_now_with_delta(timedelta(days=-1)),
+        get_utc_now_with_delta(timedelta(days=-1)),
+        get_utc_now(),
+        get_utc_now(),
+        get_utc_now_with_delta(timedelta(days=1)),
+        get_utc_now_with_delta(timedelta(days=31)),
+        get_utc_now_with_delta(timedelta(days=100)),
+        get_utc_now_with_delta(timedelta(days=1*(365))),
+        get_utc_now_with_delta(timedelta(days=5*(365))),
+    ]
+    generate_nrs(len(submitted), [], [], submitted)
+
+    # get the resource (this is what we are testing)
+    rv = client.get(
+        f'api/v1/requests?submittedStartDateTime={submitted_start_date_time}&rows=1000',
+        headers=create_header(jwt, [User.VIEWONLY])
+    )
+    data = rv.data
+    assert data
+    resp = json.loads(data.decode('utf-8'))
+
+    assert resp.get('nameRequests') and resp.get('response')
+    response_count = len(resp['nameRequests'][0])
+    assert response_count >= 0
+    assert response_count == expected_result_count
+
+
+@pytest.mark.parametrize('submitted_end_date_time, expected_result_count', [
+    (get_utc_now_with_max_delta_str(timedelta(days=-1)), 8),
+    (get_utc_now_with_max_delta_str(timedelta(days=-32)), 3),
+    (get_utc_now_with_max_delta_str(timedelta(-5*(365))), 1),
+    (get_utc_now_with_min_delta_str(timedelta(-5*(365))), 0),
+    (get_utc_now_with_max_delta_str(timedelta(-6*(365))), 0),
+    (get_utc_now_min_time_str(), 8),
+    (get_utc_now_max_time_str(), 10),
+    (get_utc_now_with_max_delta_str(timedelta(days=1)), 11),
+    (get_utc_now_with_max_delta_str(timedelta(days=100)), 13),
+    (get_utc_now_with_max_delta_str(timedelta(days=5*(365)+1)), 15),
+    (get_utc_now_with_max_delta_str(timedelta(days=6*(365))), 15),
+])
+def test_namex_search_submitted_end_date_time(client, jwt, app, submitted_end_date_time, expected_result_count):
+    """Test searching by submitted end date."""
+
+    submitted = [
+        get_utc_now_with_delta(timedelta(days=-5*(365))),
+        get_utc_now_with_delta(timedelta(days=-1*(365))),
+        get_utc_now_with_delta(timedelta(days=-100)),
+        get_utc_now_with_delta(timedelta(days=-31)),
+        get_utc_now_with_delta(timedelta(days=-15)),
+        get_utc_now_with_delta(timedelta(days=-1)),
+        get_utc_now_with_delta(timedelta(days=-1)),
+        get_utc_now_with_delta(timedelta(days=-1)),
+        get_utc_now(),
+        get_utc_now(),
+        get_utc_now_with_delta(timedelta(days=1)),
+        get_utc_now_with_delta(timedelta(days=31)),
+        get_utc_now_with_delta(timedelta(days=100)),
+        get_utc_now_with_delta(timedelta(days=1*(365))),
+        get_utc_now_with_delta(timedelta(days=5*(365))),
+    ]
+    generate_nrs(len(submitted), [], [], submitted)
+
+    # get the resource (this is what we are testing)
+    rv = client.get(
+        f'api/v1/requests?submittedEndDateTime={submitted_end_date_time}&rows=1000',
+        headers=create_header(jwt, [User.VIEWONLY])
+    )
+    data = rv.data
+    assert data
+    resp = json.loads(data.decode('utf-8'))
+
+    assert resp.get('nameRequests') and resp.get('response')
+    response_count = len(resp['nameRequests'][0])
+    assert response_count >= 0
+    assert response_count == expected_result_count
+
+# todo add test for submitted start and end date time
+
+@pytest.mark.parametrize('submitted_start_date_time, submitted_end_date_time', [
+    (escape_date_time('2021-05-11 00:00:00-07:00'), escape_date_time('2021-05-01 23:59:59-07:00')),
+    (get_utc_now_str(), get_utc_now_with_delta_str(timedelta(days=-29))),
+    (get_utc_now_str(), get_utc_now_with_delta_str(timedelta(days=-55)))
+])
+def test_namex_search_submitted_end_date_before_submitted_start_date(client,
+                                                                     jwt,
+                                                                     app,
+                                                                     submitted_start_date_time,
+                                                                     submitted_end_date_time):
+    """Test searching by submitted end date before submitted start date."""
+
+    # get the resource (this is what we are testing)
+    rv = client.get(
+        f'api/v1/requests?submittedStartDateTime={submitted_start_date_time}&submittedEndDateTime={submitted_end_date_time}',
+        headers=create_header(jwt, [User.VIEWONLY])
+    )
+
+    assert rv
+    assert rv.status_code
+    assert rv.status_code == 400
+    assert rv.data
+    resp = json.loads(rv.data.decode('utf-8'))
+    assert resp.get('message')
+    assert resp.get('message') == 'submittedEndDateTime must be after submittedStartDateTime'
+
+
+@pytest.mark.parametrize('submitted_interval, submitted_start_date_time, submitted_end_date_time', [
+    ('Today', get_utc_now_str(), get_utc_now_str()),
+    ('7 days', get_utc_now_str(), get_utc_now_str()),
+    ('90 days', get_utc_now_str(), ''),
+    ('1 year', '', get_utc_now_str()),
+])
+def test_namex_search_submitted_interval_with_submitted_start_and_end_date(client,
+                                                                     jwt,
+                                                                     app,
+                                                                     submitted_interval,
+                                                                     submitted_start_date_time,
+                                                                     submitted_end_date_time):
+    """Test searching by submitted interval with submitted start and end date."""
+
+    # get the resource (this is what we are testing)
+    rv = client.get(
+        f'api/v1/requests?submittedInterval={submitted_interval}&submittedStartDateTime={submitted_start_date_time}&submittedEndDateTime={submitted_end_date_time}',
+        headers=create_header(jwt, [User.VIEWONLY])
+    )
+
+    assert rv
+    assert rv.status_code
+    assert rv.status_code == 400
+    assert rv.data
+    resp = json.loads(rv.data.decode('utf-8'))
+    assert resp.get('message')
+    assert 'submittedInterval cannot be used in conjuction with submittedStartDateTime and submittedEndDateTime' in resp.get('message')
+
+
+@pytest.mark.parametrize('submitted_start_date_time, submitted_end_date_time, valid_start_date, valid_end_date', [
+    ('11-05-2021', escape_date_time('2021-02-03 23:59:59+02:00'), False, True),
+    ('2021-12-01a', escape_date_time('2001-08-22 23:59:59-05:00'), False, True),
+    ('asdfdsf0sadfsf', escape_date_time('2001-07-11 23:59:59-07:00'), False, True),
+    (escape_date_time('2021-05-02a 00:00:00-07:00'), escape_date_time('2021-05-11 23:59:59-07:00'), False, True),
+    (escape_date_time('2021-05-02 00:00:00-07:00'), '20211-05-010', True, False),
+    (escape_date_time('2005-01-12 00:23:00-05:00'), '2021-05-01', True, False),
+    (escape_date_time('2005-01-12 00:23:00-05:00'), escape_date_time('2005-01-12 00:23:00-05:002'), True, False),
+    (escape_date_time('2005-01-12 00:23:00-05:00'), 'asdfsdfdsf', True, False),
+    (escape_date_time('2005-01-12 a00:23:00-05:00'), escape_date_time('a2021-05-11 23:59:59-07:00'), False, False),
+    ('asdfsdf', 'badfasdfsdf', False, False),
+    ('02-23-2005', '07-11-2006', False, False),
+    ('2005-02-23', '2006-07-11', False, False),
+])
+def test_namex_search_submitted_start_and_end_date_invalid_date_format(client,
+                                                                       jwt,
+                                                                       app,
+                                                                       submitted_start_date_time,
+                                                                       submitted_end_date_time,
+                                                                       valid_start_date,
+                                                                       valid_end_date):
+    """Test searching by submitted start and end date with incorrect date formats."""
+
+    # get the resource (this is what we are testing)
+    rv = client.get(
+        f'api/v1/requests?submittedStartDateTime={submitted_start_date_time}&submittedEndDateTime={submitted_end_date_time}',
+        headers=create_header(jwt, [User.VIEWONLY])
+    )
+
+    assert rv
+    assert rv.status_code
+    assert rv.status_code == 400
+    assert rv.data
+    resp = json.loads(rv.data.decode('utf-8'))
+    msg = resp.get('message')
+    assert msg
+
+    if not valid_start_date:
+        assert 'Invalid submittedStartDateTime: ' in msg
+        assert 'Must be of date format %Y-%m-%d %H:%M:%S%z' in msg
+    elif(valid_start_date and not valid_end_date):
+        assert 'Invalid submittedEndDateTime: ' in msg
+        assert 'Must be of date format %Y-%m-%d %H:%M:%S%z' in msg


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7433

*Description of changes:

* Added `submittedStartDate` and `submittedEndDate` search filters to `.../api/v1/requests` url.  
* Added test for `submittedStartDate` and `submittedEndDate` search filters
* Added files to ignore in `.gitignore`
* Added endpoint testing related utility functions under endpoint tests folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
