### PR TITLE
added a check that the corpNum is not None

### DIFF
--- a/api/namex/models/name.py
+++ b/api/namex/models/name.py
@@ -134,7 +134,7 @@ def update_nr_name_search(mapper, connection, target):
         # set nr state to consumed
         name_consume_history = get_history(name, 'corpNum')
         current_app.logger.debug('name_consume_history.added {}'.format(nr.nrNum))
-        if len(name_consume_history.added):
+        if len(name_consume_history.added) and name.corpNum:
             # Adding an after_flush_postexec to avoid connection and transaction closed issue's
             # Creating one time execution event when ever corpNum is added to a name
             # corpNum sets from nro-extractor job


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
- added check that corpNum is not None, so that CONSUMED is not set.
Error -> extractor.app - DEBUG - [name.py:146] - moved to CONSUMED state **None**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
