### PR TITLE
8810_for_SP_GP_dont_call_queue_services

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -619,7 +619,9 @@ def on_insert_or_update_nr(mapper, connection, request):
 
        Temporary NRs (nrNum starting with 'NR L') are discarded.
     """
-    if current_app.config.get('DISABLE_NAMEREQUEST_NATS_UPDATES', 0) != 1 and not request.nrNum.startswith('NR L'):
+
+    if current_app.config.get('DISABLE_NAMEREQUEST_NATS_UPDATES', 0) != 1 and not request.nrNum.startswith('NR L') \
+        and request.entity_type_cd != 'FR' and request.entity_type_cd != 'GP':
         state_cd_history = get_history(request, 'stateCd')
         nr_num_history = get_history(request, 'nrNum')
         if len(nr_num_history.added) or len(state_cd_history.added):

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -619,9 +619,9 @@ def on_insert_or_update_nr(mapper, connection, request):
 
        Temporary NRs (nrNum starting with 'NR L') are discarded.
     """
-
-    if current_app.config.get('DISABLE_NAMEREQUEST_NATS_UPDATES', 0) != 1 and not request.nrNum.startswith('NR L') \
-        and request.entity_type_cd != 'FR' and request.entity_type_cd != 'GP':
+    if current_app.config.get('DISABLE_NAMEREQUEST_NATS_UPDATES', 0) != 1 \
+       and not request.nrNum.startswith('NR L') \
+       and request.entity_type_cd not in ('FR', 'GP'):
         state_cd_history = get_history(request, 'stateCd')
         nr_num_history = get_history(request, 'nrNum')
         if len(nr_num_history.added) or len(state_cd_history.added):

--- a/api/tests/python/models/test_request.py
+++ b/api/tests/python/models/test_request.py
@@ -1,5 +1,8 @@
 from flask import jsonify
 from unittest import mock
+from unittest.mock import patch
+from namex.utils import queue_util
+from flask import current_app
 import pytest
 
 
@@ -107,6 +110,103 @@ def test_has_consumed_name():
 
     assert nr.has_consumed_name is True
 
+def test_no_cloud_event_sent_for_approved_sp_gp_nrs():
+    """func description"""
+    from namex.models import Name, Request as RequestDAO, State
+    
+
+    with patch.dict(current_app.config, {'DISABLE_NAMEREQUEST_NATS_UPDATES': 0}):
+        with patch.object(queue_util, 'send_name_request_state_msg', return_value=True) as mock_queue_util_send_msg_func:
+            name = Name()
+            name.choice = 1
+            name.name = 'TEST'
+            name.state = 'APPROVED'
+
+            nr = RequestDAO()
+            nr.nrNum='NR 0000001'
+            nr.stateCd = State.APPROVED
+            nr.names.append(name)
+            nr.entity_type_cd = 'FR'
+            nr.save_to_db()
+
+            assert mock_queue_util_send_msg_func.called == False
+
+            name = Name()
+            name.choice = 1
+            name.name = 'TEST 2'
+            name.state = 'APPROVED'
+
+            nr = RequestDAO()
+            nr.nrNum='NR 0000002'
+            nr.stateCd = State.APPROVED
+            nr.names.append(name)
+            nr.entity_type_cd = 'GP'
+            nr.save_to_db()
+
+            assert mock_queue_util_send_msg_func.called == False
+
+            name = Name()
+            name.choice = 1
+            name.name = 'TEST 3'
+            name.state = 'APPROVED'
+
+            nr = RequestDAO()
+            nr.nrNum='NR 0000003'
+            nr.stateCd = State.APPROVED
+            nr.names.append(name)
+            nr.entity_type_cd = 'CR'
+            nr.save_to_db()
+
+            assert mock_queue_util_send_msg_func.called == True
+
+def test_no_cloud_event_sent_for_conditional_sp_gp_nrs():
+    """func description"""
+    from namex.models import Name, Request as RequestDAO, State
+    
+    with patch.dict(current_app.config, {'DISABLE_NAMEREQUEST_NATS_UPDATES': 0}):
+        with patch.object(queue_util, 'send_name_request_state_msg', return_value=True) as mock_queue_util_send_msg_func:
+         
+            name = Name()
+            name.choice = 1
+            name.name = 'TEST'
+            name.state = 'CONDITION'
+
+            nr = RequestDAO()
+            nr.nrNum='NR 0000001'
+            nr.stateCd = State.CONDITIONAL
+            nr.names.append(name)
+            nr.entity_type_cd = 'FR'
+            nr.save_to_db()
+
+            assert mock_queue_util_send_msg_func.called == False
+
+            name = Name()
+            name.choice = 1
+            name.name = 'TEST 2'
+            name.state = 'CONDITION'
+
+            nr = RequestDAO()
+            nr.nrNum='NR 0000002'
+            nr.stateCd = State.CONDITIONAL
+            nr.names.append(name)
+            nr.entity_type_cd = 'GP'
+            nr.save_to_db()
+
+            assert mock_queue_util_send_msg_func.called == False
+
+            name = Name()
+            name.choice = 1
+            name.name = 'TEST 3'
+            name.state = 'CONDITION'
+
+            nr = RequestDAO()
+            nr.nrNum='NR 0000003'
+            nr.stateCd = State.CONDITIONAL
+            nr.names.append(name)
+            nr.entity_type_cd = 'CR'
+            nr.save_to_db()
+
+            assert mock_queue_util_send_msg_func.called == True    
 
 def test_is_expired():
     """Assert is_expired."""

