### PR TITLE
7087_restore_reinstate_bug fix

### DIFF
--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -386,7 +386,7 @@ class CreateNameRequestPayment(AbstractNameRequestResource):
                                     timedelta(hours=NAME_REQUEST_EXTENSION_PAD_HOURS) < datetime.utcnow():
                                 msg = f'Extend NR for payment.id={payment.id} nr_model.state{nr_model.stateCd}, nr_model.expires:{nr_model.expirationDate}'
                                 current_app.logger.debug(msg)
-                            expiry_days = nr_svc.get_expiry_days(nr_model)
+                            expiry_days = int(nr_svc.get_expiry_days(nr_model))
                             nr_model.expirationDate = nr_svc.create_expiry_date(nr_model.expirationDate, expiry_days)
                             payment.payment_completion_date = datetime.utcnow()
 

--- a/api/namex/services/name_request/name_request.py
+++ b/api/namex/services/name_request/name_request.py
@@ -160,7 +160,7 @@ class NameRequestService(AbstractNameRequestMixin):
         """
         start_datetime = start_date if start_date else datetime.utcnow()
         try:
-            expiry_days = cls.get_expiry_days(name_request)
+            expiry_days = int(cls.get_expiry_days(name_request))
            
             name_request.expirationDate = cls.create_expiry_date(
                 start=start_datetime,
@@ -214,7 +214,7 @@ class NameRequestService(AbstractNameRequestMixin):
                 name_request.consentFlag = 'Y'
 
             if self.new_state_code in [State.RESERVED, State.COND_RESERVE]:
-                expiry_days = self.get_expiry_days(name_request)
+                expiry_days = int(self.get_expiry_days(name_request))
                 name_request.expirationDate = self.create_expiry_date(
                     start=name_request.submittedDate,
                     expires_in_days=expiry_days

--- a/jobs/nro-update/nro_update.py
+++ b/jobs/nro-update/nro_update.py
@@ -87,7 +87,7 @@ try:
 
         try:
             nr_service = NameRequestService()
-            expiry_days = nr_service.get_expiry_days(r)
+            expiry_days = int(nr_service.get_expiry_days(r))
             nro_data_pump_update(r, ora_cursor, expiry_days)
             db.session.add(r)
             EventRecorder.record(user, Event.NRO_UPDATE, r, r.json(), save_to_session=True)


### PR DESCRIPTION
*Issue #bcgov/entity/#7087, if available:*

*Description of changes:*


the return value from get_expiry_days needs to be converted to integer to fix TZ string issue in create_expiry_date
