### PR TITLE
Added name state type filter to SOLR Query

### DIFF
--- a/api/namex/analytics/solr.py
+++ b/api/namex/analytics/solr.py
@@ -105,7 +105,8 @@ class SolrQueries:
             '{synonyms_clause}{name_copy_clause}',
         HISTORY:
             '/solr/names/select?sow=false&df=name_exact_match&wt=json&&rows={rows}&q={name}'
-            '&fl=nr_num,name,score,submit_count,name_state_type_cd,start_date,jurisdiction',
+            '&fl=nr_num,name,score,submit_count,name_state_type_cd,start_date,jurisdiction'
+            'fq=name_state_type_cd:A&fq=name_state_type_cd:R',
         TRADEMARKS:
             '/solr/trademarks/select?'
             'defType=edismax'


### PR DESCRIPTION
*Issue #, 20344*

*Description of changes:*
Based on the requirements from name examiners, I added name state filter to display only `A`(Approved) and `R`(Rejected) names on history tab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