--- a/api/tests/python/models/test_request.py
+++ b/api/tests/python/models/test_request.py
@@ -1,9 +1,11 @@
-from flask import jsonify
 from unittest import mock
 from unittest.mock import patch
-from namex.utils import queue_util
-from flask import current_app
+
 import pytest
+from flask import current_app
+from flask import jsonify
+
+from namex.utils import queue_util
 
 
 def test_get_queued_oldest(client, app):
@@ -110,15 +112,15 @@ def test_has_consumed_name():
 
     assert nr.has_consumed_name is True
 
-@pytest.mark.parametrize(['compName', 'compState', 'nrNum','nrEntity','assertValue'], [
-    ('TEST1', 'APPROVED','NR 0000001', 'FR', False),
-    ('TEST2', 'APPROVED','NR 0000002', 'GP', False),
-    ('TEST3', 'APPROVED','NR 0000003', 'CR', True),
-    ('TEST4', 'CONDITION','NR 0000004', 'FR', False),
-    ('TEST5', 'CONDITION','NR 0000005', 'GP', False),
-    ('TEST6', 'CONDITION','NR 0000006', 'CR', True),
+@pytest.mark.parametrize(['testName','compName', 'compState', 'nrNum','nrEntity','assertValue'], [
+    ('Sole Prop Approved Company', 'TEST1', 'APPROVED','NR 0000001', 'FR', False),
+    ('Gen Partner Approved Company','TEST2', 'APPROVED','NR 0000002', 'GP', False),
+    ('CORPORATION Approved Company','TEST3', 'APPROVED','NR 0000003', 'CR', True),
+    ('Sole Prop Conditional Company','TEST4', 'CONDITION','NR 0000004', 'FR', False),
+    ('Gen Partner Conditional Company','TEST5', 'CONDITION','NR 0000005', 'GP', False),
+    ('CORPORATION Conditional Company','TEST6', 'CONDITION','NR 0000006', 'CR', True),
 ])
-def test_no_cloud_event_sent_for_sp_gp_nrs(compName, compState, nrNum, nrEntity, assertValue):
+def test_no_cloud_event_sent_for_sp_gp_nrs(testName, compName, compState, nrNum, nrEntity, assertValue):
     """func description"""
     from namex.models import Name, Request as RequestDAO, State
     


### PR DESCRIPTION
*Issue #8810

*Description of changes:*
When nr is updated or inserted, a listener executes code to update queue services Do not call this function if the company entity_type_cd is FR (Sole prop) or GP (General Partnership)

