### PR TITLE
27414 - Fix Before-Expiry NR Email Logging Error

### DIFF
--- a/services/emailer/src/namex_emailer/email_processors/nr_notification.py
+++ b/services/emailer/src/namex_emailer/email_processors/nr_notification.py
@@ -85,7 +85,6 @@ def process(email_info: SimpleCloudEvent, option) -> dict:  # pylint: disable-ms
 
     file_name_suffix = option.upper()
     request_action = nr_data["request_action_cd"]
-    template = get_main_template(request_action, f"NR-{file_name_suffix}.html")
     if option == Option.BEFORE_EXPIRY.value:
         if "entity_type_cd" in nr_data:
             legal_type = nr_data["entity_type_cd"]
@@ -96,6 +95,8 @@ def process(email_info: SimpleCloudEvent, option) -> dict:  # pylint: disable-ms
                 file_name_suffix += instruction_group.upper()
 
         template = get_main_template(request_action, f"NR-{file_name_suffix}.html", status=option)
+    else:
+        template = get_main_template(request_action, f"NR-{file_name_suffix}.html")
     filled_template = substitute_template_parts(template)
 
     # render template with vars


### PR DESCRIPTION
Issue #: /https://github.com/bcgov/entity/issues/27414 

*Description of changes:*
- The first call to `get_main_template` was causing logging errors since it doesn't have the correct values for the **before-expiry NR case** => moved this call to the else case

Logs Before:
![image](https://github.com/user-attachments/assets/a04c693e-99cb-46dd-a067-54ffa5031888)

Logs After:
![image](https://github.com/user-attachments/assets/64a4276b-adb5-4ec8-bcb6-2e1ca884ea05)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
