### PR TITLE
add ocp cli tool steps to ocp relay

### DIFF
--- a/.github/workflows/ocp-relay-cd.yml
+++ b/.github/workflows/ocp-relay-cd.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install CLI tools from OpenShift
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+
       - name: Login Openshift
         shell: bash
         run: |
@@ -78,6 +83,11 @@ jobs:
       - name: Set env by input
         run: |
           echo "TAG_NAME=${{ github.event.inputs.environment }}" >> $GITHUB_ENV
+
+      - name: Install CLI tools from OpenShift
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
 
       - name: Login Openshift
         shell: bash


### PR DESCRIPTION
*Description of changes:*
The Ubuntu upgrade was causing this error on CD: https://github.com/bcgov/namex/actions/runs/14114530499/job/39541363726

This PR applies the same fix as was done in https://github.com/bcgov/lear/commit/3df04fcd21dcbf0d3f62442c2aa76635e4ee2694



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
