### PR TITLE
23382 and 24193: updated codes

### DIFF
--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -104,10 +104,10 @@ class EntityTypes(AbstractEnum):
     # Used for mapping back to legacy oracle codes
     FIRM = 'FIRM'
     # Continued In Types
-    CONTINUE_IN = 'C'             # Continued In BC Ltd.
-    CONTINUE_IN_CBEN = 'CBEN'     # Continued In Benefit Company 
-    CONTINUE_IN_CCC = 'CCC'       # Continued In Community Contribution Company
-    CONTINUE_IN_CUL = 'CUL'       # Continued In Unlimited Liability Company
+    CONTINUE_IN = 'C'             # Continued In BC Limited Company
+    BEN_CONTINUE_IN = 'CBEN'      # Continued In BC Benefit Company 
+    CCC_CONTINUE_IN = 'CCC'       # Continued In BC Community Contribution Company
+    ULC_CONTINUE_IN = 'CUL'       # Continued In BC Unlimited Liability Company
 
 
 
@@ -139,9 +139,9 @@ EntityTypeDescriptions = {
     EntityTypes.FIRM: 'FIRM (Legacy Oracle)',
     #continue-in
     EntityTypes.CONTINUE_IN: 'Corporation',
-    EntityTypes.CONTINUE_IN_CBEN: 'Benefit Company',
-    EntityTypes.CONTINUE_IN_CCC: 'Community Contribution Company',
-    EntityTypes.CONTINUE_IN_CUL: 'Unlimited Liability Company',
+    EntityTypes.BEN_CONTINUE_IN: 'Benefit Company',
+    EntityTypes.CCC_CONTINUE_IN: 'Community Contribution Company',
+    EntityTypes.ULC_CONTINUE_IN: 'Unlimited Liability Company',
 }
 
 '''
@@ -455,35 +455,31 @@ request_type_mapping = [
     
     ('CCR', EntityTypes.CONTINUE_IN.value, RequestAction.CHG.value, True),
     ('CCR', EntityTypes.CONTINUE_IN.value, RequestAction.RESUBMIT.value),
-
-    ('CCC', EntityTypes.CONTINUE_IN_CCC.value, RequestAction.CHG.value, True),
-    ('CCC', EntityTypes.CONTINUE_IN_CCC.value, RequestAction.RESUBMIT.value),
-
-    ('CUL', EntityTypes.CONTINUE_IN_CUL.value, RequestAction.CHG.value, True),
-    ('CUL', EntityTypes.CONTINUE_IN_CUL.value, RequestAction.RESUBMIT.value, True),
-
-    ('BEC', EntityTypes.CONTINUE_IN_CBEN.value, RequestAction.CHG.value, True),
-    ('BEC', EntityTypes.CONTINUE_IN_CBEN.value, RequestAction.RESUBMIT.value),
-
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.REST.value, True),
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.REH.value),
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.REN.value),
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 
-    ('RCC', EntityTypes.CONTINUE_IN_CCC.value, RequestAction.REST.value, True),
-    ('RCC', EntityTypes.CONTINUE_IN_CCC.value, RequestAction.REH.value),
-    ('RCC', EntityTypes.CONTINUE_IN_CCC.value, RequestAction.REN.value),
-    ('RCC', EntityTypes.CONTINUE_IN_CCC.value, RequestAction.RESUBMIT.value),
+    ('CCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.CHG.value, True),
+    ('CCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.REST.value, True),
+    ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.REH.value),
+    ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.REN.value),
+    ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 
-    ('RUL', EntityTypes.CONTINUE_IN_CUL.value, RequestAction.REST.value, True),
-    ('RUL', EntityTypes.CONTINUE_IN_CUL.value, RequestAction.REH.value),
-    ('RUL', EntityTypes.CONTINUE_IN_CUL.value, RequestAction.REN.value),
-    ('RUL', EntityTypes.CONTINUE_IN_CUL.value, RequestAction.RESUBMIT.value),
+    ('CUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.CHG.value, True),
+    ('CUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.RESUBMIT.value, True),
+    ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.REST.value, True),
+    ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.REH.value),
+    ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.REN.value),
+    ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 
-    ('BERE', EntityTypes.CONTINUE_IN_CBEN.value, RequestAction.REST.value, True),
-    ('BERE', EntityTypes.CONTINUE_IN_CBEN.value, RequestAction.REH.value),
-    ('BERE', EntityTypes.CONTINUE_IN_CBEN.value, RequestAction.REN.value),
-    ('BERE', EntityTypes.CONTINUE_IN_CBEN.value, RequestAction.RESUBMIT.value),
+    ('BEC', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.CHG.value, True),
+    ('BEC', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.REST.value, True),
+    ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.REH.value),
+    ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.REN.value),
+    ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 ]
 
 reverse_request_type_mapping = [m for m in request_type_mapping if len(m) == 4 and m[3] is True]

--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -286,6 +286,11 @@ request_type_mapping = [
     ('RCR', EntityTypes.CORPORATION.value, RequestAction.REH.value),
     ('RCR', EntityTypes.CORPORATION.value, RequestAction.REN.value),
     ('RCR', EntityTypes.CORPORATION.value, RequestAction.RESUBMIT.value),
+    ('BECR', EntityTypes.CORPORATION.value, RequestAction.CNV.value, True), # Benefit Company -> BC Limited Company
+    ('BECR', EntityTypes.CORPORATION.value, RequestAction.RESUBMIT.value),
+    ('ULCB', EntityTypes.CORPORATION.value, RequestAction.CNV.value, True), # Unlimited Liability Company -> BC Limited Company
+    ('ULCB', EntityTypes.CORPORATION.value, RequestAction.RESUBMIT.value),
+
     ('XCR', EntityTypes.XPRO_CORPORATION.value, RequestAction.NEW_AML.value, True),
     ('XCR', EntityTypes.XPRO_CORPORATION.value, RequestAction.NEW.value),
     ('XCR', EntityTypes.XPRO_CORPORATION.value, RequestAction.AML.value),
@@ -385,8 +390,10 @@ request_type_mapping = [
     ('CC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.NEW.value),
     ('CC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.AML.value),
     ('CC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.RESUBMIT.value),
-    ('CCV', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.CNV.value, True),
+    ('CCV', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.CNV.value, True), # BC Limited Company -> Community Contribution Company
     ('CCV', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.RESUBMIT.value),
+    ('BECC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.CNV.value, True), # Benefit Company -> Community Contribution Company
+    ('BECC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.RESUBMIT.value),
     ('CCC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.CHG.value, True),
     ('CCC', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.RESUBMIT.value),
     ('CCCT', EntityTypes.COMMUNITY_CONTRIBUTION_COMPANY.value, RequestAction.MVE.value, True),
@@ -398,7 +405,7 @@ request_type_mapping = [
     ('UL', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.NEW.value, True),
     ('UL', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.AML.value),
     ('UL', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.RESUBMIT.value),
-    ('UC', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.CNV.value, True),
+    ('UC', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.CNV.value, True), # BC Limited Company -> Unlimited Liability Company
     ('UC', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.RESUBMIT.value),
     ('CUL', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.CHG.value, True),
     ('CUL', EntityTypes.UNLIMITED_LIABILITY_COMPANY.value, RequestAction.RESUBMIT.value, True),
@@ -444,14 +451,10 @@ request_type_mapping = [
     ('BERE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.REH.value),
     ('BERE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.REN.value),
     ('BERE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.RESUBMIT.value),
-    ('BECV', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value, True),
+    ('BECV', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value, True), # BC Limited Company -> Benefit Company
     ('BECV', EntityTypes.BENEFIT_COMPANY.value, RequestAction.RESUBMIT.value),
-    ('ULBE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value, True),
+    ('ULBE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.CNV.value, True), # Unlimited Liability Company -> Benefit Company
     ('ULBE', EntityTypes.BENEFIT_COMPANY.value, RequestAction.RESUBMIT.value),
-    ('BECR', EntityTypes.CORPORATION.value, RequestAction.CNV.value, True),
-    ('BECR', EntityTypes.CORPORATION.value, RequestAction.RESUBMIT.value),
-    ('ULCB', EntityTypes.CORPORATION.value, RequestAction.CNV.value, True),
-    ('ULCB', EntityTypes.CORPORATION.value, RequestAction.RESUBMIT.value),
     
     ('CCR', EntityTypes.CONTINUE_IN.value, RequestAction.CHG.value, True),
     ('CCR', EntityTypes.CONTINUE_IN.value, RequestAction.RESUBMIT.value),
@@ -459,6 +462,10 @@ request_type_mapping = [
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.REH.value),
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.REN.value),
     ('RCR', EntityTypes.CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('BECR', EntityTypes.CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in Benefit Company -> continued in BC Limited Company
+    ('BECR', EntityTypes.CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('ULCB', EntityTypes.CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in Unlimited Liability Company -> continued in BC Limited Company
+    ('ULCB', EntityTypes.CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 
     ('CCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.CHG.value, True),
     ('CCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
@@ -466,6 +473,10 @@ request_type_mapping = [
     ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.REH.value),
     ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.REN.value),
     ('RCC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('CCV', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in BC Limited Company -> continued in Community Contribution Company
+    ('CCV', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('BECC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in Benefit Company -> continued in Community Contribution Company
+    ('BECC', EntityTypes.CCC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 
     ('CUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.CHG.value, True),
     ('CUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.RESUBMIT.value, True),
@@ -473,6 +484,8 @@ request_type_mapping = [
     ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.REH.value),
     ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.REN.value),
     ('RUL', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('UC', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in BC Limited Company -> continued in Unlimited Liability Company
+    ('UC', EntityTypes.ULC_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 
     ('BEC', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.CHG.value, True),
     ('BEC', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
@@ -480,6 +493,10 @@ request_type_mapping = [
     ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.REH.value),
     ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.REN.value),
     ('BERE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('BECV', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in BC Limited Company -> continued in Benefit Company
+    ('BECV', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
+    ('ULBE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.CNV.value, True), # continued in Unlimited Liability Company -> continued in Benefit Company
+    ('ULBE', EntityTypes.BEN_CONTINUE_IN.value, RequestAction.RESUBMIT.value),
 ]
 
 reverse_request_type_mapping = [m for m in request_type_mapping if len(m) == 4 and m[3] is True]

--- a/api/namex/services/lookup/name_request_filing_actions.py
+++ b/api/namex/services/lookup/name_request_filing_actions.py
@@ -46,81 +46,114 @@ class NameRequestFilingActions:
     # multiple filing actions per nr_type is supported
     # NR Type', 'LegalTypeCd', 'LegalTypeName', 'Filing Name', 'Target', 'entitiesFilingName', 'URL', 'learTemplate
     raw_nr_to_action_mapping = [
-        ('CR', 'BC', 'B.C. Company', 'Incorporation', 'lear', None, None, None),
-        ('CR', 'BC', 'B.C. Company', 'Amalgamation', 'colin', None, None, None),
-        ('CCR', 'BC', 'B.C. Company', 'Change of Name', 'lear', None, None, None),
-        ('CT', 'C', 'B.C. Company', 'Continuation In', 'lear', None, None, None),
-        ('RCR', 'BC', 'B.C. Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('CR', 'BC', 'BC Limited Company', 'Incorporation', 'lear', None, None, None),
+        ('CR', 'BC', 'BC Limited Company', 'Amalgamation', 'colin', None, None, None),
+        ('CCR', 'BC', 'BC Limited Company', 'Change of Name', 'lear', None, None, None),
+        ('RCR', 'BC', 'BC Limited Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('BECR', 'BC', 'BC Limited Company', 'Conversion from Benefit Company ', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULCB', 'BC', 'BC Limited Company', 'Conversion from ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+
         ('XCR', 'XCR', 'Corporation (Foreign)', 'Extraprovincial Registration', 'colin', None, None, None),
         ('XCR', 'XCR', 'Corporation (Foreign)', 'Extraprovincial Amalgamation', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#forms', None),
         ('XCCR', 'XCR', 'Corporation (Foreign)', 'Extraprovincial Change of Name', 'colin', None, None, None),
         ('XRCR', 'XCR', 'Corporation (Foreign)', 'Extraprovincial Reinstatement', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
         ('AS', 'XCR', 'Corporation (Foreign)', 'Extraprovincial Assumed Name', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#forms', None),
+
         ('LC', 'LLC', 'Extraprovincial Limited Liability Company', 'Extraprovincial Registration', 'static', None, 'https://www2.gov.bc.ca/assets/gov/employment-business-and-economic-development/business-management/permits-licences-and-registration/registries-packages/pack_33_xco_-_registration_statement_and_business_number_request.pdf', None),
         ('CLC', 'LLC', 'Extraprovincial Limited Liability Company', 'Extraprovincial Change of Name', 'static', None, 'https://www2.gov.bc.ca/assets/gov/employment-business-and-economic-development/business-management/permits-licences-and-registration/registries-forms/form_37_xco_-_name_change.pdf', None),
         ('RLC', 'LLC', 'Extraprovincial Limited Liability Company', 'Extraprovincial Reinstatement', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
         ('AL', 'LLC', 'Extraprovincial Limited Liability Company', 'Extraprovincial Assumed Name', 'static', None, 'https://www2.gov.bc.ca/assets/gov/employment-business-and-economic-development/business-management/permits-licences-and-registration/registries-forms/form_37_xco_-_name_change.pdf', None),
+
         ('FR_FR', 'SP', 'Sole Proprietorship', 'Registration', 'lear', None, None, None),
-        ('FR_DBA', 'SP', 'Sole Proprietorship (DBA)', 'Registration', 'lear', None, None, None),
-        ('FR_GP', 'GP', 'General Partnership', 'Registration', 'lear', None, None, None),
         ('CFR_FR', 'SP', 'Sole Proprietorship', 'Change of Name', 'lear', None, None, None),
+        ('FR_DBA', 'SP', 'Sole Proprietorship (DBA)', 'Registration', 'lear', None, None, None),
         ('CFR_DBA', 'SP', 'Sole Proprietorship (DBA)', 'Change of Name', 'lear', None, None, None),
+
+        ('FR_GP', 'GP', 'General Partnership', 'Registration', 'lear', None, None, None),
         ('CFR_GP', 'GP', 'General Partnership', 'Change of Name', 'lear', None, None, None),
+
         ('LL', 'LL', 'Limited Liability Partnership', 'Registration', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('CLL', 'LL', 'Limited Liability Partnership', 'Change of Name', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
+
         ('XLL', 'XP', 'Extraprovincial Limited Liability Partnership', 'Registration', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('XCLL', 'XP', 'Extraprovincial Limited Liability Partnership', 'Change of Name', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
+
         ('LP', 'LP', 'Limited Partnership', 'Registration', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('CLP', 'LP', 'Limited Partnership', 'Change of Name', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
+
         ('XLP', 'XL', 'Extraprovincial Limited Partnership', 'Registration', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('XCLP', 'XL', 'Extraprovincial Limited Partnership', 'Change of Name', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
+
         ('CP', 'CP', 'Cooperative', 'Incorporation', 'lear', 'incorporationApplication', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
         ('CP', 'CP', 'Cooperative', 'Amalgamation', 'lear', 'manual', None, None),
         ('CCP', 'CP', 'Cooperative', 'Change of Name', 'lear', 'changeOfName', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
         ('CTC', 'CP', 'Cooperative', 'Continuation In', 'lear', 'manual', None, None),
         ('RCP', 'CP', 'Cooperative', 'Restoration', 'lear', 'manual', None, None),
+
         ('XCP', 'XCP', 'Extraprovincial Cooperative', 'Incorporation', 'lear', 'manual', None, None),
         ('XCP', 'XCP', 'Extraprovincial Cooperative', 'Amalgamation', 'lear', 'manual', None, None),
         ('XCCP', 'XCP', 'Extraprovincial Cooperative', 'Change of Name', 'lear', 'manual', None, None),
         ('XRCP', 'XCP', 'Extraprovincial Cooperative', 'Restoration', 'lear', 'manual', None, None),
-        ('CC', 'CC', 'Community Contribution Co.', 'Incorporation', 'lear', None, None, None),
-        ('CC', 'CC', 'Community Contribution Co.', 'Amalgamation', 'colin', None, None, None),
-        ('CCV', 'CC', 'Community Contribution Co.', 'BC to CCC Conversion', 'colin', None, None, None),
-        ('CCC', 'CC', 'Community Contribution Co.', 'Change of Name', 'lear', None, None, None),
-        ('CCCT', 'CCC', 'Community Contribution Co.', 'Continuation In', 'lear', None, None, None),
-        ('RCC', 'CC', 'Community Contribution Co.', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('UL', 'ULC', 'Unlimited Liability Co.', 'Incorporation', 'lear', None, None, None),
-        ('UL', 'ULC', 'Unlimited Liability Co.', 'Amalgamation', 'colin', None, None, None),
-        ('UC', 'ULC', 'Unlimited Liability Co.', 'BC to ULC Conversion', 'colin', None, None, None),
-        ('CUL', 'ULC', 'Unlimited Liability Co.', 'Change of Name', 'lear', None, None, None),
-        ('ULCT', 'CUL', 'Unlimited Liability Co.', 'Continuation In', 'lear', None, None, None),
-        ('RUL', 'ULC', 'Unlimited Liability Co.', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+
+        ('CC', 'CC', 'Community Contribution Company', 'Incorporation', 'lear', None, None, None),
+        ('CC', 'CC', 'Community Contribution Company', 'Amalgamation', 'colin', None, None, None),
+        ('CCC', 'CC', 'Community Contribution Company', 'Change of Name', 'lear', None, None, None),
+        ('RCC', 'CC', 'Community Contribution Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('CCV', 'CC', 'Community Contribution Company', 'Conversion from BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BECC', 'CC', 'Community Contribution Company', 'Conversion from Benefit Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+
+        ('UL', 'ULC', 'Unlimited Liability Company', 'Incorporation', 'lear', None, None, None),
+        ('UL', 'ULC', 'Unlimited Liability Company', 'Amalgamation', 'colin', None, None, None),
+        ('CUL', 'ULC', 'Unlimited Liability Company', 'Change of Name', 'lear', None, None, None),
+        ('RUL', 'ULC', 'Unlimited Liability Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('UC', 'ULC', 'Unlimited Liability Company', 'Conversion from BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+
         ('UA', 'A', 'Extraprovincial Unlimited Liability Company', 'Assumed', 'colin', None, None, None),
         ('XUL', 'A', 'Extraprovincial Unlimited Liability Company', 'Incorporation', 'colin', None, None, None),
         ('XCUL', 'A', 'Extraprovincial Unlimited Liability Company', 'Amalgamation', 'colin', None, None, None),
         ('XRUL', 'A', 'Extraprovincial Unlimited Liability Company', 'Restoration', 'colin', None, None, None),
+
         ('FI', 'FI', 'Financial Institution (BC)', 'Incorporation', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('CFI', 'FI', 'Financial Institution (BC)', 'Change of Name', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('RFI', 'FI', 'Financial Institution (BC)', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
+
         ('PA', 'PA', 'Private Act', 'Incorporation', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
         ('PAR', 'PAR', 'Parish', 'Incorporation', 'static', None, 'https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services', None),
-        ('BC', 'BEN', 'BC Benefit Company Incorporation', 'Incorporation', 'lear', 'incorporationApplication', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('BEAM', 'BEN', 'BC Benefit Company Incorporation', 'Amalgamation', 'lear', None, None, None),
-        ('BEC', 'BEN', 'BC Benefit Company Incorporation', 'Change of Name', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('BECT', 'CBEN', 'BC Benefit Company Incorporation', 'Continuation In', 'lear', None, None, None),
-        ('BERE', 'BEN', 'BC Benefit Company Incorporation', 'Restoration', 'lear', None, None, None),
-        ('BECV', 'BEN', 'BC Benefit Company Incorporation', 'Alteration', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('BECR', 'BC', 'B.C. limited Company', 'Convert to BC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('ULBE', 'BEN', 'BC Benefit Company', 'Alteration', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('ULCB', 'BC', 'B.C. limited Company', 'Alteration', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('RCR', 'C', 'Continued In BC Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('RCC', 'CCC', 'Continued In CCC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('RUL', 'CUL', 'Continued In ULC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('BERE', 'CBEN', 'Continued in Benefit Company', 'Restoration', 'lear', None, None, None),
+
+        # Benefit Company
+        ('BC', 'BEN', 'Benefit Company', 'Incorporation', 'lear', 'incorporationApplication', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BEAM', 'BEN', 'Benefit Company', 'Amalgamation', 'lear', None, None, None),
+        ('BEC', 'BEN', 'Benefit Company', 'Change of Name', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BERE', 'BEN', 'Benefit Company', 'Restoration', 'lear', None, None, None),
+        ('BECV', 'BEN', 'Benefit Company', 'Conversion from BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULBE', 'BEN', 'Benefit Company', 'Conversion from ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+
+        # continued in BC Limited Company
+        ('CT', 'C', 'Continued In BC Limited Company', 'Continuation In', 'lear', None, None, None),
         ('CCR', 'C', 'Continued In BC Limited Company', 'Change of Name', 'lear', None, None, None),
-        ('CCC', 'CCC', 'Continued In CCC', 'Change of Name', 'lear', None, None, None),
-        ('CUL', 'CUL', 'Continued In ULC', 'Change of Name', 'lear', None, None, None),
+        ('RCR', 'C', 'Continued In BC Limited Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('BECR', 'C', 'Continued In BC Limited Company', 'Conversion from Continued In Benefit Company ', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULCB', 'C', 'Continued In BC Limited Company', 'Conversion from Continued In ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+
+        # continued in Benefit Company
+        ('BECT', 'CBEN', 'Continued In Benefit Company', 'Continuation In', 'lear', None, None, None),
         ('BEC', 'CBEN', 'Continued In Benefit Company', 'Change of Name', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BERE', 'CBEN', 'Continued in Benefit Company', 'Restoration', 'lear', None, None, None),
+        ('BECV', 'CBEN', 'Continued In Benefit Company', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULBE', 'CBEN', 'Continued In Benefit Company', 'Conversion from Continued In ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+
+        # continued in Community Contribution Company
+        ('CCCT', 'CCC', 'Continued In CCC', 'Continuation In', 'lear', None, None, None),
+        ('CCC', 'CCC', 'Continued In CCC', 'Change of Name', 'lear', None, None, None),
+        ('RCC', 'CCC', 'Continued In CCC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('CCV', 'CCC', 'Continued In CCC', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BECC', 'CCC', 'Continued In CCC', 'Conversion from Continued In Benefit Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        
+        # continued in Unlimited Liability Company
+        ('ULCT', 'CUL', 'Continued In ULC', 'Continuation In', 'lear', None, None, None),
+        ('CUL', 'CUL', 'Continued In ULC', 'Change of Name', 'lear', None, None, None),
+        ('RUL', 'CUL', 'Continued In ULC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('UC', 'CUL', 'Continued In ULC', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
     ]
 
     @cached_property


### PR DESCRIPTION
*Issue #:* bcgov/entity#23382 and bcgov/entity#24193

*Description of changes:*
    - renamed enums for consistency with LEAR
    - regrouped mapping items for consistency
    - moved some codes together
    - added BECC (x2)
    - added CNV codes for continued in businesses
    - added comments
    - moved some codes together
    - spelled out "BC Limited Company" and others
    - added BECC and other missing CNV codes
    - added whitespace and comments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).