### PR TITLE
8793 Update NR CONSUMED state change processing logic

### DIFF
--- a/services/solr-names-updater/src/solr_names_updater/worker.py
+++ b/services/solr-names-updater/src/solr_names_updater/worker.py
@@ -80,25 +80,17 @@ async def process_names_event_message(msg: dict, flask_app: Flask):
     with flask_app.app_context():
         logger.debug('entering processing of nr event msg: %s', msg)
         request_state_change = msg.get('data').get('request', None)
-        name_state_change = msg.get('data').get('name', None)
 
         if request_state_change:
             new_state = request_state_change.get('newState')
             if new_state in ('APPROVED', 'CONDITIONAL'):
                 process_names_add(request_state_change)
                 process_possible_conflicts_add(request_state_change)
-            elif new_state in ('CANCELLED', 'RESET'):
+            elif new_state in ('CANCELLED', 'RESET', 'CONSUMED'):
                 process_names_delete(request_state_change)
                 process_possible_conflicts_delete(request_state_change)
             else:
                 logger.debug('no names processing required for request state change message %s', msg)
-        elif name_state_change:
-            new_state = name_state_change.get('newState')
-            if new_state == 'CONSUMED':
-                process_names_delete(name_state_change)
-                process_possible_conflicts_delete(name_state_change)
-            else:
-                logger.debug('no names processing required for name state message %s', msg)
         else:
             logger.debug('skipping - no matching state change message %s', msg)
 

--- a/services/solr-names-updater/tests/unit/__init__.py
+++ b/services/solr-names-updater/tests/unit/__init__.py
@@ -113,24 +113,3 @@ def create_request_state_change_message(new_state, prev_state):
             }
         }
     }
-
-
-def create_name_state_change_message(new_state, prev_state):
-
-    return {
-        'specversion': '1.0.1',
-        'type': 'bc.registry.names.events',
-        'source': '/requests/NR 6724165/name/234234234',
-        'id': '16fd2706-8baf-433b-82eb-8c7fada847aa',
-        'time': '',
-        'datacontenttype': 'application/json',
-        'identifier': 'NR 6724165',
-        'data': {
-            'name': {
-                'nrId': '234234234',
-                'nrNum': 'NR 6724165',
-                'newState': new_state,
-                'previousState': prev_state
-            }
-        }
-    }

--- a/services/solr-names-updater/tests/unit/test_names_processor.py
+++ b/services/solr-names-updater/tests/unit/test_names_processor.py
@@ -21,8 +21,7 @@ from namex.utils import queue_util
 from solr_names_updater import worker  # noqa: I001
 from solr_names_updater.names_processors.names import get_nr_ids_to_delete_from_solr
 
-from . import create_queue_mock_message, create_nr, MockResponse, create_request_state_change_message, \
-    create_name_state_change_message # noqa: I003
+from . import create_queue_mock_message, create_nr, MockResponse, create_request_state_change_message # noqa: I003
 
 
 @pytest.mark.parametrize(
@@ -144,9 +143,9 @@ async def test_should_add_names_to_solr(
             ['APPROVED', 'CONDITION', 'REJECTED']
         ),
         (
-            'name',
-            create_name_state_change_message('CONSUMED', ''),
-            'APPROVED', 'DRAFT',
+            'request',
+            create_request_state_change_message('CONSUMED', 'APPROVED'),
+            'CONSUMED', 'APPROVED',
             ['TEST NAME 1', 'TEST NAME 2', 'TEST NAME 3'],
             ['APPROVED', 'CONDITION', 'REJECTED']
         ),

--- a/services/solr-names-updater/tests/unit/test_possible_conflicts_processor.py
+++ b/services/solr-names-updater/tests/unit/test_possible_conflicts_processor.py
@@ -21,8 +21,7 @@ import pytest
 from namex.utils import queue_util
 from solr_names_updater import worker  # noqa: I001
 
-from . import create_queue_mock_message, create_nr, MockResponse, create_request_state_change_message, \
-    create_name_state_change_message # noqa: I003
+from . import create_queue_mock_message, create_nr, MockResponse, create_request_state_change_message  # noqa: I003
 
 
 @pytest.mark.parametrize(
@@ -173,9 +172,9 @@ async def test_should_add_possible_conflicts_to_solr(
             ['APPROVED', 'CONDITION', 'REJECTED']
         ),
         (
-            'name',
-            create_name_state_change_message('CONSUMED', ''),
-            'APPROVED', 'DRAFT',
+            'request',
+            create_request_state_change_message('CONSUMED', 'APPROVED'),
+            'CONSUMED', 'APPROVED',
             ['TEST NAME 1', 'TEST NAME 2', 'TEST NAME 3'],
             ['APPROVED', 'CONDITION', 'REJECTED']
         )


### PR DESCRIPTION
*Issue #: bcgov/entity#8793

*Description of changes:*

* Update `CONSUME` state processing logic for an NR
* Update tests for `CONSUME` state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
