### PR TITLE
11256_restore_reinstate_action_cd_null_fix

### DIFF
--- a/api/namex/resources/payment/payment.py
+++ b/api/namex/resources/payment/payment.py
@@ -738,7 +738,9 @@ class NameRequestPaymentAction(AbstractNameRequestResource):
     def complete_reapply_payment(self, nr_model: RequestDAO, payment_id: int):
         """
         Invoked when re-applying for an existing Name Request reservation.
-        Extend the Name Request's expiration date by 56 days. If the request action is set to REH or REST,
+        Extend the Name Request's expiration date by 56 days. 
+        If the request action is set to REH, REN or REST, OR request type is 
+        'RCR', 'RUL', 'BERE', 'RCC', 'RCP', 'RFI', 'XRCR', 'RLC', 'XRCP','RSO','XRSO'
         extend the expiration by an additional year (plus the default 56 days).
         :param nr_model:
         :param payment_id:

--- a/api/namex/services/name_request/name_request.py
+++ b/api/namex/services/name_request/name_request.py
@@ -144,10 +144,13 @@ class NameRequestService(AbstractNameRequestMixin):
         """
         returns expiry days of an NR.
         """
-        if name_request.request_action_cd in [RequestAction.REH.value, RequestAction.REN.value]:
+        if name_request.request_action_cd in [RequestAction.REH.value, RequestAction.REN.value, RequestAction.REST.value]:
             expires_days = ExpiryDays.NAME_REQUEST_REH_REN_LIFESPAN_DAYS.value
         else:
-            expires_days = ExpiryDays.NAME_REQUEST_LIFESPAN_DAYS.value
+            if name_request.request_type_cd in ['RCR', 'RUL', 'BERE', 'RCC', 'RCP', 'RFI', 'XRCR', 'RLC', 'XRCP','RSO','XRSO']:
+                expires_days = ExpiryDays.NAME_REQUEST_REH_REN_LIFESPAN_DAYS.value
+            else:
+                expires_days = ExpiryDays.NAME_REQUEST_LIFESPAN_DAYS.value
 
         return expires_days
 

--- a/api/tests/python/services/name_request/test_abstract_name_request.py
+++ b/api/tests/python/services/name_request/test_abstract_name_request.py
@@ -75,12 +75,16 @@ def test_create_expiry_date(input_datetime_utc, expected_date_utc, time_offset):
     assert expiry_date_in_utc.minute == expected_date_utc.minute
     assert expiry_date_in_utc.second == expected_date_utc.second
 
-@pytest.mark.parametrize('test_name, action_cd, days', [
-    ('Testing an NR restoration', RequestAction.REH.value, 421),
-    ('Testing an NR reinstatement', RequestAction.REN.value, 421),
-    ('Testing an NR (new)', RequestAction.NEW.value, 56)
+@pytest.mark.parametrize('test_name, action_cd, request_type, days', [
+    ('Testing an NR restoration', RequestAction.REH.value, 'RCR', 421),
+    ('Testing an NR reinstatement', RequestAction.REN.value, 'RCR', 421),
+    ('Testing an NR NRO restoration', RequestAction.REST.value, 'RCR', 421),
+    ('Testing an NR RequestAction is new, Benefit Restore_Reinstate', RequestAction.NEW.value, 'BERE', 421),
+    ('Testing an NR RequestAction is null, BC Comp Restore_Reinstate', None, 'RCR', 421),
+    ('Testing an NR RequestAction is null, BC Company', None, 'CR', 56),
+    ('Testing an NR RequestAction is new, BC Company', RequestAction.NEW.value, 'CR', 56)
 ])
-def test_get_expiry_days(client, test_name, days, action_cd):
+def test_get_expiry_days(client, test_name, days, action_cd, request_type):
     """
     Test that get_expiry_date method returns a either 56 or 421 days
     """
@@ -89,8 +93,9 @@ def test_get_expiry_days(client, test_name, days, action_cd):
     # Set defaults, if these exist in the provided data they will be overwritten
     mock_nr.stateCd = State.APPROVED
     mock_nr.request_action_cd = action_cd
+    mock_nr.request_type_cd = request_type
     mock_nr.expirationDate = None
-    mock_expiry_days = nr_svc.get_expiry_days(mock_nr)
+    mock_expiry_days = int(nr_svc.get_expiry_days(mock_nr))
 
     assert mock_expiry_days == days
 


### PR DESCRIPTION
*Issue #:/bcgov/entity#11256

*Description of changes:*

Expiration_date fix when Request Action Cd is null, then we check Request Type to set expiry days
