### PR TITLE
Fix issue with serializing new details field in payment service response 

### DIFF
--- a/api/namex/services/payment/models/__init__.py
+++ b/api/namex/services/payment/models/__init__.py
@@ -109,6 +109,7 @@ class PaymentInvoice(Serializable):
     lineItems: list = field(default_factory=list)
     receipts: list = field(default_factory=list)
     references: list = field(default_factory=list)
+    details: list = field(default_factory=list)
     _links: list = field(default_factory=list)
 
 


### PR DESCRIPTION


*Description of changes:*

* Added `details` field to `PaymentInvoice` class

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
