### PR TITLE
namex-api is running out of memory in test, default is 512MB

### DIFF
--- a/api/devops/gcp/clouddeploy.yaml
+++ b/api/devops/gcp/clouddeploy.yaml
@@ -32,6 +32,8 @@ serialPipeline:
       container-name: "namex-api-dev"
       service-account: "sa-api@a083gt-dev.iam.gserviceaccount.com"
       cloudsql-instances: "a083gt-dev:northamerica-northeast1:namex-db-dev"
+      resources-cpu: 1000m
+      resources-memory: 1Gi
  - targetId: a083gt-test
    profiles: [test]
    strategy:
@@ -45,6 +47,8 @@ serialPipeline:
       container-name: "namex-api-test"
       service-account: "sa-api@a083gt-test.iam.gserviceaccount.com"
       cloudsql-instances: "a083gt-test:northamerica-northeast1:namex-db-test"
+      resources-cpu: 2000m
+      resources-memory: 2Gi
  - targetId: a083gt-prod
    profiles: [prod]
    strategy:
@@ -58,3 +62,5 @@ serialPipeline:
       container-name: "namex-api-prod"
       service-account: "sa-api@a083gt-prod.iam.gserviceaccount.com"
       cloudsql-instances: "a083gt-prod:northamerica-northeast1:namex-db-prod"
+      resources-cpu: 2000m
+      resources-memory: 4Gi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I manually increased resources for dev/test. These configs will make that resource allocation will stick next deployment.

<img width="1187" alt="Screenshot 2025-03-07 at 4 27 49 PM" src="https://github.com/user-attachments/assets/92ec4b11-5fa0-47ad-bd7a-7813caa27dcb" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
