### PR TITLE
fixed schema, removed check from namex edit

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -692,7 +692,7 @@ class RequestsHeaderSchema(ma.SQLAlchemySchema):
     nroLastUpdate = fields.Field(allow_none=True)
     nwpta = fields.Field(allow_none=True)
     previousNr = fields.String(allow_none=True)
-    previousRequestId = fields.String(allow_none=True)
+    previousRequestId = fields.Integer(allow_none=True)
     previousStateCd = fields.String(allow_none=True)
     priorityCd = fields.String(allow_none=True)
     priorityDate = fields.Field(allow_none=True)

--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -644,11 +644,6 @@ class Request(Resource):
 
             # update request header
 
-            errors = request_header_schema.validate(json_input, partial=True)
-            if errors:
-                # return jsonify(errors), 400
-                MessageServices.add_message(MessageServices.ERROR, 'request_validation', errors)
-
             # if reset is set to true then this nr will be set to H + name_examination proc will be called in oracle
             reset = False
             if nrd.furnished == RequestDAO.REQUEST_FURNISHED and json_input.get('furnished', None) == 'N':


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #, if available:*

*Description of changes:*
previousRequestId comes in as an integer so schema check was failing on edit
- changed schema value to int
- removed schema check from edit since we are trying to move away from ma and there could be other edge cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
