### PR TITLE
fix env var typo and prepend namex before job name

### DIFF
--- a/jobs/notebook-report/.env.smample
+++ b/jobs/notebook-report/.env.smample
@@ -12,6 +12,6 @@ export ERROR_EMAIL_RECIPIENTS=            #- comma separated without any space b
 export ENVIRONMENT=
 
 export NOTIFY_API_URL=
-export NOTIFY_CLIENT_ID=
-export NOTIFY_CLIENT_SECRET=
+export KEYCLOAK_CLIENT_ID=
+export KEYCLOAK_CLIENT_SECRET=
 export KEYCLOAK_AUTH_TOKEN_URL=

--- a/jobs/notebook-report/devops/gcp/clouddeploy.yaml
+++ b/jobs/notebook-report/devops/gcp/clouddeploy.yaml
@@ -29,7 +29,7 @@ serialPipeline:
    - values:
       deploy-env: "development"
       deploy-project-id: "a083gt-dev"
-      job-name: "notebook-report-dev"
+      job-name: "namex-notebook-report-dev"
       service-account: "sa-api@a083gt-dev.iam.gserviceaccount.com"
       cloudsql-instances: "a083gt-dev:northamerica-northeast1:namex-db-dev"
       run-command: "./run.sh"
@@ -42,7 +42,7 @@ serialPipeline:
    - values:
       deploy-env: "test"
       deploy-project-id: "a083gt-test"
-      job-name: "notebook-report-test"
+      job-name: "namex-notebook-report-test"
       service-account: "sa-api@a083gt-test.iam.gserviceaccount.com"
       cloudsql-instances: "a083gt-test:northamerica-northeast1:namex-db-test"
       run-command: "./run.sh" 
@@ -55,9 +55,7 @@ serialPipeline:
    - values:
       deploy-env: "production"
       deploy-project-id: "a083gt-prod"
-      job-name: "notebook-report-prod"
+      job-name: "namex-notebook-report-prod"
       service-account: "sa-api@a083gt-prod.iam.gserviceaccount.com"
-      max-scale: "10"
-      container-concurrency: "20"
       cloudsql-instances: "a083gt-prod:northamerica-northeast1:namex-db-prod"
       run-command: "./run.sh"

--- a/jobs/notebook-report/src/config.py
+++ b/jobs/notebook-report/src/config.py
@@ -25,8 +25,8 @@ class Config(object):
     ENVIRONMENT = os.getenv('ENVIRONMENT', '')
      
     NOTIFY_API_URL = f"{os.getenv("NOTIFY_API_URL", "") + os.getenv("NOTIFY_API_VERSION", "")}/notify"
-    NOTIFY_CLIENT_ID = os.getenv("NOTIFY_CLIENT_ID")
-    NOTIFY_CLIENT_SECRET = os.getenv("NOTIFY_CLIENT_SECRET")
+    NOTIFY_CLIENT_ID = os.getenv("KEYCLOAK_CLIENT_ID")
+    NOTIFY_CLIENT_SECRET = os.getenv("KEYCLOAK_CLIENT_SECRET")
     KEYCLOAK_AUTH_TOKEN_URL = os.getenv("KEYCLOAK_AUTH_TOKEN_URL")
 
 


### PR DESCRIPTION
*Issue #, if available:*
Values pulled from env need to match what is in the vaults.gcp.env file
https://github.com/bcgov/namex/blob/main/jobs/notebook-report/devops/vaults.gcp.env#L14



*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
