### PR TITLE
8488- Updates for new NATS messages and Resubmit payment action

### DIFF
--- a/api/namex/services/queue.py
+++ b/api/namex/services/queue.py
@@ -105,6 +105,7 @@ class QueueService():
                 # Update the client_id if nats is reconnecting
                 self.stan_options['client_id'] = self.get_client_id()
                 await ctx.stan.connect(**self.stan_options)
+                self.logger.warning('NATS has been connected with STAN client_id: %s', self.stan_options['client_id'])
 
     def get_client_id(self):
         return (self.name.lower().strip(string.whitespace)).translate(

--- a/services/namex-pay/config.py
+++ b/services/namex-pay/config.py
@@ -160,13 +160,6 @@ class TestConfig(Config):
     DISABLE_NAMEREQUEST_SOLR_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_SOLR_UPDATES', 0))
     DISABLE_NAMEREQUEST_NATS_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NATS_UPDATES', 1))
 
-    NATS_SERVERS = os.getenv('NATS_SERVERS', 'nats://localhost:4222')
-    NATS_CLIENT_NAME = os.getenv('NATS_CLIENT_NAME', 'namex.worker')
-    NATS_CLUSTER_ID = os.getenv('NATS_CLUSTER_ID', 'test-cluster')
-    NATS_QUEUE = os.getenv('NATS_QUEUE', 'namerequest-processor')
-    NATS_NR_STATE_SUBJECT = os.getenv('NATS_NR_STATE_SUBJECT', 'namex.event')
-    NATS_EMAILER_SUBJECT = os.getenv('NATS_EMAILER_SUBJECT', 'entity.email')
-
     # JWT OIDC settings
     # JWT_OIDC_TEST_MODE will set jwt_manager to use
     JWT_OIDC_TEST_MODE = True

--- a/services/namex-pay/config.py
+++ b/services/namex-pay/config.py
@@ -88,6 +88,14 @@ class Config(object):
     # You can disable NRO updates for Name Requests by setting the variable in your .env / OpenShift configuration
     DISABLE_NAMEREQUEST_NRO_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NRO_UPDATES', 0))
     DISABLE_NAMEREQUEST_SOLR_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_SOLR_UPDATES', 0))
+    DISABLE_NAMEREQUEST_NATS_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NATS_UPDATES', 0))
+
+    NATS_SERVERS = os.getenv('NATS_SERVERS', 'nats://localhost:4222')
+    NATS_CLIENT_NAME = os.getenv('NATS_CLIENT_NAME', 'namex.worker')
+    NATS_CLUSTER_ID = os.getenv('NATS_CLUSTER_ID', 'test-cluster')
+    NATS_QUEUE = os.getenv('NATS_QUEUE', 'namerequest-processor')
+    NATS_NR_STATE_SUBJECT = os.getenv('NATS_NR_STATE_SUBJECT', 'namex.event')
+    NATS_EMAILER_SUBJECT = os.getenv('NATS_EMAILER_SUBJECT', 'entity.email')
 
     # NATS Configuration options
     NATS_CONNECTION_OPTIONS = {
@@ -122,7 +130,7 @@ class DevConfig(Config):
     # We can't run NRO locally unless you're provisioned, you can disable NRO updates for Name Requests by setting the variable in your .env
     DISABLE_NAMEREQUEST_NRO_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NRO_UPDATES', 0))
     DISABLE_NAMEREQUEST_SOLR_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_SOLR_UPDATES', 0))
-
+    DISABLE_NAMEREQUEST_NATS_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NATS_UPDATES', 0))
 
 class TestConfig(Config):
     """Test config used for pytests."""
@@ -150,6 +158,14 @@ class TestConfig(Config):
     # We can't run NRO locally for running our tests
     DISABLE_NAMEREQUEST_NRO_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NRO_UPDATES', 1))
     DISABLE_NAMEREQUEST_SOLR_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_SOLR_UPDATES', 0))
+    DISABLE_NAMEREQUEST_NATS_UPDATES = int(os.getenv('DISABLE_NAMEREQUEST_NATS_UPDATES', 1))
+
+    NATS_SERVERS = os.getenv('NATS_SERVERS', 'nats://localhost:4222')
+    NATS_CLIENT_NAME = os.getenv('NATS_CLIENT_NAME', 'namex.worker')
+    NATS_CLUSTER_ID = os.getenv('NATS_CLUSTER_ID', 'test-cluster')
+    NATS_QUEUE = os.getenv('NATS_QUEUE', 'namerequest-processor')
+    NATS_NR_STATE_SUBJECT = os.getenv('NATS_NR_STATE_SUBJECT', 'namex.event')
+    NATS_EMAILER_SUBJECT = os.getenv('NATS_EMAILER_SUBJECT', 'entity.email')
 
     # JWT OIDC settings
     # JWT_OIDC_TEST_MODE will set jwt_manager to use

--- a/services/namex-pay/requirements.txt
+++ b/services/namex-pay/requirements.txt
@@ -7,6 +7,7 @@ asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
 pycountry==20.7.3
 Werkzeug==2.0.1
+nest_asyncio
 
 git+https://github.com/bcgov/business-schemas.git#egg=registry_schemas
 git+https://github.com/bcgov/namex.git#egg=namex&subdirectory=api

--- a/services/namex-pay/src/namex_pay/config.py
+++ b/services/namex-pay/src/namex_pay/config.py
@@ -88,6 +88,13 @@ class _Config():  # pylint: disable=too-few-public-methods
     NRO_HOST = os.getenv('NRO_HOST', '')
     NRO_PORT = int(os.getenv('NRO_PORT', '1521'))
 
+    NATS_SERVERS = os.getenv('NATS_SERVERS', 'nats://localhost:4222')
+    NATS_CLIENT_NAME = os.getenv('NATS_CLIENT_NAME', 'namex.worker')
+    NATS_CLUSTER_ID = os.getenv('NATS_CLUSTER_ID', 'test-cluster')
+    NATS_QUEUE = os.getenv('NATS_QUEUE', 'namerequest-processor')
+    NATS_NR_STATE_SUBJECT = os.getenv('NATS_NR_STATE_SUBJECT', 'namex.event')
+    NATS_EMAILER_SUBJECT = os.getenv('NATS_EMAILER_SUBJECT', 'entity.email')
+
     NATS_CONNECTION_OPTIONS = {
         'servers': os.getenv('NATS_SERVERS', 'nats://127.0.0.1:4222').split(','),
         'name': os.getenv('NATS_CLIENT_NAME', 'entity.filing.worker')

--- a/services/namex-pay/src/namex_pay/worker.py
+++ b/services/namex-pay/src/namex_pay/worker.py
@@ -26,6 +26,7 @@ the model to a standalone SQLAlchemy usage with an async engine would need
 to be pursued.
 """
 import asyncio
+import nest_asyncio
 import json
 import os
 import time
@@ -270,7 +271,7 @@ FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
 queue.init_app(FLASK_APP, asyncio.new_event_loop())
-
+nest_asyncio.apply()
 
 async def cb_subscription_handler(msg: nats.aio.client.Msg):
     """Use Callback to process Queue Msg objects.

--- a/services/namex-pay/src/namex_pay/worker.py
+++ b/services/namex-pay/src/namex_pay/worker.py
@@ -36,7 +36,7 @@ import nats
 from flask import Flask
 from namex import nro
 from namex.models import db, Event, Payment, Request as RequestDAO, State, User  # noqa:I001; import orders
-from namex.services import EventRecorder
+from namex.services import EventRecorder, queue
 from queue_common.messages import create_cloud_event_msg  # noqa:I005
 from queue_common.service import QueueServiceManager
 from queue_common.service_utils import QueueException, logger
@@ -92,7 +92,7 @@ async def update_payment_record(payment: Payment) -> Optional[Payment]:
 
     payment_action = payment.payment_action
     nr = RequestDAO.find_by_id(payment.nrId)
-    if payment_action == Payment.PaymentActions.CREATE.value:  # pylint: disable=R1705
+    if payment_action in [Payment.PaymentActions.CREATE.value, Payment.PaymentActions.RESUBMIT.value]:  # pylint: disable=R1705
         if nr.stateCd == State.PENDING_PAYMENT:
             nr.stateCd = State.DRAFT
             nr.save_to_db()
@@ -266,6 +266,7 @@ APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
+queue.init_app(FLASK_APP)
 
 
 async def cb_subscription_handler(msg: nats.aio.client.Msg):

--- a/services/namex-pay/src/namex_pay/worker.py
+++ b/services/namex-pay/src/namex_pay/worker.py
@@ -93,6 +93,8 @@ async def update_payment_record(payment: Payment) -> Optional[Payment]:
 
     payment_action = payment.payment_action
     nr = RequestDAO.find_by_id(payment.nrId)
+    
+    # As RESUBMIT is a new NR it should follow the same flow as CREATE
     if payment_action in [Payment.PaymentActions.CREATE.value, Payment.PaymentActions.RESUBMIT.value]:  # pylint: disable=R1705
         if nr.stateCd == State.PENDING_PAYMENT:
             nr.stateCd = State.DRAFT

--- a/services/namex-pay/src/namex_pay/worker.py
+++ b/services/namex-pay/src/namex_pay/worker.py
@@ -25,6 +25,7 @@ Flask-SQLAlchemy currently allows the base model to be changed, or reworking
 the model to a standalone SQLAlchemy usage with an async engine would need
 to be pursued.
 """
+import asyncio
 import json
 import os
 import time
@@ -266,7 +267,7 @@ APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
-queue.init_app(FLASK_APP)
+queue.init_app(FLASK_APP, asyncio.new_event_loop())
 
 
 async def cb_subscription_handler(msg: nats.aio.client.Msg):

--- a/services/namex-pay/tests/conftest.py
+++ b/services/namex-pay/tests/conftest.py
@@ -26,6 +26,7 @@ from namex.models import db
 from nats.aio.client import Client as Nats
 from sqlalchemy import event, text
 from stan.aio.client import Client as Stan
+from namex.services import queue
 
 from . import FROZEN_DATETIME
 
@@ -62,6 +63,7 @@ def app():
     print(config)
     _app.config.from_object(get_named_config('testing'))
     db.init_app(_app)
+    queue.init_app(_app)
 
     return _app
 

--- a/services/namex-pay/tests/unit/test_worker.py
+++ b/services/namex-pay/tests/unit/test_worker.py
@@ -49,7 +49,7 @@ def test_extract_payment_token():
     'start_payment_date,end_payment_has_value,'
     'error', [
         ('draft',  # test name
-         Payment.PaymentActions.CREATE.value,  # payment action [CREATE|UPGRADE|REAPPLY]
+         Payment.PaymentActions.CREATE.value,  # payment action [CREATE|UPGRADE|REAPPLY|RESUBMIT]
          State.PENDING_PAYMENT,  # start state of NR
          State.DRAFT,           # end state of NR
          'N',  # start state of Priority
@@ -62,7 +62,7 @@ def test_extract_payment_token():
          'is not',  # end_payment_has_value
          None  # error
          ),
-        ('already draft', Payment.PaymentActions.CREATE.value, State.DRAFT, State.DRAFT, 'N', 'N', datetime.utcnow(), 0, 'COMPLETED', 'COMPLETED', None, 'is', None),
+        ('already draft', Payment.PaymentActions.CREATE.value, State.DRAFT, State.DRAFT, 'N', 'N', datetime.utcnow(), 0, 'COMPLETED', 'COMPLETED', None, 'is not', None),
         ('upgrade', Payment.PaymentActions.UPGRADE.value, State.DRAFT, State.DRAFT, 'N', 'Y', datetime.utcnow(), 0, 'PENDING_PAYMENT', 'COMPLETED', None, 'is not', None),
         ('re-upgrade', Payment.PaymentActions.UPGRADE.value, State.DRAFT, State.DRAFT, 'Y', 'Y', datetime.utcnow(), 0, 'PENDING_PAYMENT', 'COMPLETED', None, 'is not', None),
         ('extend ', Payment.PaymentActions.REAPPLY.value, State.DRAFT, State.DRAFT, 'N', 'N',

--- a/services/namex-pay/tests/unit/test_worker.py
+++ b/services/namex-pay/tests/unit/test_worker.py
@@ -63,6 +63,8 @@ def test_extract_payment_token():
          None  # error
          ),
         ('already draft', Payment.PaymentActions.CREATE.value, State.DRAFT, State.DRAFT, 'N', 'N', datetime.utcnow(), 0, 'COMPLETED', 'COMPLETED', None, 'is not', None),
+        ('resubmit', Payment.PaymentActions.RESUBMIT.value, State.PENDING_PAYMENT, State.DRAFT, 'N', 'N', datetime.utcnow(), 0, None, 'COMPLETED', None, 'is not', None),
+        ('resubmit draft', Payment.PaymentActions.RESUBMIT.value, State.DRAFT, State.DRAFT, 'N', 'N', datetime.utcnow(), 0, 'COMPLETED', 'COMPLETED', None, 'is not', None),
         ('upgrade', Payment.PaymentActions.UPGRADE.value, State.DRAFT, State.DRAFT, 'N', 'Y', datetime.utcnow(), 0, 'PENDING_PAYMENT', 'COMPLETED', None, 'is not', None),
         ('re-upgrade', Payment.PaymentActions.UPGRADE.value, State.DRAFT, State.DRAFT, 'Y', 'Y', datetime.utcnow(), 0, 'PENDING_PAYMENT', 'COMPLETED', None, 'is not', None),
         ('extend ', Payment.PaymentActions.REAPPLY.value, State.DRAFT, State.DRAFT, 'N', 'N',

--- a/services/namex-pay/tests/unit/test_worker.py
+++ b/services/namex-pay/tests/unit/test_worker.py
@@ -15,6 +15,7 @@
 from datetime import timedelta
 from namex.models import Request, State, Payment
 import json
+import nest_asyncio
 
 import pytest
 from freezegun import freeze_time
@@ -23,7 +24,6 @@ import namex_pay
 
 from namex_pay.utils.datetime import datetime, timedelta
 from namex_pay.worker import NAME_REQUEST_LIFESPAN_DAYS
-
 
 def test_extract_payment_token():
     """Assert that the payment token can be extracted from the Queue delivered Msg."""
@@ -156,6 +156,7 @@ async def test_process_payment(app, session, mocker,
                                      ):
     from namex.models import Request, State, Payment
     from namex_pay.worker import process_payment, FLASK_APP
+    nest_asyncio.apply()
 
     # setup
     PAYMENT_TOKEN = 'dog'


### PR DESCRIPTION
*Issue:  bcgov/entity#8488*

*Description of changes:*

- Added config; 
- Initialized the queue;
- Updated the stan client_id everytime nats reconnects; 
- Initalized QueueService with a new event loop; 
- Added nest_asyncio to tests for the queue services work properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
