### PR TITLE
10139 - Use NameRequestService.create_expiry_date()

### DIFF
--- a/jobs/nro-update/nro/nro_datapump.py
+++ b/jobs/nro-update/nro/nro_datapump.py
@@ -4,23 +4,15 @@ from pytz import timezone
 import pytz
 
 from namex.models import Name, State
+from namex.services.name_request import NameRequestService
 from namex.services.nro.utils import nro_examiner_name
 
 
-def create_expiry_date(start: datetime, expires_in_days: int, expiry_hour: int = 0, expiry_min: int = 1, tz: timezone = timezone('US/Pacific')) -> datetime:
-    """Return an expiry date in given days starting tomorrow."""
-    date = (start.astimezone(tz) + timedelta(days=expires_in_days+1))\
-        .replace(hour=expiry_hour, minute=expiry_min, second=0, microsecond=0)
-
-    return date
-
-
 def nro_data_pump_update(nr, ora_cursor, expires_days=56):
-
-    expiry_date = create_expiry_date(
+    nr_service = NameRequestService()
+    expiry_date = nr_service.create_expiry_date(
         start=nr.lastUpdate,
-        expires_in_days=expires_days,
-        tz=timezone('US/Pacific')
+        expires_in_days=expires_days
     )
 
     current_app.logger.debug(f'Setting expiry date to: { expiry_date }')

--- a/jobs/nro-update/requirements.txt
+++ b/jobs/nro-update/requirements.txt
@@ -2,14 +2,15 @@ Flask-SQLAlchemy==2.5.1
 Flask==1.1.2
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-SQLAlchemy==1.4.2
+SQLAlchemy==1.4.11
 Werkzeug==1.0.1
 click==7.1.2
 cx-Oracle==8.1.0
 greenlet==1.0.0
 itsdangerous==1.1.0
 psycopg2-binary==2.8.6
-python-dotenv==0.15.0
+python-dotenv==0.17.1
 pytz==2021.1
 git+https://github.com/bcgov/namex.git#egg=namex&subdirectory=api
 git+https://github.com/bcgov/namex-synonyms-api-py-client.git#egg=swagger_client
+git+https://github.com/bcgov/namex.git#egg=queue_common&subdirectory=services/common

--- a/jobs/nro-update/tests/test_nro_datapump.py
+++ b/jobs/nro-update/tests/test_nro_datapump.py
@@ -3,28 +3,27 @@ from datetime import datetime
 import pytest
 from pytz import timezone
 
-from nro.nro_datapump import nro_data_pump_update, create_expiry_date
+from nro.nro_datapump import nro_data_pump_update
 from namex.models import Request, Name, State, User
+from namex.services.name_request import NameRequestService
 
 
 expiry_date_test_data = [
     ('using epoch utc',            # test descriptive name
      datetime(1970, 1, 1, 00, 00, tzinfo=timezone('US/Pacific', )), # start date - time
      20,                           # days to add
-     23,                           # hour to set the final date time to
-     59,                           # minute to set the final date time to
      'US/Pacific',                 # timezone that should be used
      datetime(1970, 1, 21, 23, 59)), # expected outcome
     ('using a time after 4pm',
-     datetime(2001, 8, 5, 19, 00, tzinfo=timezone('US/Pacific',)), 20, 23, 59, 'US/Pacific', datetime(2001, 8, 25, 23, 59)),
+     datetime(2001, 8, 5, 19, 00, tzinfo=timezone('US/Pacific',)), 20, 'US/Pacific', datetime(2001, 8, 25, 23, 59)),
     ('using a time before 4pm',
-     datetime(2001, 8, 5, 9, 00, tzinfo=timezone('US/Pacific',)), 20, 23, 59, 'US/Pacific', datetime(2001, 8, 25, 23, 59)),
+     datetime(2001, 8, 5, 9, 00, tzinfo=timezone('US/Pacific',)), 20, 'US/Pacific', datetime(2001, 8, 25, 23, 59)),
 ]
 
-@pytest.mark.parametrize("test_name, start_date, days, hours, mins, tz, ,expected_date", expiry_date_test_data)
-def test_create_expiry_date(test_name, start_date, days, hours, mins, tz, expected_date):
-
-    ced = create_expiry_date(start_date, expires_in_days=days, expiry_hour=hours, expiry_min=mins, tz=timezone(tz))
+@pytest.mark.parametrize("test_name, start_date, days, tz, expected_date", expiry_date_test_data)
+def test_create_expiry_date(test_name, start_date, days, tz, expected_date):
+    nr_service = NameRequestService()
+    ced = nr_service.create_expiry_date(start_date, expires_in_days=days)
 
     assert ced.replace(tzinfo=None) == expected_date
     assert ced.tzinfo.zone == tz


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10139

*Description of changes:*

- Call NameRequestService.create_expiry_date() in place of local function. This is in the job that runs after a NR is approved, and which sets the expiration datetime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
