### PR TITLE
current ci pipelines depend on makefile contents - update makefiles t…

### DIFF
--- a/.github/workflows/namex-api-ci.yml
+++ b/.github/workflows/namex-api-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [assigned, synchronize]
     paths:
       - "api/**"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -15,10 +16,8 @@ jobs:
   setup-job:
     runs-on: ubuntu-20.04
 
-    if: github.repository == 'bcgov/namex'
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup check
         run: |
           echo "setup check pass."
@@ -29,10 +28,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -40,14 +39,10 @@ jobs:
       - name: Install dependencies
         run: |
           make setup
-      - name: Lint with pylint
-        id: pylint
-        run: |
-          make pylint
       - name: Lint with flake8
         id: flake8
         run: |
-          make flake8
+          poetry run flake8
 
   testing:
     needs: setup-job
@@ -61,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
 
     services:
       postgres:
@@ -76,7 +71,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -87,7 +82,7 @@ jobs:
       - name: Test with pytest
         id: test
         run: |
-          make test
+          poetry run pytest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -101,7 +96,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build to check strictness
         id: build
         run: |

--- a/.github/workflows/namex-pay-ci.yml
+++ b/.github/workflows/namex-pay-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [assigned, synchronize]
     paths:
       - "services/namex-pay/**"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -14,8 +15,6 @@ defaults:
 jobs:
   setup-job:
     runs-on: ubuntu-20.04
-
-    if: github.repository == 'bcgov/namex'
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -40,14 +39,10 @@ jobs:
       - name: Install dependencies
         run: |
           make setup
-      - name: Lint with pylint
-        id: pylint
-        run: |
-          make pylint
       - name: Lint with flake8
         id: flake8
         run: |
-          make flake8
+          poetry run flake8
 
   testing:
     needs: setup-job
@@ -65,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     services:
       postgres:
@@ -91,7 +86,7 @@ jobs:
       - name: Test with pytest
         id: test
         run: |
-          make test
+          poetry run pytest
       - name: Temporarily save coverage.xml
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nr-day-job-ci.yml
+++ b/.github/workflows/nr-day-job-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [assigned, synchronize]
     paths:
       - "jobs/nr-day-job/**"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -15,10 +16,8 @@ jobs:
   setup-job:
     runs-on: ubuntu-20.04
 
-    if: github.repository == 'bcgov/namex'
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: "true"
 
   linting:
@@ -27,10 +26,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -38,14 +37,10 @@ jobs:
       - name: Install dependencies
         run: |
           make setup
-      - name: Lint with pylint
-        id: pylint
-        run: |
-          make pylint
       - name: Lint with flake8
         id: flake8
         run: |
-          make flake8
+          poetry run flake8 nr_day_job.py
 
   # testing:
   #   needs: setup-job
@@ -69,7 +64,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build to check strictness
         id: build
         run: |

--- a/.github/workflows/nro-extractor-ci.yml
+++ b/.github/workflows/nro-extractor-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [assigned, synchronize]
     paths:
       - "jobs/nro-extractor/**"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -15,10 +16,8 @@ jobs:
   setup-job:
     runs-on: ubuntu-20.04
 
-    if: github.repository == 'bcgov/namex'
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: "true"
 
   linting:
@@ -27,10 +26,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -38,20 +37,20 @@ jobs:
       - name: Install dependencies
         run: |
           make setup
-      - name: Lint with pylint
-        id: pylint
-        run: |
-          make pylint
       - name: Lint with flake8
         id: flake8
         run: |
-          make flake8
+          poetry run flake8
 
   testing:
     needs: setup-job
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -62,7 +61,7 @@ jobs:
       - name: Test with pytest
         id: test
         run: |
-          make test
+          poetry run pytest
       #- name: Upload coverage to Codecov
       #  uses: codecov/codecov-action@v3
       #  with:
@@ -76,7 +75,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build to check strictness
         id: build
         run: |

