### PR TITLE
release emailer branch - get request hotfix

### DIFF
--- a/services/emailer/src/namex_emailer/email_processors/name_request.py
+++ b/services/emailer/src/namex_emailer/email_processors/name_request.py
@@ -74,7 +74,6 @@ def _get_pdfs(nr_id: str, payment_token: str) -> list:
     # get nr payments
     nr_payments = requests.get(
         f'{current_app.config.get("NAMEX_SVC_URL")}/payments/{nr_id}',
-        json={},
         headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
     )
     if nr_payments.status_code != HTTPStatus.OK:


### PR DESCRIPTION
OpenShift did not mind when the get request had an empty JSON payload but GCP does (returns a 400 malformed request)

This code needs to be in the production NameX Emailer before NameX API moves to GCP.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
