### PR TITLE
22774 consider 'CONSUMED' state in state transition validation

### DIFF
--- a/api/namex/services/name_request/utils.py
+++ b/api/namex/services/name_request/utils.py
@@ -158,7 +158,9 @@ def valid_state_transition(user, nr, new_state):
         return True
 
     # NR is in a final state, but maybe the user wants to pull it back for corrections
-    if nr.stateCd in State.COMPLETED_STATE:
+    if new_state == State.CONSUMED:
+        return nr.stateCd == State.APPROVED or (nr.stateCd == State.CONDITIONAL and (nr.consentFlag in ('R', 'N')))
+    elif nr.stateCd in State.COMPLETED_STATE:
         if not jwt.validate_roles([User.APPROVER]) and not jwt.validate_roles([User.EDITOR]):
             return False
             # return jsonify({"message": "Only Names Examiners can alter completed Requests"}), 401
@@ -178,6 +180,7 @@ def valid_state_transition(user, nr, new_state):
     elif nr.stateCd == State.INPROGRESS:
         if nr.userId != user.id:
             return False
+
     return True
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/bcgov/entity/issues/22774

*Description of changes:*
1. Consider 'consumed' state in state transition validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