--- a/.github/workflows/solr-names-updater-ci.yml
+++ b/.github/workflows/solr-names-updater-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [assigned, synchronize]
     paths:
       - "services/solr-names-updater/**"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -14,8 +15,6 @@ defaults:
 jobs:
   setup-job:
     runs-on: ubuntu-20.04
-
-    if: github.repository == 'bcgov/namex'
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -40,14 +39,10 @@ jobs:
       - name: Install dependencies
         run: |
           make setup
-      - name: Lint with pylint
-        id: pylint
-        run: |
-          make pylint
       - name: Lint with flake8
         id: flake8
         run: |
-          make flake8
+          poetry run flake8
 
   testing:
     needs: setup-job
@@ -64,7 +59,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     services:
       postgres:
@@ -90,7 +85,7 @@ jobs:
       - name: Test with pytest
         id: test
         run: |
-          make test
+          poetry run pytest
       - name: Temporarily save coverage.xml
         uses: actions/upload-artifact@v2
         with:

--- a/api/Makefile
+++ b/api/Makefile
@@ -20,7 +20,7 @@ license: ## Verify source code license headers.
 #################################################################################
 # COMMANDS -- Setup                                                             #
 #################################################################################
-setup: clean install install-dev ## Setup the project
+setup: clean install ## Setup the project
 
 clean: clean-build clean-pyc clean-test ## Clean the project
 	rm -rf venv/
@@ -44,27 +44,15 @@ clean-test: ## clean test files
 	rm -f .coverage
 	rm -fr htmlcov/
 
-build-req: clean ## Upgrade requirements
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
-	. venv/bin/activate ;\
-	pip install --upgrade pip ;\
-	pip install -U setuptools; \
-	pip install -Ur requirements/prod.txt ;\
-	pip freeze | sort > requirements.txt ;\
-	cat requirements/bcregistry-libraries.txt >> requirements.txt ;\
-	pip install -Ur requirements/bcregistry-libraries.txt
+update: ## Upgrade lock
+	poetry update
 
 install: clean ## Install python virtrual environment
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
+	test -f venv/bin/activate || python -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install --upgrade pip ;\
-	pip install -U setuptools; \
-	pip install -Ur requirements.txt
+	pipx install poetry
+	poetry install
 
-install-dev: ## Install local application
-	. venv/bin/activate ; \
-	pip install -Ur requirements/dev.txt; \
-	pip install -e .
 
 #################################################################################
 # COMMANDS - CI                                                                 #

--- a/jobs/nr-day-job/Makefile
+++ b/jobs/nr-day-job/Makefile
@@ -12,7 +12,7 @@ DOCKER_NAME:=nr-day-job
 #################################################################################
 # COMMANDS -- Setup                                                             #
 #################################################################################
-setup: install install-dev ## Setup the project
+setup: install ## Setup the project
 
 clean: clean-build clean-pyc clean-test ## Clean the project
 	rm -rf venv/
@@ -36,25 +36,15 @@ clean-test: ## clean test files
 	rm -f .coverage
 	rm -fr htmlcov/
 
-build-req: clean ## Upgrade requirements
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
-	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements/prod.txt ;\
-	pip freeze | sort > requirements.txt ;\
-	cat requirements/bcregistry-libraries.txt >> requirements.txt ;\
-	pip install -Ur requirements/bcregistry-libraries.txt
+update: ## Upgrade lock
+	poetry update
 
 install: clean ## Install python virtrual environment
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
+	test -f venv/bin/activate || python -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements.txt
+	pipx install poetry
+	poetry install
 
-install-dev: ## Install local application
-	. venv/bin/activate ; \
-	pip install -Ur requirements/dev.txt; \
-	pip install -e .
 
 #################################################################################
 # COMMANDS - CI                                                                 #

--- a/jobs/nro-extractor/Makefile
+++ b/jobs/nro-extractor/Makefile
@@ -18,7 +18,7 @@ license: ## Verify source code license headers.
 #################################################################################
 # COMMANDS -- Setup                                                             #
 #################################################################################
-setup: clean install install-dev ## Setup the project
+setup: install ## Setup the project
 
 clean: clean-build clean-pyc clean-test ## Clean the project
 	rm -rf venv/
