### PR TITLE
8676: Ignore unknown attributes in payment-requests response json.

### DIFF
--- a/api/namex/services/payment/models/__init__.py
+++ b/api/namex/services/payment/models/__init__.py
@@ -1,6 +1,8 @@
-from .abstract import Serializable
+import dataclasses
 from dataclasses import dataclass, field
 from datetime import date
+
+from .abstract import Serializable
 
 
 @dataclass
@@ -143,6 +145,13 @@ class PaymentInvoice(Serializable):
     details: list = field(default_factory=list)
     _links: list = field(default_factory=list)
     paymentAccount: dict = field(default_factory=dict)
+
+    def __init__(self, **kwargs):
+        """Set the attributes only if the field is defined."""
+        names = set([f.name for f in dataclasses.fields(self)])
+        for k, v in kwargs.items():
+            if k in names:
+                setattr(self, k, v)
 
 
 @dataclass

--- a/api/tests/python/services/payment/__init__.py
+++ b/api/tests/python/services/payment/__init__.py
@@ -1,0 +1,13 @@
+# Copyright © c2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/api/tests/python/services/payment/test_models.py
+++ b/api/tests/python/services/payment/test_models.py
@@ -1,0 +1,38 @@
+# Copyright © c2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from namex.services.payment.models import PaymentInvoice
+
+
+def test_payment_invoice_model(session):
+    """Assert that the data class ignores unknown response attributes."""
+    sample_response = {
+        'businessIdentifier': 'NR L000002',
+        'corpTypeCode': 'NRO',
+        'id': 11801,
+        'paid': 0.0,
+        'paymentAccount': {
+            'accountId': '2698',
+            'accountName': 'online banking 13.1'
+        },
+        'paymentMethod': 'ONLINE_BANKING',
+        'serviceFees': 1.5,
+        'statusCode': 'CREATED',
+        'total': 31.5,
+        'test_field_to_be_ignored': 'Hi'
+    }
+
+    invoice_model = PaymentInvoice(**sample_response)
+    assert invoice_model.businessIdentifier == sample_response['businessIdentifier']
+    assert not getattr(invoice_model, 'test_field_to_be_ignored', None)
+


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/bcgov/entity/issues/8676

*Description of changes:*
- Ignore unknown attributes in payment-requests response json.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
