### PR TITLE
6968 Update wait time calculation logic to mirror NRO

### DIFF
--- a/api/namex/services/statistics/__init__.py
+++ b/api/namex/services/statistics/__init__.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from namex.constants import AbstractEnum
 
 response_keys = ['auto_approved_count', 'priority_wait_time', 'regular_wait_time']
@@ -7,3 +9,7 @@ class UnitTime(AbstractEnum):
     DAY = 'days'
     HR = 'hours'
     MIN = 'minutes'
+
+# this is a separate function to make it easier to mock datetime.utcnow() for testing purposes
+def get_utc_now():
+    return datetime.utcnow()

--- a/api/tests/python/end_points/common/utils.py
+++ b/api/tests/python/end_points/common/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, time
 from dateutil import tz
 
 from namex.constants import DATE_FORMAT_NAMEX_SEARCH
@@ -51,3 +51,18 @@ def get_utc_server_now():
     result = server_now.astimezone(tz.UTC)
     return result
 
+
+def create_utc_min_date_time(date_str: str):
+    """Create UTC datetime with min time from provided date string."""
+    utc_date_time = datetime.strptime(date_str, DATE_FORMAT_NAMEX_SEARCH)
+    min_time = time(hour=0, minute=0, second=0, microsecond=0)
+    utc_date_time = datetime.combine(utc_date_time, min_time, tzinfo=tz.UTC)
+    return utc_date_time
+
+
+def create_utc_date_time(date_str: str, hour: int, minute: int, second: int, microsecond: int):
+    """Create UTC datetime with date and time from provided input params."""
+    utc_date_time = datetime.strptime(date_str, DATE_FORMAT_NAMEX_SEARCH)
+    time_part = time(hour=hour, minute=minute, second=second, microsecond=microsecond)
+    utc_date_time = datetime.combine(utc_date_time, time_part, tzinfo=tz.UTC)
+    return utc_date_time

--- a/api/tests/python/end_points/statistics/common.py
+++ b/api/tests/python/end_points/statistics/common.py
@@ -80,3 +80,20 @@ def save_approved_names_by_examiner(approved_number_records):
         event.eventDate = datetime.date.today() - datetime.timedelta(days=1)
         nr.events = [event]
         nr.save_to_db()
+
+
+def save_name(submitted_date, nr_num, priority=False):
+    from namex.models import Request as RequestDAO, State
+    num = 0
+    global num_records
+
+    nr_num_label = 'NR '
+    nr_num = nr_num_label + str(nr_num)
+
+    nr = RequestDAO()
+    nr.nrNum = nr_num
+    nr.stateCd = State.DRAFT
+    nr.priorityCd = 'Y' if priority else 'N'
+    nr._source = 'NAMEREQUEST'
+    nr.submittedDate = submitted_date
+    nr.save_to_db()

--- a/api/tests/python/end_points/statistics/test_statistics.py
+++ b/api/tests/python/end_points/statistics/test_statistics.py
@@ -1,7 +1,14 @@
 import json
-from .common import API_BASE_URI, save_names_queue, save_auto_approved_names, save_approved_names_by_examiner
-from ..common.http import build_request_uri
+
+import pytest
+from unittest.mock import patch
+
+from .common import API_BASE_URI, save_names_queue, save_name, save_auto_approved_names, save_approved_names_by_examiner
 from ..common.logging import log_request_path
+
+from namex.services.statistics import wait_time_statistics
+from namex.services.cache import cache
+from tests.python.end_points.common.utils import create_utc_min_date_time, create_utc_date_time
 
 
 def test_get_statistics(client, jwt, app):
@@ -19,3 +26,39 @@ def test_get_statistics(client, jwt, app):
     assert isinstance(payload.get('auto_approved_count'), int) is True
     assert isinstance(payload.get('priority_wait_time'), int) is True
     assert isinstance(payload.get('regular_wait_time'), int) is True
+
+
+
+
+@pytest.mark.parametrize('oldest_draft_nr_date, todays_date, expected_wait_days', [
+    ('2021-07-03', '2021-07-04', 1)
+    ,('2021-07-02', '2021-07-05', 2)
+    ,('2021-05-30', '2021-07-10', 30)
+    ,('2021-06-28', '2021-07-02', 5)
+    ,('2021-07-01', '2021-07-08', 6)
+    ,('2021-05-02', '2021-05-23', 15)
+    ,('2020-01-01', '2021-07-10', 398)
+])
+def test_get_statistics_wait_time(client, jwt, app, oldest_draft_nr_date, todays_date, expected_wait_days):
+    """Assert that wait time statistics are being generated correctly."""
+    request_uri = API_BASE_URI
+    # create some NR data to simulate real scenario
+    save_auto_approved_names(1000)
+    save_approved_names_by_examiner(150)
+    save_names_queue(20)
+    save_names_queue(80, True)
+
+    oldest_draft_nr_dt = create_utc_min_date_time(oldest_draft_nr_date)
+    # save the oldest unexamined NR to db
+    save_name(oldest_draft_nr_dt, 1111111, False)
+    todays_dt = create_utc_date_time(todays_date, 12, 30, 59, 999999)
+
+    # need to clear cache on statistics resource to test different test param values
+    cache.clear()
+
+    # mock out get_utc_now function in wait_time_statistics to simulate today's date
+    with patch.object(wait_time_statistics, 'get_utc_now', return_value=todays_dt):
+        response = client.get(request_uri)
+        payload = json.loads(response.data)
+        assert payload
+        assert payload['regular_wait_time'] == expected_wait_days


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6968

*Description of changes:*

* Update wait time calculation logic in `statistics` endpoint to mirror NRO logic which is to use the oldest unexamined NR minus weekends

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
