### PR TITLE
Create 2 new API requests for the Home Team #22774

### DIFF
--- a/api/namex/resources/requests.py
+++ b/api/namex/resources/requests.py
@@ -547,6 +547,10 @@ class Request(Resource):
 
         # do the cheap check first before the more expensive ones
         # check states
+        # some nr requested from Legancy application includes %20 after NR. e.g. 'NR%209288253', which should be 'NR 9288253'
+        nr = nr.replace("%20", " ")
+        current_app.logger.debug("NR: {0}".format(nr))
+        
         json_input = request.get_json()
         if not json_input:
             return make_response(jsonify({'message': 'No input data provided'}), 400)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
some nr requested from Legancy application includes %20 after NR. e.g. 'NR%209288253', which should be 'NR 9288253'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
