### PR TITLE
8810 dont update solr names DB for SP and GP

### DIFF
--- a/services/solr-names-updater/Makefile
+++ b/services/solr-names-updater/Makefile
@@ -67,6 +67,8 @@ pylint: ## Linting with pylint
 flake8: ## Linting with flake8 ## tests
 	. venv/bin/activate && flake8 src/$(PROJECT_NAME)
 
+lint: pylint flake8 ## run all lint type scripts
+
 test: ## Unit testing
 	. venv/bin/activate && pytest
 

--- a/services/solr-names-updater/src/solr_names_updater/worker.py
+++ b/services/solr-names-updater/src/solr_names_updater/worker.py
@@ -69,7 +69,9 @@ def is_processable(msg: dict):
     """Determine if message is processable using message type of msg."""
     nr_num = msg.get('nrNum', None)
     nr = RequestDAO.find_by_nr(nr_num)
-    if msg and is_names_event_msg_type(msg) and nr.entity_type_cd not in ('FR', 'GP'):
+    if msg and is_names_event_msg_type(msg) \
+       and (nr := RequestDAO.find_by_nr(nr_num)) \
+       and nr.entity_type_cd not in ('FR', 'GP'):
         return True
 
     return False

--- a/services/solr-names-updater/src/solr_names_updater/worker.py
+++ b/services/solr-names-updater/src/solr_names_updater/worker.py
@@ -31,6 +31,7 @@ import os
 import nats
 from flask import Flask
 from namex.models import db
+from namex.models import Request as RequestDAO
 from queue_common.service import QueueServiceManager
 from queue_common.service_utils import QueueException, logger
 from requests import RequestException
@@ -66,7 +67,9 @@ def is_names_event_msg_type(msg: dict):
 
 def is_processable(msg: dict):
     """Determine if message is processable using message type of msg."""
-    if msg and is_names_event_msg_type(msg):
+    nr_num = msg.get('nrNum', None)
+    nr = RequestDAO.find_by_nr(nr_num)
+    if msg and is_names_event_msg_type(msg) and nr.entity_type_cd not in ('FR', 'GP'):
         return True
 
     return False

--- a/services/solr-names-updater/src/solr_names_updater/worker.py
+++ b/services/solr-names-updater/src/solr_names_updater/worker.py
@@ -68,7 +68,6 @@ def is_names_event_msg_type(msg: dict):
 def is_processable(msg: dict):
     """Determine if message is processable using message type of msg."""
     nr_num = msg.get('nrNum', None)
-    nr = RequestDAO.find_by_nr(nr_num)
     if msg and is_names_event_msg_type(msg) \
        and (nr := RequestDAO.find_by_nr(nr_num)) \
        and nr.entity_type_cd not in ('FR', 'GP'):

--- a/services/solr-names-updater/src/solr_names_updater/worker.py
+++ b/services/solr-names-updater/src/solr_names_updater/worker.py
@@ -30,8 +30,8 @@ import os
 
 import nats
 from flask import Flask
-from namex.models import db
 from namex.models import Request as RequestDAO
+from namex.models import db
 from queue_common.service import QueueServiceManager
 from queue_common.service_utils import QueueException, logger
 from requests import RequestException

--- a/services/solr-names-updater/tests/unit/__init__.py
+++ b/services/solr-names-updater/tests/unit/__init__.py
@@ -77,6 +77,7 @@ def create_nr(nr_num: str, request_state: str, names: list, names_state: list):
         name_request.stateCd = request_state
         name_request._source = 'NRO'
         name_request.expirationDate = add_years(now, 1)
+        name_request.entity_type_cd = 'CR'
         # name_request.priorityCd = start_priority
         name_request.save_to_db()
 

--- a/services/solr-names-updater/tests/unit/test_names_processor.py
+++ b/services/solr-names-updater/tests/unit/test_names_processor.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import requests
 import pytest
 
+from namex.models import Request as RequestDAO
 from namex.utils import queue_util
 from solr_names_updater import worker  # noqa: I001
 from solr_names_updater.names_processors.names import get_nr_ids_to_delete_from_solr
