### PR TITLE
18567 update nr_day_job query

### DIFF
--- a/jobs/nr-day-job/nr_day_job.py
+++ b/jobs/nr-day-job/nr_day_job.py
@@ -94,7 +94,8 @@ def notify_nr_before_expiry():
         current_app.logger.debug('entering notify_nr_before_expiry')
 
         where_clause = text(
-            "expiration_date::DATE - interval '14 day' <= CURRENT_DATE")
+            "expiration_date::DATE - interval '14 day' <= CURRENT_DATE" \
+                "and expiration_date::DATE > CURRENT_DATE")
         requests = db.session.query(Request).filter(
             Request.stateCd.in_((State.APPROVED, State.CONDITIONAL)),
             Request.notifiedBeforeExpiry == False,  # noqa E712; pylint: disable=singleton-comparison

--- a/jobs/nr-day-job/nr_day_job.py
+++ b/jobs/nr-day-job/nr_day_job.py
@@ -94,7 +94,7 @@ def notify_nr_before_expiry():
         current_app.logger.debug('entering notify_nr_before_expiry')
 
         where_clause = text(
-            "expiration_date - interval '14 day' <= CURRENT_DATE AND expiration_date > CURRENT_DATE")
+            "expiration_date::DATE - interval '14 day' <= CURRENT_DATE")
         requests = db.session.query(Request).filter(
             Request.stateCd.in_((State.APPROVED, State.CONDITIONAL)),
             Request.notifiedBeforeExpiry == False,  # noqa E712; pylint: disable=singleton-comparison
@@ -111,10 +111,9 @@ def notify_nr_expired():
     try:
         current_app.logger.debug('entering notify_nr_expired')
 
-        where_clause = text('expiration_date <= CURRENT_DATE')
+        where_clause = text('expiration_date::DATE <= CURRENT_DATE')
         requests = db.session.query(Request).filter(
             Request.stateCd.in_((State.APPROVED, State.CONDITIONAL)),
-            Request.notifiedBeforeExpiry == True,  # noqa E712; pylint: disable=singleton-comparison
             Request.notifiedExpiry == False,  # noqa E712; pylint: disable=singleton-comparison
             where_clause
         ).all()
@@ -130,5 +129,5 @@ if __name__ == '__main__':
 
     application = create_app()
     with application.app_context():
-        notify_nr_before_expiry()
         notify_nr_expired()
+        notify_nr_before_expiry()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/bcgov/entity/issues/18567

*Description of changes:*
update queries:
1. update the query to pick up the nrs to be expired:
    a. cast expiration_date in the query to be a Date type, so that the time part aligns up CURRENT_DATE, which is 0:00
    b. remove the condition: Request.notifiedBeforeExpiry == True. notified before expiry should not be a condition to expiry an NR.
2. update the query to pick up the nrs to be notified before expired
   a. cast expiration_date in the query to a be Date type 

3. move notify_nr_expired() before notify_nr_before_expiry, because notify_nr_expired includes state_cd update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
