### PR TITLE
7812, 7818 skip refund for routingSlip and waiveFee, remove staff auth header if no option provided

### DIFF
--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -323,6 +323,10 @@ class CreateNameRequestPayment(AbstractNameRequestResource):
                 if 'waiveFees' in headers:
                     del headers['waiveFees']
 
+                # This is to support staff-payment-enabled switch to false in Launch Darkly
+                if not account_info:
+                    headers = {}
+
             # Create our payment request
             req = PaymentRequest(
                 paymentInfo=payment_info,


### PR DESCRIPTION
*Issue*:
bcgov/entity#7812
bcgov/entity#7818

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