@@ -85,7 +86,7 @@ async def test_should_add_names_to_solr(
     queue_util.send_name_request_state_msg = mock.Mock(return_value="True")
     nr_num = message_payload['data']['request']['nrNum']
     nr_new_state = message_payload['data']['request']['newState']
-    create_nr(nr_num, nr_new_state, names, names_state)
+    mock_nr = create_nr(nr_num, nr_new_state, names, names_state)
     mock_msg = create_queue_mock_message(message_payload)
     mock_response = MockResponse({}, 200)
 
@@ -97,25 +98,27 @@ async def test_should_add_names_to_solr(
             with patch.object(worker, 'process_possible_conflicts_add', return_value=True):
                 # mock process_possible_conflicts_delete to do nothing in order to isolate testing relevant to this test
                 with patch.object(worker, 'process_possible_conflicts_delete', return_value=True):
-                    await worker.cb_subscription_handler(mock_msg)
+                    # mock find_by_nr to do nothing in order to isolate testing relevant to this test
+                    with patch.object(RequestDAO, 'find_by_nr', return_value=mock_nr):
+                        await worker.cb_subscription_handler(mock_msg)
 
-                    if len(expected_names_to_add_to_solr) > 0:
-                        assert mock_solr_feeder_api_post.called == True
-                        assert 'api/v1/feeds' in mock_solr_feeder_api_post.call_args[0][0]
+                        if len(expected_names_to_add_to_solr) > 0:
+                            assert mock_solr_feeder_api_post.called == True
+                            assert 'api/v1/feeds' in mock_solr_feeder_api_post.call_args[0][0]
 
-                        post_json = mock_solr_feeder_api_post.call_args[1]['json']
-                        assert post_json['solr_core']
-                        assert post_json['solr_core'] == 'names'
+                            post_json = mock_solr_feeder_api_post.call_args[1]['json']
+                            assert post_json['solr_core']
+                            assert post_json['solr_core'] == 'names'
 
-                        request_json = post_json['request']
+                            request_json = post_json['request']
 
-                        for index, expect_name in enumerate(expected_names_to_add_to_solr):
-                            assert expect_name in request_json
+                            for index, expect_name in enumerate(expected_names_to_add_to_solr):
+                                assert expect_name in request_json
 
-                        for index, not_expect_name in enumerate(not_expected_names_to_add_to_solr):
-                            assert not_expect_name not in request_json
-                    else:
-                        assert mock_solr_feeder_api_post.called == False
+                            for index, not_expect_name in enumerate(not_expected_names_to_add_to_solr):
+                                assert not_expect_name not in request_json
+                        else:
+                            assert mock_solr_feeder_api_post.called == False
 
 
 @pytest.mark.parametrize(
@@ -167,8 +170,8 @@ async def test_should_delete_names_from_solr(
     queue_util.send_name_request_state_msg = mock.Mock(return_value="True")
     queue_util.send_name_state_msg = mock.Mock(return_value="True")
     nr_num = message_payload['data'][state_change_type]['nrNum']
-    nr = create_nr(nr_num, new_nr_state, names, name_states)
-    nr_ids_to_delete_from_solr = get_nr_ids_to_delete_from_solr(nr)
+    mock_nr = create_nr(nr_num, new_nr_state, names, name_states)
+    nr_ids_to_delete_from_solr = get_nr_ids_to_delete_from_solr(mock_nr)
     mock_msg = create_queue_mock_message(message_payload)
     mock_response = MockResponse({}, 200)
 
@@ -176,19 +179,21 @@ async def test_should_delete_names_from_solr(
     with patch.object(requests, 'post', return_value=mock_response) as mock_solr_feeder_api_post:
         # mock process_possible_conflicts_delete to do nothing in order to isolate testing relevant to this test
         with patch.object(worker, 'process_possible_conflicts_delete', return_value=True):
-            await worker.cb_subscription_handler(mock_msg)
+            # mock find_by_nr to do nothing in order to isolate testing relevant to this test
+            with patch.object(RequestDAO, 'find_by_nr', return_value=mock_nr):
+                await worker.cb_subscription_handler(mock_msg)
 
-            assert mock_solr_feeder_api_post.called == True
-            assert 'api/v1/feeds' in mock_solr_feeder_api_post.call_args[0][0]
+                assert mock_solr_feeder_api_post.called == True
+                assert 'api/v1/feeds' in mock_solr_feeder_api_post.call_args[0][0]
 
-            post_json = mock_solr_feeder_api_post.call_args[1]['json']
-            assert post_json['solr_core']
-            assert post_json['solr_core'] == 'names'
+                post_json = mock_solr_feeder_api_post.call_args[1]['json']
+                assert post_json['solr_core']
+                assert post_json['solr_core'] == 'names'
 
-            request_json = post_json['request']
+                request_json = post_json['request']
 
-            assert 'delete' in request_json
-            assert len(nr_ids_to_delete_from_solr) > 0
-            request_json = post_json['request']
-            for nr_id in nr_ids_to_delete_from_solr:
+                assert 'delete' in request_json
+                assert len(nr_ids_to_delete_from_solr) > 0
+                request_json = post_json['request']
+                for nr_id in nr_ids_to_delete_from_solr:
                     assert nr_id in request_json

--- a/services/solr-names-updater/tests/unit/test_worker.py
+++ b/services/solr-names-updater/tests/unit/test_worker.py
@@ -23,7 +23,7 @@ from freezegun import freeze_time
 from namex.models import Request as RequestDAO
 from namex.utils import queue_util
 from queue_common.service_utils import QueueException
-from solr_names_updater import worker
+from solr_names_updater import worker # noqa: I001
 from . import create_queue_mock_message, create_nr, MockResponse, create_request_state_change_message # noqa: I003
 
 @pytest.mark.parametrize(
@@ -56,7 +56,9 @@ async def test_sp_gp_names_not_processed_to_solr(
     mock_nr = mock.Mock()
     mock_nr.entity_type_cd = nr_entity
 
+    # mock process_names_event_message to do nothing in order to isolate testing relevant to this test
     with patch.object(worker, 'process_names_event_message', return_value=True) as mock_process_names_evt_func:
+        # mock find_by_nr to do nothing in order to isolate testing relevant to this test
         with patch.object(RequestDAO, 'find_by_nr', return_value=mock_nr):
             await worker.cb_subscription_handler(mock_msg)
 

--- a/services/solr-names-updater/tests/unit/test_worker.py
+++ b/services/solr-names-updater/tests/unit/test_worker.py
@@ -12,10 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Test Suites to ensure that the worker is operating correctly."""
-from datetime import timedelta
 import json
+from datetime import timedelta
+from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from freezegun import freeze_time
-from queue_common.service_utils import QueueException
 
+from namex.models import Request as RequestDAO
+from namex.utils import queue_util
+from queue_common.service_utils import QueueException
+from solr_names_updater import worker
+from . import create_queue_mock_message, create_nr, MockResponse, create_request_state_change_message # noqa: I003
+
+@pytest.mark.parametrize(
+    ['testname','message_payload','nr_entity','assert_value'],[
+     ('Sole Prop Approved', create_request_state_change_message('APPROVED', 'DRAFT'), 'FR', False),
+     ('Sole Prop Conditional', create_request_state_change_message('CONDITIONAL', 'DRAFT'),'FR', False),
+     ('Sole Prop Cancelled', create_request_state_change_message('CANCELLED', 'DRAFT'), 'FR', False),
+     ('Sole Prop Reset', create_request_state_change_message('RESET', 'DRAFT'), 'FR', False),
+     ('Sole Prop Consumed', create_request_state_change_message('CONSUMED', 'DRAFT'), 'FR', False),
+     ('Gen Part Approved', create_request_state_change_message('APPROVED', 'DRAFT'),   'GP', False),
+     ('Gen Part Conditional', create_request_state_change_message('CONDITIONAL', 'DRAFT'), 'GP', False),
+     ('Gen Part Cancelled', create_request_state_change_message('CANCELLED', 'DRAFT'), 'GP', False),
+     ('Gen Part Reset', create_request_state_change_message('RESET', 'DRAFT'), 'GP', False),
+     ('Gen Part Consumed', create_request_state_change_message('CONSUMED', 'DRAFT'), 'GP', False),
+     ('CORPORATION Approved', create_request_state_change_message('APPROVED', 'DRAFT'), 'CR', True),
+     ('CORPORATION Conditional', create_request_state_change_message('CONDITIONAL', 'DRAFT'), 'CR', True),
+     ('CORPORATION Cancelled', create_request_state_change_message('CANCELLED', 'DRAFT'), 'CR', True),
+     ('CORPORATION Reset', create_request_state_change_message('RESET', 'DRAFT'), 'CR', True),
+     ('CORPORATION Consumed', create_request_state_change_message('CONSUMED', 'DRAFT'), 'CR', True)
+    ])
+async def test_sp_gp_names_not_processed_to_solr(
+        testname,
+        message_payload,
+        nr_entity,
+        assert_value):
+    """Assert that names are added to solr."""
+
+    queue_util.process_names_event_message = mock.Mock(return_value="True")
+    mock_msg = create_queue_mock_message(message_payload)
+    mock_nr = mock.Mock()
+    mock_nr.entity_type_cd = nr_entity
+
+    with patch.object(worker, 'process_names_event_message', return_value=True) as mock_process_names_evt_func:
+        with patch.object(RequestDAO, 'find_by_nr', return_value=mock_nr):
+            await worker.cb_subscription_handler(mock_msg)
+
+            assert mock_process_names_evt_func.called == assert_value


### PR DESCRIPTION
*Issue # https://github.com/bcgov/entity/issues/8810

*Description of changes:*

When nr is processed through the solr names updater bypass the posts to SOLR database functions if the company entity_type_cd is FR (Sole prop) or GP (General Partnership)
