### PR TITLE
26429: fix not receiving payment receipt email when submitting an nr

### DIFF
--- a/services/emailer/src/namex_emailer/email_processors/name_request.py
+++ b/services/emailer/src/namex_emailer/email_processors/name_request.py
@@ -76,7 +76,6 @@ def _get_pdfs(nr_id: str, payment_token: str) -> list:
     # get nr payments
     nr_payments = requests.get(
         f'{current_app.config.get("NAMEX_SVC_URL")}/payments/{nr_id}',
-        json={},
         headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
     )
     if nr_payments.status_code != HTTPStatus.OK:


### PR DESCRIPTION
*Issue #, if available:* [Zenhub 26429](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/26429)

*Description of changes:*

- GET requests should not include a request body.
- Having a json body caused google cloud run to reject the request with a 400 bad request error.
- This resolves the issue where the emailer was unable to retrieve payment info successfully. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
