### PR TITLE
25901 conflict popping up twice, one for nr and one for company

### DIFF
--- a/services/solr-names-updater/src/solr_names_updater/resources/worker.py
+++ b/services/solr-names-updater/src/solr_names_updater/resources/worker.py
@@ -157,7 +157,7 @@ def process_names_event_message_firm(msg: dict, flask_app: Flask):
         new_state = request_state_change.get('newState')
         if new_state in ('APPROVED', 'CONDITIONAL'):
             process_names_add(request_state_change)
-        elif new_state in ('CANCELLED', 'RESET'):
+        elif new_state in ('CANCELLED', 'RESET', 'CONSUMED', 'EXPIRED'):
             process_names_delete(request_state_change)
         else:
             structured_log(f'no names processing required for request state change message: {msg}')


### PR DESCRIPTION
*Issue #, if available:* [zenhub 25901](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/25901)

*Description of changes:*

The conflict is popping up twice because it is in two solr cores: the names core and the search businesses core. 

The names core is not for companies that are consumed or expired, it is only for companies that are approved or conditionally approved. Once a NR gets consumed it moves to the businesses search core in a different solr instance. 

This PR removes firms from the names core when they become consumed or expired. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
