### PR TITLE
fix 'InstrumentedList' object has no attribute 'all'

### DIFF
--- a/jobs/nro-update/nro/nro_datapump.py
+++ b/jobs/nro-update/nro/nro_datapump.py
@@ -29,7 +29,7 @@ def nro_data_pump_update(nr, ora_cursor, expires_days=56):
         {'state': None, 'decision': None, 'conflict1': None, 'conflict2': None, 'conflict3': None}
     ]
     current_app.logger.debug('processing names for :{}'.format(nr.nrNum))
-    for name in nr.names.all():
+    for name in nr.names:
         choice = name.choice - 1
         if name.state in [Name.APPROVED, Name.CONDITION]:
             nro_names[choice]['state'] = 'A'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: nro-update job is currently broken in main. job runs result in errors:

2023-05-11 23:08:09,608 - nro.app - ERROR in nro_update:nro_update.py:96 - <module>: 'InstrumentedList' object has no attribute 'all'

InstrumentedList is a SQLAlchemy iterable object. Removing .all() causes jobs to succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
