### PR TITLE
add missing secrets

### DIFF
--- a/jobs/nr-day-job/devops/vaults.json
+++ b/jobs/nr-day-job/devops/vaults.json
@@ -5,5 +5,12 @@
             "postgres-namex",
             "namex-api"
         ]
+    },
+        {
+        "vault": "nats",
+        "application": [
+            "namex",
+            "base"
+        ]
     }
 ]


### PR DESCRIPTION
*Description of changes: nr-day-job in openshift was missing nats related secrets, so github actions deployment would break the job, since all necessary secrets would not be pulled from 1password


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
