### PR TITLE
To fix all notebook reports Sent but not delivered Issue#2247

### DIFF
--- a/jobs/notebook-report/Makefile
+++ b/jobs/notebook-report/Makefile
@@ -69,7 +69,7 @@ pylint: ## Linting with pylint
 	. venv/bin/activate && pylint --rcfile=setup.cfg  notebookreport.py
 
 flake8: ## Linting with flake8
-	. venv/bin/activate && flake8 notebookreport.py tests
+	. venv/bin/activate && flake8 notebookreport.py
 
 lint: pylint flake8 ## run all lint type scripts
 

--- a/jobs/notebook-report/notebookreport.py
+++ b/jobs/notebook-report/notebookreport.py
@@ -62,7 +62,7 @@ def send_email(subject, filename, emailtype, errormessage):
         if subject.startswith('Weekly NameX'):
             recipients = os.getenv('WEEKLY_REPORT_NAMEX_RECIPIENTS', '')
         # Add body to email
-        message.attach(MIMEText('Please see attached.', 'plain'))
+        message.attach(MIMEText('Please see the attachment(s).', 'plain'))
 
         # Open file in binary mode
         with open(os.getenv('DATA_DIR', '')+filename, 'rb') as attachment:

--- a/jobs/nr-duplicates-report/notebookreport.py
+++ b/jobs/nr-duplicates-report/notebookreport.py
@@ -67,7 +67,7 @@ def send_email(emailtype, errormessage):
         filename = 'nr_duplicates_' + date + '.csv'
         recipients = os.getenv('DAILY_REPORT_RECIPIENTS', '')
         # Add body to email
-        message.attach(MIMEText('Please see attached.', 'plain'))
+        message.attach(MIMEText('Please see the attachment(s).', 'plain'))
 
         # Open file in binary mode
         with open(os.path.join(os.getcwd(), r'data/')+filename, 'rb') as attachment:


### PR DESCRIPTION
*Issue #, if available:* 2247

*Description of changes:*

All notebook reports (including Namex, LEAR, PAY notebook reports) were sent but didn't deliver to the receivers. The reason for this is that the contents in the email body were filter by the email server. Need to update codes to fix this issue.

[To fix all notebook reports Sent but not delivered Issue#2247](https://app.zenhub.com/workspaces/entity-5bf2f2164b5806bc2bf60531/issues/gh/bcgov-registries/ops-support/2247)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
