### PR TITLE
deleted duplicate pylint

### DIFF
--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -36,7 +36,7 @@ notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
 min-similarity-lines=100
-disable=W0511
+disable=C0103,C0301,W0511,W0703,R0801,R0902,R0401,R1718
 
 [isort]
 line_length = 120
@@ -44,15 +44,6 @@ indent = 4
 multi_line_output = 3
 lines_after_imports = 2
 include_trailing_comma = True
-
-
-[pylint]
-ignore=migrations,test
-max_line_length=120
-notes=FIXME,XXX,TODO
-ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
-ignored-classes=scoped_session
-disable=C0103,C0301,W0511,W0703,R0801,R0902,R0401,R1718
 
 [aliases]
 test=pytest


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #, if available:* N/A

*Description of changes:*
duplicate pylint in setup was causing make cmd errs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
