### PR TITLE
ensure response from ocp relay is proper json

### DIFF
--- a/jobs/nr-duplicates-report/nr_duplicates_report/daily/nr-duplicates.ipynb
+++ b/jobs/nr-duplicates-report/nr_duplicates_report/daily/nr-duplicates.ipynb
@@ -223,7 +223,8 @@
     "response = requests.get(COLIN_PAY_RELAY_URL, params=params, headers=headers)\n",
     "\n",
     "if response.ok:\n",
-    "    invoices = response.json()\n",
+    "    fixed_json_text = response.text.replace(\"NaN\", \"null\")\n",
+    "    invoices = json.loads(fixed_json_text)\n",
     "    global_payment_frame = pd.DataFrame(invoices)\n",
     "else:\n",
     "    print(\"Error fetching invoices:\", response.status_code, response.text)"


### PR DESCRIPTION
*Description of changes:*
- Response from Colin from getting invoices sometimes had NaN in the response.
- This PR replaces the NaN with null (proper json) so this error no longer happens

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
