### PR TITLE
24564 Fixed filing actions lookup for continued in companies

### DIFF
--- a/api/namex/constants/__init__.py
+++ b/api/namex/constants/__init__.py
@@ -127,6 +127,7 @@ EntityTypeDescriptions = {
     EntityTypes.PRIVATE_ACT: 'Private Act',
     EntityTypes.FINANCIAL_INSTITUTION: 'Financial Institution',
     EntityTypes.PARISH: 'Parish',
+
     # XPRO and Foreign Types
     EntityTypes.XPRO_CORPORATION: 'Extraprovincial Corporation',
     EntityTypes.XPRO_UNLIMITED_LIABILITY_COMPANY: 'Extraprovincial Unlimited Liability Company',
@@ -135,9 +136,11 @@ EntityTypeDescriptions = {
     EntityTypes.XPRO_LIMITED_LIABILITY_PARTNERSHIP: 'Extraprovincial Limited Liability Partnership',
     EntityTypes.XPRO_COOPERATIVE: 'Extraprovincial Cooperative',
     EntityTypes.XPRO_SOCIETY: 'Extraprovincial Society',
+
     # Used for mapping back to legacy oracle codes, description not required
     EntityTypes.FIRM: 'FIRM (Legacy Oracle)',
-    #continue-in
+
+    # Continued in Companies
     EntityTypes.CONTINUE_IN: 'Corporation',
     EntityTypes.BEN_CONTINUE_IN: 'Benefit Company',
     EntityTypes.CCC_CONTINUE_IN: 'Community Contribution Company',
@@ -173,6 +176,10 @@ class BCProtectedNameEntityTypes(AbstractEnum):
     PRIVATE_ACT = EntityTypes.PRIVATE_ACT.value
     PARISH = EntityTypes.PARISH.value
     SOCIETY = EntityTypes.SOCIETY.value
+    CONTINUE_IN = EntityTypes.CONTINUE_IN
+    BEN_CONTINUE_IN = EntityTypes.BEN_CONTINUE_IN
+    CCC_CONTINUE_IN = EntityTypes.CCC_CONTINUE_IN
+    ULC_CONTINUE_IN = EntityTypes.ULC_CONTINUE_IN
 
 
 # TODO: Are these still valid for unprotected?

--- a/api/namex/services/lookup/name_request_filing_actions.py
+++ b/api/namex/services/lookup/name_request_filing_actions.py
@@ -129,31 +129,31 @@ class NameRequestFilingActions:
         ('ULBE', 'BEN', 'Benefit Company', 'Conversion from ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
 
         # continued in BC Limited Company
-        ('CT', 'C', 'Continued In BC Limited Company', 'Continuation In', 'lear', None, None, None),
-        ('CCR', 'C', 'Continued In BC Limited Company', 'Change of Name', 'lear', None, None, None),
-        ('RCR', 'C', 'Continued In BC Limited Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('BECR', 'C', 'Continued In BC Limited Company', 'Conversion from Continued In Benefit Company ', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('ULCB', 'C', 'Continued In BC Limited Company', 'Conversion from Continued In ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('CT_C', 'C', 'Continued In BC Limited Company', 'Continuation In', 'lear', None, None, None),
+        ('CCR_C', 'C', 'Continued In BC Limited Company', 'Change of Name', 'lear', None, None, None),
+        ('RCR_C', 'C', 'Continued In BC Limited Company', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('BECR_C', 'C', 'Continued In BC Limited Company', 'Conversion from Continued In Benefit Company ', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULCB_C', 'C', 'Continued In BC Limited Company', 'Conversion from Continued In ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
 
         # continued in Benefit Company
-        ('BECT', 'CBEN', 'Continued In Benefit Company', 'Continuation In', 'lear', None, None, None),
-        ('BEC', 'CBEN', 'Continued In Benefit Company', 'Change of Name', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('BERE', 'CBEN', 'Continued in Benefit Company', 'Restoration', 'lear', None, None, None),
-        ('BECV', 'CBEN', 'Continued In Benefit Company', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('ULBE', 'CBEN', 'Continued In Benefit Company', 'Conversion from Continued In ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BECT_CBEN', 'CBEN', 'Continued In Benefit Company', 'Continuation In', 'lear', None, None, None),
+        ('BEC_CBEN', 'CBEN', 'Continued In Benefit Company', 'Change of Name', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BERE_CBEN', 'CBEN', 'Continued in Benefit Company', 'Restoration', 'lear', None, None, None),
+        ('BECV_CBEN', 'CBEN', 'Continued In Benefit Company', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULBE_CBEN', 'CBEN', 'Continued In Benefit Company', 'Conversion from Continued In ULC', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
 
         # continued in Community Contribution Company
-        ('CCCT', 'CCC', 'Continued In CCC', 'Continuation In', 'lear', None, None, None),
-        ('CCC', 'CCC', 'Continued In CCC', 'Change of Name', 'lear', None, None, None),
-        ('RCC', 'CCC', 'Continued In CCC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('CCV', 'CCC', 'Continued In CCC', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
-        ('BECC', 'CCC', 'Continued In CCC', 'Conversion from Continued In Benefit Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('CCCT_CCC', 'CCC', 'Continued In CCC', 'Continuation In', 'lear', None, None, None),
+        ('CCC_CCC', 'CCC', 'Continued In CCC', 'Change of Name', 'lear', None, None, None),
+        ('RCC_CCC', 'CCC', 'Continued In CCC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('CCV_CCC', 'CCC', 'Continued In CCC', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('BECC_CCC', 'CCC', 'Continued In CCC', 'Conversion from Continued In Benefit Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
         
         # continued in Unlimited Liability Company
-        ('ULCT', 'CUL', 'Continued In ULC', 'Continuation In', 'lear', None, None, None),
-        ('CUL', 'CUL', 'Continued In ULC', 'Change of Name', 'lear', None, None, None),
-        ('RUL', 'CUL', 'Continued In ULC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
-        ('UC', 'CUL', 'Continued In ULC', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
+        ('ULCT_CUL', 'CUL', 'Continued In ULC', 'Continuation In', 'lear', None, None, None),
+        ('CUL_CUL', 'CUL', 'Continued In ULC', 'Change of Name', 'lear', None, None, None),
+        ('RUL_CUL', 'CUL', 'Continued In ULC', 'Restoration', 'static', None, 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/forms-corporate-registry#information-packages', None),
+        ('UC_CUL', 'CUL', 'Continued In ULC', 'Conversion from Continued In BC Limited Company', 'lear', 'alteration', None, "{'filing': {'header': {'name': {entitiesFilingName} }, '{entitiesFilingName}': {'nameRequest': {'nrNumber': '{nrNumber}', 'legalName': '{legalName}', 'legalType': '{legalType}'}}}}"),
     ]
 
     @cached_property
@@ -188,6 +188,10 @@ class NameRequestFilingActions:
             learTemplate: the templat that can be used to create a draft filing.
         """
         if nr_type in ['FR', 'CFR'] and entity_type_cd in ['FR', 'DBA', 'GP']:
+            nr_type = nr_type + '_' + entity_type_cd
+
+        # special case for continued in types that otherwise have the same NR type as regular companies
+        if entity_type_cd in ['C', 'CBEN', 'CCC', 'CUL']:
             nr_type = nr_type + '_' + entity_type_cd
 
         return self.get_dict.get(nr_type)


### PR DESCRIPTION
*Issue #:* bcgov/entity#24564

*Description of changes:*
- added continued-in companies to BCProtectedNameEntityTypes enum
- updated continued-in NR types for proper dictionary search
- added special case for continued-in dictionary search

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).