### PR TITLE
Fixing issue with NR invoice creation failure, when folioNumber is empty string

### DIFF
--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -303,9 +303,8 @@ class CreateNameRequestPayment(AbstractNameRequestResource):
             auth = headers.get('Authorization')
             account_info = {}
 
-            if folio_number := headers.get('folioNumber'):
+            if folio_number := headers.pop('folioNumber', None):
                 filing_info['folioNumber'] = folio_number
-                del headers['folioNumber']
 
             if auth and validate_roles(jwt, auth, [User.STAFF]):
                 if routing_slip_number := headers.get('routingSlipNumber'):

--- a/api/namex/services/payment/client/__init__.py
+++ b/api/namex/services/payment/client/__init__.py
@@ -194,7 +194,7 @@ class BaseClient:
         try:
             if method not in HttpVerbs:
                 raise ApiClientError(message=MSG_INVALID_HTTP_VERB)
-            if not headers:
+            if not headers or 'Authorization' not in headers:
                 authenticated, token = self.get_client_credentials(PAYMENT_SVC_AUTH_URL, PAYMENT_SVC_AUTH_CLIENT_ID, PAYMENT_SVC_CLIENT_SECRET)
                 if not authenticated:
                     raise ApiAuthError(token, message=MSG_CLIENT_CREDENTIALS_REQ_FAILED)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- When folioNumber is coming as empty string, it doesn't get removed from headers. This causes NR code to not creating a service account token which in turn causes 401 for payment calls.
-  https://github.com/bcgov/namex/blob/main/api/namex/resources/payment/payment.py#L306 : If value is empty string; doesn't reach the if section and headers doesn't get deleted.
- https://github.com/bcgov/namex/blob/main/api/namex/services/payment/client/__init__.py#L197 : Since the headers is not empty, it doesn't create a service account token.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
