### PR TITLE
fix incorrect indentation in bad designation notifier job

### DIFF
--- a/jobs/bad-designation-notifier/src/services/email_service.py
+++ b/jobs/bad-designation-notifier/src/services/email_service.py
@@ -49,13 +49,13 @@ def send_email_notification(formatted_result):
                 "attachments": [],
             },
         }
-    resp = send_email(email_data, token)
-    if resp.status_code == HTTPStatus.OK:
-        current_app.logger.info(f"Email sent successfully to: {recipient}")
-    else:
-        current_app.logger.error(
-            f"Failed to send email. Status Code: {resp.status_code}, Response: {resp.text}"
-        )
+        resp = send_email(email_data, token)
+        if resp.status_code == HTTPStatus.OK:
+            current_app.logger.info(f"Email sent successfully to: {recipient}")
+        else:
+            current_app.logger.error(
+                f"Failed to send email. Status Code: {resp.status_code}, Response: {resp.text}"
+            )
 
 def format_email_body(formatted_result):
     """Formats the email body as a list of key-value lists."""


### PR DESCRIPTION
*Description of changes:*
Sending an email needs to be inside the loop when going over the recipient list. In the old implementation only the last recipient was getting an email. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
