### PR TITLE
8721 refactor nr day job to fix event loop already running issue

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -136,7 +136,7 @@ def update_nr_name_search(mapper, connection, target):
         current_app.logger.debug('name_consume_history.added {}'.format(nr.nrNum))
         if len(name_consume_history.added):
             # Adding an after_flush_postexec to avoid connection and transaction closed issue's
-            # It registrars and executes only once, so its only for the current session
+            # Creating one time execution event when ever corpNum is added to a name
             # corpNum sets from nro-extractor job
             @event.listens_for(db.session, 'after_flush_postexec', once=True)
             def receive_after_flush_postexec(session, flush_context):


### PR DESCRIPTION
*Issue:* bcgov/entity#8721

*Description of changes:*
  - To avoid nested loop error, making nr day job as sync function (This will allow queue.py to create a new event loop)
  - When there is a stateCd change, the request model pushes a state change queue synchronously and to do that queue.py uses an event loop

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
