### PR TITLE
7388 new valult `nr-day-job` instead of using nats-emailer

### DIFF
--- a/jobs/nr-day-job/devops/vaults.json
+++ b/jobs/nr-day-job/devops/vaults.json
@@ -2,14 +2,14 @@
     {
         "vault": "nats",
         "application": [
-            "base",
-            "nats-emailer"
+            "base"
         ]
     },
     {
         "vault": "namex",
         "application": [
-            "postgres-namex"
+            "postgres-namex",
+            "nr-day-job"
         ]
     }
 ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
