### PR TITLE
fix python prorobuf error

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -57,5 +57,10 @@ tqdm==4.60.0
 urllib3==1.26.4
 asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
+
+# protobuf is a temporary solution for https://github.com/protocolbuffers/protobuf/issues/10051
+# will be removed once the bug is fixed
+protobuf==3.20.1
+
 git+https://github.com/bcgov/namex-synonyms-api-py-client.git#egg=swagger_client
 git+https://github.com/bcgov/namex.git#egg=queue_common&subdirectory=services/common


### PR DESCRIPTION
*Issue #, if available:*
12489

*Description of changes:*
Python has a [bug](https://github.com/protocolbuffers/protobuf/issues/10051) in release 4.21.0. Add “protobuf==3.20.1” to requirments to a temporary solution. Once the bug is fixed, remove the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