@@ -42,25 +42,15 @@ clean-test: ## clean test files
 	rm -f .coverage
 	rm -fr htmlcov/
 
-build-req: clean ## Upgrade requirements
-	test -f venv/bin/activate || python3 -m venv  $(CURRENT_ABS_DIR)/venv ;\
-	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements/prod.txt ;\
-	pip freeze | sort > requirements.txt ;\
-	cat requirements/bcregistry-libraries.txt >> requirements.txt ;\
-	pip install -Ur requirements/bcregistry-libraries.txt
+update: ## Upgrade lock
+	poetry update
 
 install: clean ## Install python virtrual environment
-	test -f venv/bin/activate || python3 -m venv  $(CURRENT_ABS_DIR)/venv ;\
+	test -f venv/bin/activate || python -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements.txt
+	pipx install poetry
+	poetry install
 
-install-dev: ## Install local application
-	. venv/bin/activate ; \
-	pip install -Ur requirements/dev.txt; \
-	pip install -e .
 
 #################################################################################
 # COMMANDS -- CI                                                                 #

--- a/services/namex-pay/Makefile
+++ b/services/namex-pay/Makefile
@@ -12,7 +12,7 @@ DOCKER_NAME:=namex-pay
 #################################################################################
 # COMMANDS -- Setup                                                             #
 #################################################################################
-setup: install install-dev ## Setup the project
+setup: install ## Setup the project
 
 clean: clean-build clean-pyc clean-test ## Clean the project
 	rm -rf venv/
@@ -36,25 +36,15 @@ clean-test: ## clean test files
 	rm -f .coverage
 	rm -fr htmlcov/
 
-build-req: clean ## Upgrade requirements
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
-	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements/prod.txt ;\
-	pip freeze | sort > requirements.txt ;\
-	cat requirements/bcregistry-libraries.txt >> requirements.txt ;\
-	pip install -Ur requirements/bcregistry-libraries.txt
+update: ## Upgrade lock
+	poetry update
 
 install: clean ## Install python virtrual environment
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
+	test -f venv/bin/activate || python -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements.txt
+	pipx install poetry
+	poetry install
 
-install-dev: ## Install local application
-	. venv/bin/activate ; \
-	pip install -Ur requirements/dev.txt; \
-	pip install -e .
 
 #################################################################################
 # COMMANDS - CI                                                                 #

--- a/services/solr-names-updater/Makefile
+++ b/services/solr-names-updater/Makefile
@@ -12,7 +12,7 @@ DOCKER_NAME:=solr-names-updater
 #################################################################################
 # COMMANDS -- Setup                                                             #
 #################################################################################
-setup: install install-dev ## Setup the project
+setup: install ## Setup the project
 
 clean: clean-build clean-pyc clean-test ## Clean the project
 	rm -rf venv/
@@ -36,25 +36,14 @@ clean-test: ## clean test files
 	rm -f .coverage
 	rm -fr htmlcov/
 
-build-req: clean ## Upgrade requirements
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
-	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements/prod.txt ;\
-	pip freeze | sort > requirements.txt ;\
-	cat requirements/bcregistry-libraries.txt >> requirements.txt ;\
-	pip install -Ur requirements/bcregistry-libraries.txt
+update: ## Upgrade lock
+	poetry update
 
 install: clean ## Install python virtrual environment
-	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
+	test -f venv/bin/activate || python -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
-	pip install -Ur requirements.txt
-
-install-dev: ## Install local application
-	. venv/bin/activate ; \
-	pip install -Ur requirements/dev.txt; \
-	pip install -e .
+	pipx install poetry
+	poetry install
 
 #################################################################################
 # COMMANDS - CI                                                                 #


### PR DESCRIPTION
…o use poetry

In the future common workflow from sre repo should be used (https://github.com/bcgov/bcregistry-sre/blob/main/.github/workflows/backend-ci.yaml)

While namex is still running in OpenShift we can still use Makefile scripts. I updated Makefile to reflect usage of poetry instead of requirements files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
