### PR TITLE
21659-Added Order By Choice when Retrieving a Request Record

### DIFF
--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -88,7 +88,7 @@ class Request(db.Model):
     activeUser = db.relationship('User', backref=backref('active_user', uselist=False), foreign_keys=[userId])
     submitter = db.relationship('User', backref=backref('submitter', uselist=False), foreign_keys=[submitter_userid])
     # Relationships - Names
-    names = db.relationship('Name', lazy='select')
+    names = db.relationship('Name', lazy='select', order_by='Name.choice')
     # Relationships - Events
     events = db.relationship('Event', lazy='dynamic')
     # Relationships - Applicants


### PR DESCRIPTION
*Issue #: [21659](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/21659)*

*Description of changes:*
Added `Order_by` to `Request` model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
