### PR TITLE
Another email design sync

### DIFF
--- a/api/report-templates/emails/approved.md
+++ b/api/report-templates/emails/approved.md
@@ -37,6 +37,6 @@ The following documents are attached to this email:
 
 **Business Registry**
 BC Registries and Online Services
-Toll Free: 1-877-526-1526
-Victoria Office: 250-387-7848
+Toll Free: 1-877-370-1033
+Victoria Office: 250-370-1033
 Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)

--- a/api/report-templates/emails/conditional.md
+++ b/api/report-templates/emails/conditional.md
@@ -37,6 +37,6 @@ The following documents are attached to this email:
 
 **Business Registry**
 BC Registries and Online Services
-Toll Free: 1-877-370-1033
-Victoria Office: 250-370-1033
+Toll Free: 1-877-526-1526
+Victoria Office: 250-387-7848
 Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)

--- a/api/report-templates/emails/consent.md
+++ b/api/report-templates/emails/consent.md
@@ -1,6 +1,6 @@
 #  Consent Letter Acceptance Confirmation
 
-Thank you for using Name Requests Online. The consent letter for your Name Request **{{NAMEREQUEST_NUMBER}}** has been received. Please note: Your name request will expire on **{{EXPIRATION_DATE}}**.
+Thank you for using Name Requests Online. The consent letter for your Name Request **{{NAMEREQUEST_NUMBER}}** has been received. You will receive another email notification with the result of the review. Please note: Your name request will expire on **{{EXPIRATION_DATE}}**.
 
 ---
 

--- a/api/report-templates/emails/consent.md
+++ b/api/report-templates/emails/consent.md
@@ -10,6 +10,6 @@ PLEASE DO NOT REPLY TO THIS EMAIL. It was sent from an unmonitored email address
 
 **Business Registry**
 BC Registries and Online Services
-Toll Free: 1-877-370-1033
-Victoria Office: 250-370-1033
+Toll Free: 1-877-526-1526
+Victoria Office: 250-387-7848
 Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)

--- a/api/report-templates/emails/rejected.md
+++ b/api/report-templates/emails/rejected.md
@@ -28,6 +28,6 @@ The following documents are attached to this email:
 
 **Business Registry**
 BC Registries and Online Services
-Toll Free: 1-877-370-1033
-Victoria Office: 250-370-1033
+Toll Free: 1-877-526-1526
+Victoria Office: 250-387-7848
 Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* change approval letter to tier 1 and rest to tier 2


Hi Patrick,
 
Can we please keep Maximus’s number for Receipt, Renewal, Upgrade, Expiry soon, Expiry? Is it possible to differentiate between and approved letter and a rejection letter? I think we should likely keep the Tier 2 number on the rejection and consent letters if possible.
 
Megan Fedora (she/her)
Manager, Registries Operations
BC Registries and Online Services
Service BC 
Ministry Citizens’ Services 
T 778-671-9262
Email: [Megan.Fedora@gov.bc.ca](mailto:Megan.Fedora@gov.bc.ca)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
