### PR TITLE
6033 allow system user to patch nr, required to consume nr from entity-filer

### DIFF
--- a/api/namex/models/user.py
+++ b/api/namex/models/user.py
@@ -21,6 +21,7 @@ class User(db.Model):
         default='Status,LastModifiedBy,NameRequestNumber,Names,ApplicantFirstName,ApplicantLastName,NatureOfBusiness,ConsentRequired,Priority,ClientNotification,Submitted,LastUpdate,LastComment'
     )
 
+    SYSTEM = 'system'
     STAFF = 'staff'
     APPROVER = 'names_approver'
     EDITOR = 'names_editor'

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -403,7 +403,7 @@ class Request(Resource):
 
     @staticmethod
     @cors.crossdomain(origin='*')
-    @jwt.has_one_of_roles([User.APPROVER, User.EDITOR])
+    @jwt.has_one_of_roles([User.APPROVER, User.EDITOR, User.SYSTEM])
     def patch(nr, *args, **kwargs):
         """  Patches the NR. Currently only handles STATE (with optional comment) and Previous State.
 


### PR DESCRIPTION
*Issue* bcgov/entity#6033

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
