### PR TITLE
25832 revive api unit tests that run on ci

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,7 @@
 """Config for initializing the namex-api."""
 
 import os
+import textwrap
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -181,7 +182,7 @@ class TestConfig(Config):
         ]
     }
 
-    JWT_OIDC_TEST_PRIVATE_KEY_PEM = """
+    JWT_OIDC_TEST_PRIVATE_KEY_PEM = textwrap.dedent("""
     -----BEGIN RSA PRIVATE KEY-----
     MIICXQIBAAKBgQDfn1nKQshOSj8xw44oC2klFWSNLmK3BnHONCJ1bZfq0EQ5gIfg
     tlvB+Px8Ya+VS3OnK7Cdi4iU1fxO9ktN6c6TjmmmFevk8wIwqLthmCSF3r+3+h4e
@@ -196,4 +197,4 @@ class TestConfig(Config):
     W0mOp436T6ZaELBfbFNulNLOzLLi5YzNRPLppfG1SRNZjbIrvTIKVL4N/YxLvQbT
     NrQw+2OdQACBJiEHsdZzAkBcsTk7frTH4yGx0VfHxXDPjfTj4wmD6gZIlcIr9lZg
     4H8UZcVFN95vEKxJiLRjAmj6g273pu9kK4ymXNEjWWJn
-    -----END RSA PRIVATE KEY-----"""
+    -----END RSA PRIVATE KEY-----""")

--- a/api/namex/models/request.py
+++ b/api/namex/models/request.py
@@ -1,10 +1,9 @@
-
-from dataclasses import dataclass
-from typing import List, Optional, Self
 """Request is the main business class that is the real top level object in the system"""
 
 import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import List, Optional, Self
 
 import sqlalchemy
 from flask import current_app
@@ -893,6 +892,7 @@ class RequestsAuthSearchSchema(ma.SQLAlchemySchema):
     names = ma.Nested(NameSchema, many=True, only=('name', 'state'))
     applicants = ma.Nested(ApplicantSchema, many=True, only=('emailAddress', 'phoneNumber'))
 
+
 @dataclass
 class AffiliationInvitationSearchDetails:  # pylint: disable=too-many-instance-attributes
     """Used for filtering NRs Invitations based on filters passed."""
@@ -911,6 +911,6 @@ class AffiliationInvitationSearchDetails:  # pylint: disable=too-many-instance-a
             status=req.get('status', []),
             name=req.get('name', None),
             type=req.get('type', []),
-            page=int(req.get('page',1)),
-            limit=int(req.get('limit',100000))
+            page=int(req.get('page', 1)),
+            limit=int(req.get('limit', 100000)),
         )

--- a/api/namex/services/lookup/name_request_filing_actions.py
+++ b/api/namex/services/lookup/name_request_filing_actions.py
@@ -156,7 +156,6 @@ class NameRequestFilingActions:
         ('CFR_FR', 'SP', 'Sole Proprietorship', 'Change of Name', 'lear', None, None, None),
         ('FR_DBA', 'SP', 'Sole Proprietorship (DBA)', 'Registration', 'lear', None, None, None),
         ('CFR_DBA', 'SP', 'Sole Proprietorship (DBA)', 'Change of Name', 'lear', None, None, None),
-
         ('FR_GP', 'GP', 'General Partnership', 'Registration', 'lear', None, None, None),
         ('CFR_GP', 'GP', 'General Partnership', 'Change of Name', 'lear', None, None, None),
         (
@@ -547,30 +546,30 @@ class NameRequestFilingActions:
         ),
     ]
 
-    #reverse mapping Legaltype : requestTypeCd
+    # reverse mapping Legaltype : requestTypeCd
     requestTypecd = {
-        'BC':['CR','CCR','RCR','BECR','ULCB'],
-        'XCR': ['XCR','XCCR','XRCR','AS'],
-        'LLC':['LC','CLC','RLC','AL'],
-        'SP':['FR','CFR'],
-        'GP':['FR','CFR'],
-        'LL':['LL','CLL'],
-        'XP':['XLL','XCLL'],
-        'LP':['LP','CLP'],
-        'XL':['XLP','XCLP'],
-        'CP':[ 'CP','CCP','CTC','RCP'],
-        'XCP':['XCP','XCP','XCCP','XRCP'],
-        'CC':[ 'CC','CCC','RCC','CCV','BECC'],
-        'ULC':['UL','CUL','RUL','UC'],
-        'A':['UA','XUL','XCUL','XRUL'],
-        'FI':['FI','CFI','RFI'],
-        'PA':['PA'],
+        'BC': ['CR', 'CCR', 'RCR', 'BECR', 'ULCB'],
+        'XCR': ['XCR', 'XCCR', 'XRCR', 'AS'],
+        'LLC': ['LC', 'CLC', 'RLC', 'AL'],
+        'SP': ['FR', 'CFR'],
+        'GP': ['FR', 'CFR'],
+        'LL': ['LL', 'CLL'],
+        'XP': ['XLL', 'XCLL'],
+        'LP': ['LP', 'CLP'],
+        'XL': ['XLP', 'XCLP'],
+        'CP': ['CP', 'CCP', 'CTC', 'RCP'],
+        'XCP': ['XCP', 'XCP', 'XCCP', 'XRCP'],
+        'CC': ['CC', 'CCC', 'RCC', 'CCV', 'BECC'],
+        'ULC': ['UL', 'CUL', 'RUL', 'UC'],
+        'A': ['UA', 'XUL', 'XCUL', 'XRUL'],
+        'FI': ['FI', 'CFI', 'RFI'],
+        'PA': ['PA'],
         'PAR': ['PAR'],
-        'BEN':['BC','BEAM','BEC','BERE','BECV','ULBE'],
-        'C':['CT','CCR','RCR','BECR','ULCB'],
-        'CBEN':['BECT','BEC','BERE','BECV','ULBE'],
-        'CCC':['CCCT','CCC','RCC','CCV','BECC'],
-        'CUL':['ULCT','CUL','RUL','UC']
+        'BEN': ['BC', 'BEAM', 'BEC', 'BERE', 'BECV', 'ULBE'],
+        'C': ['CT', 'CCR', 'RCR', 'BECR', 'ULCB'],
+        'CBEN': ['BECT', 'BEC', 'BERE', 'BECV', 'ULBE'],
+        'CCC': ['CCCT', 'CCC', 'RCC', 'CCV', 'BECC'],
+        'CUL': ['ULCT', 'CUL', 'RUL', 'UC'],
     }
 
     @cached_property
@@ -635,6 +634,8 @@ class NameRequestFilingActions:
 
     def get_request_type_array(self, request_type):
         if isinstance(request_type, list):
-            return { request_type: self.requestTypecd.get(request_type, "Key not found") for request_type in request_type }
+            return {
+                request_type: self.requestTypecd.get(request_type, 'Key not found') for request_type in request_type
+            }
         else:
-            return { self.requestTypecd.get(request_type, "Key not found") }
+            return {self.requestTypecd.get(request_type, 'Key not found')}

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2510,6 +2510,69 @@ files = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
 name = "referencing"
 version = "0.35.1"
 description = "JSON Referencing + Python"
@@ -2644,6 +2707,26 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.25.7"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "responses-0.25.7-py3-none-any.whl", hash = "sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c"},
+    {file = "responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-PyYAML", "types-requests"]
 
 [[package]]
 name = "rpds-py"
@@ -3363,4 +3446,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "80008609dad57e9a116a01afe0f14f2546d174c4b8ada70ab3cf8352a5d3207d"
+content-hash = "f9606b431f0060b925f37c1d972a1c23b2afa6083fd070c629be16b613151f0e"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -95,10 +95,11 @@ pydocstyle = "^6.3.0"
 coverage = "^7.4.1"
 pytest-cov = "^4.1.0"
 ruff = "^0.11.6"
+responses = "^0.25.7"
 
 [tool.ruff]
 line-length    = 120
-extend-exclude = ["migrations", "tests"]
+extend-exclude = ["migrations"]
 
 [tool.ruff.lint]
 extend-select = [
@@ -123,7 +124,8 @@ quote-style = "single"
 inline-quotes    = "single"
 
 [tool.ruff.lint.per-file-ignores]
-"**/__init__.py" = ["F401", "E402", "I"]
+"**/__init__.py" = ["F401", "E402", "I"]  # no import ordering on init files
+"tests/**/*.py"    = ["B", "C", "S", "F", "E"]  # no strict linting in test files
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -4,3 +4,6 @@ norecursedirs = .git .tox venv* requirements* build
 python_files = test*.py
 log_cli = true
 log_cli_level = 10
+
+# Silence all deprecation warnings when running tests (including SQLAlchemy 2.0 RemovedIn20Warning)
+filterwarnings = ignore::DeprecationWarning

--- a/api/tests/python/__init__.py
+++ b/api/tests/python/__init__.py
@@ -9,7 +9,7 @@ set :
     NRO_EXTRACTOR_TESTS to run integration_nro_extractor
 """
 
-import datetime
+from datetime import datetime, timezone
 
 from .util import (
     integration_oracle_local_namesdb,
@@ -22,5 +22,5 @@ from .util import (
     integration_nro_extractor,
 )
 
-EPOCH_DATETIME = datetime.datetime.utcfromtimestamp(0)
-FROZEN_DATETIME = datetime.datetime(2001, 8, 5, 7, 7, 58, 272362)
+EPOCH_DATETIME = datetime.fromtimestamp(0, tz=timezone.utc)
+FROZEN_DATETIME = datetime(2001, 8, 5, 7, 7, 58, 272362)

--- a/api/tests/python/common/test_name_request_utils.py
+++ b/api/tests/python/common/test_name_request_utils.py
@@ -52,7 +52,7 @@ def assert_field_is_mapped(req_obj, res_obj, prop_name):
     :param prop_name:
     :return:
     """
-    req_obj_val = req_obj.get(prop_name)
+    req_obj_val = req_obj.get(prop_name) if isinstance(req_obj, dict) else getattr(req_obj, prop_name)
     res_obj_val = res_obj.get(prop_name)
     print(
         'Response Field ['

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_base_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_base_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -16,6 +17,7 @@ from ..configuration import ENDPOINT_PATH
 
 
 # 2.- Unique word classified as distinctive
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_add_descriptive_word_base_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_both_classifications_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_both_classifications_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -16,6 +17,7 @@ from ..configuration import ENDPOINT_PATH
 
 
 # 4.- Unique word classified as distinctive and descriptive
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_add_descriptive_word_both_classifications_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_not_classified_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_descriptive_word_not_classified_request.py
@@ -5,12 +5,14 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_has_word_upper, assert_issue_type_is_one_of, assert_issues_count_is_gt
 from ..configuration import ENDPOINT_PATH
 
 
 # 3.- Unique word not classified in word_classification
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_add_descriptive_word_not_classified_request_response(client, jwt, app):
     # create JWT & setup header with a Bearer Token using the JWT

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_add_distinctive_word_base_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_add_distinctive_word_base_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -16,6 +17,7 @@ from ..configuration import ENDPOINT_PATH
 
 
 # 1.- Unique word classified as descriptive
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_add_distinctive_word_base_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_contains_more_than_one_word_to_avoid_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_contains_more_than_one_word_to_avoid_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_contains_more_than_one_word_to_avoid_request_response(client, jwt, app):
     words_list_classification = [
@@ -42,6 +44,7 @@ def test_contains_more_than_one_word_to_avoid_request_response(client, jwt, app)
             'location': 'BC',
             'entity_type_cd': 'CR',
             'request_action_cd': 'NEW',
+            'analysis_type': 'structure',
         }
     ]
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_contains_one_word_to_avoid_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_contains_one_word_to_avoid_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_contains_one_word_to_avoid_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_contains_unclassifiable_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_contains_unclassifiable_word_request.py
@@ -5,11 +5,13 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_has_word_upper, assert_issues_count_is_gt, save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_contains_unclassifiable_word_request_response(client, jwt, app):
     words_list_classification = [
@@ -30,6 +32,7 @@ def test_contains_unclassifiable_word_request_response(client, jwt, app):
             'location': 'BC',
             'entity_type_cd': 'CR',
             'request_action_cd': 'NEW',
+            'analysis_type': 'structure',
         }
     ]
 

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_contains_unclassifiable_words_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_contains_unclassifiable_words_request.py
@@ -5,11 +5,13 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_has_word_upper, assert_issues_count_is_gt, save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_contains_unclassifiable_words_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_descriptive_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_descriptive_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_solr
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -33,6 +34,7 @@ from ..configuration import ENDPOINT_PATH
         ('WESTWOOD BIO FUELING LTD.', 'WESTWOOD LIQUIFIED NATURAL GAS LTD.'),
     ],
 )
+@integration_solr
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_compound_descriptive_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_distinctive_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_compound_distinctive_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_solr
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -24,6 +25,7 @@ from ..configuration import ENDPOINT_PATH
         ('SOUTH LAND FREIGHT WAYS LTD.', 'SOUTHLAND FREIGHTWAYS LTD.'),
     ],
 )
+@integration_solr
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_compound_distinctive_request_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_exact_match_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_solr
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -39,6 +40,7 @@ from ..configuration import ENDPOINT_PATH
         ('MARKET CAFE LTD.', 'MARKET CAFE LTD.'),
     ],
 )
+@integration_solr
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_exact_match_request_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_solr
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -37,6 +38,7 @@ from ..configuration import ENDPOINT_PATH
         ('CHAMPIONS OF FLOORING LTD.', 'CHAMPION HARDWOOD FLOORS LTD.'),
     ],
 )
+@integration_solr
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_request_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_same_classification.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_same_classification.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_solr
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -23,6 +24,7 @@ from ..configuration import ENDPOINT_PATH
         ('VALLEY VIEW HOME LTD.', 'VALLEY VIEW REALTY LTD.'),
     ],
 )
+@integration_solr
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_same_classification_request_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_strip_out_numbers_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_corporate_name_conflict_strip_out_numbers_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_solr
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -38,6 +39,7 @@ from ..configuration import ENDPOINT_PATH
         # ("EQTEC ENGINEERING & SOLUTIONS LTD.", "EQTEC ENGINEERING LTD.") # To be fixed with 4844:FixesFromUATRejectionTesting
     ],
 )
+@integration_solr
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_strip_out_numbers_request_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_existence_incomplete_designation_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_existence_incomplete_designation_request.py
@@ -5,11 +5,13 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_has_issue_type, assert_issues_count_is_gt, save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_existence_incomplete_designation_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_existence_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_existence_request.py
@@ -5,11 +5,13 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_has_designations_upper, assert_issues_count_is_gt, save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_existence_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_more_than_one_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_more_than_one_word_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_designations_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_mismatch_more_than_one_word_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_one_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_one_word_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_designations_upper,
@@ -17,6 +18,7 @@ from ..configuration import ENDPOINT_PATH
 
 
 # TODO: COOP is also a special word. What if coop is typed in CR entity type. Do we show mismatch designation and special word use?
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_mismatch_one_word_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_one_word_with_hyphen_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_mismatch_one_word_with_hyphen_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_issue_type,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_mismatch_one_word_with_hyphen_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_designation_misplaced_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_designation_misplaced_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_designations_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_misplaced_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_end_designation_more_than_once.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_end_designation_more_than_once.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_designations_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_end_designation_more_than_once_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_incorrect_year_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_incorrect_year_request.py
@@ -5,12 +5,14 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_is_number, assert_issues_count_is_gt, save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
 # 2.- Unique word classified as distinctive
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_incorrect_year_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_compound_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_compound_word_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_name_requires_consent_compound_word_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_more_than_one_word_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_requires_consent_more_than_one_word_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_name_requires_consent_more_than_one_word_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_use_special_words_more_than_one_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_use_special_words_more_than_one_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_name_use_special_words_more_than_one_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_name_use_special_words_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_name_use_special_words_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_word_upper,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_name_use_special_words_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_queue_name_conflict_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_additional_conflict_parameters,
@@ -30,6 +31,7 @@ from ..configuration import ENDPOINT_PATH
         ('LE BLUE CAFE LTD.', 'LE BLUE FOX CAFE INC.'),
     ],
 )
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_corporate_name_conflict_request_response(client, jwt, app, name, expected):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_request_actions_bc.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_request_actions_bc.py
@@ -5,11 +5,13 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import assert_has_no_issue_type, save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_designation_existence_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_successful_well_formed_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_successful_well_formed_request.py
@@ -3,12 +3,14 @@ from urllib.parse import quote_plus
 import jsonpickle
 import pytest
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import save_words_list_classification
 from ..configuration import ENDPOINT_PATH
 
 
 # 5.- Successful well formed name:
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_successful_well_formed_request_response(client, jwt, app):
     words_list_classification = [
@@ -37,4 +39,4 @@ def test_successful_well_formed_request_response(client, jwt, app):
         response = client.get(path, headers=headers)
         payload = jsonpickle.decode(response.data)
         print('Assert that the payload status is Available')
-        assert ('Available', payload.get('status'))
+        assert payload.get('status') == 'Available'

--- a/api/tests/python/end_points/auto_analyse/protected_names/test_too_many_words_request.py
+++ b/api/tests/python/end_points/auto_analyse/protected_names/test_too_many_words_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from namex.services.name_request.auto_analyse import AnalysisIssueCodes
 
+from .... import integration_synonym_api
 from ...common import claims, token_header
 from ..common import (
     assert_has_issue_type,
@@ -15,6 +16,7 @@ from ..common import (
 from ..configuration import ENDPOINT_PATH
 
 
+@integration_synonym_api
 @pytest.mark.xfail(raises=ValueError)
 def test_too_many_words_request_response(client, jwt, app):
     words_list_classification = [

--- a/api/tests/python/end_points/auto_analyse_v2/test_name_analysis.py
+++ b/api/tests/python/end_points/auto_analyse_v2/test_name_analysis.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import requests
 
+from ... import integration_synonym_api
 from .configuration import ENDPOINT_PATH
 
 
@@ -35,6 +36,7 @@ class MockResponse:
         return self.json_data
 
 
+@integration_synonym_api
 def test_auto_analyze_post(client):
     """Test to ensure that post endpoint works as expected."""
     headers = {'content-type': 'application/json'}
@@ -55,6 +57,7 @@ def test_auto_analyze_post(client):
         assert response_json['analysis']
 
 
+@integration_synonym_api
 def test_auto_analyze_get(client):
     """Test to ensure that get endpoint works as expected."""
     identifier = 'sdf321421344'
@@ -74,6 +77,7 @@ def test_auto_analyze_get(client):
         assert response_json['analysis']
 
 
+@integration_synonym_api
 def test_auto_analyze_delete(client):
     """Test to ensure that delete endpoint works as expected."""
     identifier = 'sdf321421344'

--- a/api/tests/python/end_points/common/configuration.py
+++ b/api/tests/python/end_points/common/configuration.py
@@ -3,13 +3,13 @@ from namex.models import User
 token_header = {'alg': 'RS256', 'typ': 'JWT', 'kid': 'flask-jwt-oidc-test-client'}
 
 claims = {
-    'iss': 'https://sso-dev.pathfinder.gov.bc.ca/auth/realms/sbc',
+    'iss': 'https://example.localdomain/auth/realms/example',
     'sub': '43e6a245-0bf7-4ccf-9bd0-e7fb85fd18cc',
-    'aud': 'NameX-Dev',
+    'aud': 'example',
     'exp': 31531718745,
     'iat': 1531718745,
     'jti': 'flask-jwt-oidc-test-support',
     'typ': 'Bearer',
     'username': 'test-user',
-    'realm_access': {'roles': ['{}'.format(User.EDITOR), '{}'.format(User.APPROVER), 'viewer', 'user']},
+    'realm_access': {'roles': [User.EDITOR, User.APPROVER, 'viewer', 'user']},
 }

--- a/api/tests/python/end_points/common/http.py
+++ b/api/tests/python/end_points/common/http.py
@@ -16,3 +16,8 @@ def build_test_query(test_params):
 
 def build_request_uri(request_uri, query):
     return request_uri + '?' + query if len(query) > 0 else request_uri
+
+
+def setup_test_token(jwt, claims, token_header):
+    token = jwt.create_jwt(claims, token_header)
+    return token, {'Authorization': 'Bearer ' + token, 'content-type': 'application/json'}

--- a/api/tests/python/end_points/mras/test_mras.py
+++ b/api/tests/python/end_points/mras/test_mras.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from tests.python import integration_mras
+from ... import integration_mras
 
 # Import token and claims if you need it
 # from ..common import token_header, claims

--- a/api/tests/python/end_points/name_requests/test_nr_actions.py
+++ b/api/tests/python/end_points/name_requests/test_nr_actions.py
@@ -10,18 +10,19 @@ from sbc_common_components.utils.enums import QueueMessageTypes
 
 from namex.constants import EntityTypes, NameRequestActions
 from namex.models import State
-from tests.python.common.test_name_request_utils import (
+
+from ... import integration_solr
+from ...common.test_name_request_utils import (
     assert_field_equals_value,
     assert_field_is_lt_value,
     assert_field_is_mapped,
 )
-from tests.python.end_points.common.http import get_test_headers
-from tests.python.end_points.name_requests.test_setup_utils.test_helpers import add_test_user_to_db
 
 # Import token and claims if you need it
 # from ..common import token_header, claims
-from ..common.http import build_request_uri, build_test_query
+from ..common.http import build_request_uri, build_test_query, get_test_headers
 from ..common.logging import log_request_path
+from ..name_requests.test_setup_utils.test_helpers import add_test_user_to_db
 from .configuration import API_BASE_URI
 from .test_setup_utils.test_helpers import (
     assert_applicant_is_mapped_correctly,
@@ -440,6 +441,7 @@ def test_draft_patch_edit_and_repatch(client, jwt, app, mocker):
     assert_field_is_mapped(draft_nr, patched_nr, 'nrNum')
 
 
+@integration_solr
 def test_draft_patch_cancel(client, jwt, app, mocker):
     """
     Setup:
@@ -605,7 +607,7 @@ def test_draft_patch_cancel_with_consumed_name(client, jwt, app, mocker):
     # Expect this to fail as we
     nr_data = {}
 
-    patch_response = patch_nr(client, NameRequestActions.CANCEL.value, test_nr.get('id'), nr_data, mocker)
+    patch_response = patch_nr(client, NameRequestActions.CANCEL.value, test_nr.id, nr_data, mocker)
 
     # Ensure the request failed
     assert patch_response.status_code == 500
@@ -668,7 +670,7 @@ def test_draft_patch_cancel_with_expired_nr(client, jwt, app, mocker):
     # Expect this to fail as we
     nr_data = {}
 
-    patch_response = patch_nr(client, NameRequestActions.CANCEL.value, test_nr.get('id'), nr_data, mocker)
+    patch_response = patch_nr(client, NameRequestActions.CANCEL.value, test_nr.id, nr_data, mocker)
 
     # Ensure the request failed
     assert patch_response.status_code == 500

--- a/api/tests/python/end_points/name_requests/test_nr_request_combos.py
+++ b/api/tests/python/end_points/name_requests/test_nr_request_combos.py
@@ -3,10 +3,10 @@ import json
 import pytest
 
 from namex.constants import NameRequestActions
-from tests.python.common.test_name_request_utils import (
+
+from ...common.test_name_request_utils import (
     assert_field_equals_value,
 )
-
 from .test_setup_utils.test_helpers import create_draft_nr, patch_nr
 
 # Define our data

--- a/api/tests/python/end_points/name_requests/test_nr_response.py
+++ b/api/tests/python/end_points/name_requests/test_nr_response.py
@@ -5,6 +5,7 @@ Integration tests for Name Request reponses.
 import json
 
 import pytest
+import responses
 
 from namex.models import State
 
@@ -45,11 +46,12 @@ def build_test_input_fields():
     }
 
 
+@responses.activate
 @pytest.mark.parametrize(
     'priorityCd, queue_time_returned, status_cd',
     [('Y', True, State.DRAFT), ('N', True, State.DRAFT), ('N', False, State.INPROGRESS)],
 )
-def test_draft_response(priorityCd, queue_time_returned, status_cd, client, jwt, app):
+def test_draft_response(priorityCd, queue_time_returned, status_cd, client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -68,7 +70,8 @@ def test_draft_response(priorityCd, queue_time_returned, status_cd, client, jwt,
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 

--- a/api/tests/python/end_points/name_requests/test_nr_response_actions.py
+++ b/api/tests/python/end_points/name_requests/test_nr_response_actions.py
@@ -5,10 +5,12 @@ Integration tests for Name Request state transitions.
 import datetime
 import json
 
+import responses
+
 from namex.constants import NameRequestActions
 from namex.models import State
-from tests.python.common.test_name_request_utils import assert_field_is_mapped, assert_list_contains_exactly
 
+from ...common.test_name_request_utils import assert_field_is_mapped, assert_list_contains_exactly
 from .test_setup_utils.test_helpers import create_test_nr, get_nr
 
 
@@ -46,7 +48,8 @@ def build_test_input_fields():
     }
 
 
-def test_draft_response_actions(client, jwt, app):
+@responses.activate
+def test_draft_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -64,7 +67,8 @@ def test_draft_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -94,7 +98,8 @@ def test_draft_response_actions(client, jwt, app):
     )
 
 
-def test_approved_response_actions(client, jwt, app):
+@responses.activate
+def test_approved_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -112,7 +117,8 @@ def test_approved_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -129,18 +135,14 @@ def test_approved_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,
             NameRequestActions.CANCEL.value,
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
-            # TODO: Add logic to test 5 days / expiry
-            # NameRequestActions.REAPPLY.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_approved_and_expired_response_actions(client, jwt, app):
+@responses.activate
+def test_approved_and_expired_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -161,7 +163,8 @@ def test_approved_and_expired_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -178,16 +181,15 @@ def test_approved_and_expired_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
+            NameRequestActions.CANCEL.value,
             NameRequestActions.REAPPLY.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_conditional_response_actions(client, jwt, app):
+@responses.activate
+def test_conditional_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -205,7 +207,8 @@ def test_conditional_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -222,18 +225,14 @@ def test_conditional_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,
             NameRequestActions.CANCEL.value,
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
-            # TODO: Add logic to test 5 days / expiry
-            # NameRequestActions.REAPPLY.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_conditional_and_expired_response_actions(client, jwt, app):
+@responses.activate
+def test_conditional_and_expired_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -254,7 +253,8 @@ def test_conditional_and_expired_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -271,16 +271,15 @@ def test_conditional_and_expired_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
+            NameRequestActions.CANCEL.value,
             NameRequestActions.REAPPLY.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_consumed_and_conditional_response_actions(client, jwt, app):
+@responses.activate
+def test_consumed_and_conditional_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -313,7 +312,8 @@ def test_consumed_and_conditional_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -330,15 +330,14 @@ def test_consumed_and_conditional_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.CANCEL.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_consumed_and_approved_response_actions(client, jwt, app):
+@responses.activate
+def test_consumed_and_approved_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -371,7 +370,8 @@ def test_consumed_and_approved_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -388,15 +388,14 @@ def test_consumed_and_approved_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.CANCEL.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_rejected_response_actions(client, jwt, app):
+@responses.activate
+def test_rejected_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -414,7 +413,8 @@ def test_rejected_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -431,15 +431,13 @@ def test_rejected_response_actions(client, jwt, app):
     assert_list_contains_exactly(
         actions,
         [
-            NameRequestActions.EDIT.value,  # TODO: Make sure we can only edit contact info somehow as part of this test
-            # TODO: Show receipt action ONLY if there is an existing payment!
-            # NameRequestActions.RECEIPT.value,
-            NameRequestActions.RESEND.value,
+            NameRequestActions.RESULT.value,
         ],
     )
 
 
-def test_historical_response_actions(client, jwt, app):
+@responses.activate
+def test_historical_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -457,7 +455,8 @@ def test_historical_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -480,7 +479,8 @@ def test_historical_response_actions(client, jwt, app):
     )
 
 
-def test_hold_response_actions(client, jwt, app):
+@responses.activate
+def test_hold_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -498,7 +498,8 @@ def test_hold_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -515,7 +516,8 @@ def test_hold_response_actions(client, jwt, app):
     assert len(actions) == 0
 
 
-def test_inprogress_response_actions(client, jwt, app):
+@responses.activate
+def test_inprogress_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -533,7 +535,8 @@ def test_inprogress_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 
@@ -550,7 +553,8 @@ def test_inprogress_response_actions(client, jwt, app):
     assert len(actions) == 0
 
 
-def test_cancelled_response_actions(client, jwt, app):
+@responses.activate
+def test_cancelled_response_actions(client, jwt, app, mock_auth_affiliation):
     """
     Test the Name Request's data fields. Excludes associations 'names' and 'applicant' - we have other tests for those.
     Setup:
@@ -568,7 +572,8 @@ def test_cancelled_response_actions(client, jwt, app):
     assert test_nr is not None
 
     # Grab the record using the API
-    get_response = get_nr(client, test_nr.get('id'))
+    mock_auth_affiliation(nr_num='NR 123456')
+    get_response = get_nr(client, test_nr.id, jwt)
     nr = json.loads(get_response.data)
     assert nr is not None
 

--- a/api/tests/python/end_points/name_requests/test_setup_utils/create_nr.py
+++ b/api/tests/python/end_points/name_requests/test_setup_utils/create_nr.py
@@ -1,5 +1,6 @@
 from namex.models import State
-from tests.python.unit.test_setup_utils.build_nr import build_nr
+
+from ....unit.test_setup_utils.build_nr import build_nr
 
 
 def create_nr(nr_state, data=None):

--- a/api/tests/python/end_points/name_requests/test_setup_utils/test_helpers.py
+++ b/api/tests/python/end_points/name_requests/test_setup_utils/test_helpers.py
@@ -7,16 +7,19 @@ import json
 import pytest
 
 from namex.models import State, User
-from tests.python.common.test_name_request_utils import (
+
+from ....common.test_name_request_utils import (
     assert_applicant_has_id,
     assert_field_is_mapped,
     assert_name_has_id,
     assert_name_has_name,
     pick_name_from_list,
 )
-from tests.python.end_points.common.http import build_request_uri, build_test_query, get_test_headers
-from tests.python.end_points.common.logging import log_request_path
-from tests.python.unit.test_setup_utils import build_nr
+from ....end_points.common.http import build_request_uri, build_test_query, get_test_headers
+from ....end_points.common.logging import log_request_path
+from ....unit.test_setup_utils import build_nr
+from ...common import claims, token_header
+from ...common.http import setup_test_token
 
 # Import token and claims if you need it
 # from tests.python.end_points.common.configuration import claims, token_header
@@ -199,7 +202,7 @@ def create_test_nr(nr_data=None, nr_state=State.DRAFT):
 
         nr.save_to_db()
 
-        return nr.json()
+        return nr
     except Exception as err:
         print(repr(err))
 
@@ -340,12 +343,12 @@ def patch_nr(client, action, nr_id, nr_data, mocker):
 
 
 @pytest.mark.skip
-def get_nr(client, nr_id):
+def get_nr(client, nr_id, jwt):
     try:
         request_uri = API_BASE_URI + str(nr_id)
-        test_params = [{}]
+        test_params = [{'org_id': '1234'}]
 
-        headers = get_test_headers()
+        _, headers = setup_test_token(jwt, claims, token_header)
         query = build_test_query(test_params)
         path = build_request_uri(request_uri, query)
         print('Get Name Request [' + str(nr_id) + ']')

--- a/api/tests/python/end_points/statistics/test_statistics.py
+++ b/api/tests/python/end_points/statistics/test_statistics.py
@@ -5,8 +5,8 @@ import pytest
 
 from namex.services.cache import cache
 from namex.services.statistics import wait_time_statistics
-from tests.python.end_points.common.utils import create_utc_date_time, create_utc_min_date_time
 
+from ...end_points.common.utils import create_utc_date_time, create_utc_min_date_time
 from ..common.logging import log_request_path
 from .common import API_BASE_URI, save_approved_names_by_examiner, save_auto_approved_names, save_name, save_names_queue
 

--- a/api/tests/python/end_points/test_cobrs_phonetic_match.py
+++ b/api/tests/python/end_points/test_cobrs_phonetic_match.py
@@ -5,7 +5,8 @@ import pytest
 import requests
 
 from namex.models import User
-from tests.python import integration_solr, integration_synonym_api
+
+from .. import integration_solr, integration_synonym_api
 
 token_header = {'alg': 'RS256', 'typ': 'JWT', 'kid': 'flask-jwt-oidc-test-client'}
 claims = {

--- a/api/tests/python/end_points/test_exact_match.py
+++ b/api/tests/python/end_points/test_exact_match.py
@@ -6,7 +6,8 @@ import pytest
 import requests
 
 from namex.models import User
-from tests.python import integration_solr
+
+from .. import integration_solr
 
 token_header = {'alg': 'RS256', 'typ': 'JWT', 'kid': 'flask-jwt-oidc-test-client'}
 claims = {

--- a/api/tests/python/end_points/test_histories.py
+++ b/api/tests/python/end_points/test_histories.py
@@ -5,7 +5,8 @@ import pytest
 import requests
 
 from namex.models import User
-from tests.python import integration_solr
+
+from .. import integration_solr
 
 token_header = {'alg': 'RS256', 'typ': 'JWT', 'kid': 'flask-jwt-oidc-test-client'}
 claims = {

--- a/api/tests/python/end_points/test_namex_search.py
+++ b/api/tests/python/end_points/test_namex_search.py
@@ -10,13 +10,14 @@ import pytest
 
 from namex.analytics.solr import SolrQueries
 from namex.models import Applicant, Name, Request, State, User
-from tests.python.end_points.common.utils import (
+
+from ..end_points.common.utils import (
     get_server_now_str,
     get_server_now_with_delta_str,
     get_utc_server_now,
     get_utc_server_now_with_delta,
 )
-from tests.python.end_points.util import create_header
+from ..end_points.util import create_header
 
 # TODO: import these helper functions from somewhere shared by the tests
 

--- a/api/tests/python/end_points/test_requests.py
+++ b/api/tests/python/end_points/test_requests.py
@@ -22,8 +22,9 @@ from namex.models import (
     State,
     User,
 )
-from tests.python import integration_oracle_namesdb
-from tests.python.end_points.util import create_header
+
+from .. import integration_oracle_namesdb
+from ..end_points.util import create_header
 
 
 def test_get_next(client, jwt, app):
@@ -43,9 +44,8 @@ def test_get_next(client, jwt, app):
     # get the resource (this is the test)
     rv = client.get('/api/v1/requests/queues/@me/oldest', headers=headers)
 
-    # will be partial
-    assert rv.status_code == HTTPStatus.PARTIAL_CONTENT
-    assert b'"nameRequest": "NR 0000001"' in rv.data
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('nameRequest') == 'NR 0000001'
 
 
 def test_get_next_no_draft_avail(client, jwt, app):
@@ -90,8 +90,7 @@ def test_get_next_oldest(client, jwt, app):
     # get the resource (this is the test)
     rv = client.get('/api/v1/requests/queues/@me/oldest', headers=headers)
 
-    # will be partial
-    assert rv.status_code == HTTPStatus.PARTIAL_CONTENT
+    assert rv.status_code == HTTPStatus.OK
     assert b'"nameRequest": "NR 0000001"' in rv.data
 
 
@@ -296,7 +295,6 @@ def test_remove_name_from_nr(client, jwt, app):
 
 
 def test_add_new_comment_to_nr(client, jwt, app):
-
     # add a user for the comment
     user = User(
         'test-user',
@@ -394,6 +392,7 @@ def test_comment_where_no_user(client, jwt, app):
 def test_comment_where_no_comment(client, jwt, app):
     # create JWT & setup header with a Bearer Token using the JWT
     headers = create_header(jwt, [User.VIEWONLY, User.APPROVER, User.EDITOR])
+    headers['Content-Type'] = 'application/json'
     new_comment = None
     rv = client.post('/api/v1/requests/NR%200000002/comments', data=json.dumps(new_comment), headers=headers)
     assert rv.status_code == HTTPStatus.BAD_REQUEST

--- a/api/tests/python/end_points/test_sounds_like.py
+++ b/api/tests/python/end_points/test_sounds_like.py
@@ -6,7 +6,8 @@ import requests
 from hamcrest import *
 
 from namex.models import User
-from tests.python import integration_solr, integration_synonym_api
+
+from .. import integration_solr, integration_synonym_api
 
 token_header = {'alg': 'RS256', 'typ': 'JWT', 'kid': 'flask-jwt-oidc-test-client'}
 claims = {

--- a/api/tests/python/end_points/test_user_settings.py
+++ b/api/tests/python/end_points/test_user_settings.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 
 from namex.models import User
-from tests.python.end_points.util import create_header
+
+from ..end_points.util import create_header
 
 
 def test_get_new_user_settings(client, jwt, app):

--- a/api/tests/python/models/test_names.py
+++ b/api/tests/python/models/test_names.py
@@ -1,4 +1,3 @@
-
 from namex.models import Name, NameSchema
 
 
@@ -61,9 +60,10 @@ def test_name_schema():
         choice=1,
     )
 
-    name_dump = name_schema.dump(name).data
+    name_dump = name_schema.dump(name)
 
-    assert name_dump == name_json
+    for key, val in name_json.items():
+        assert name_dump[key] == val
 
 
 def test_name_schema_db_update(session):
@@ -91,13 +91,17 @@ def test_name_schema_db_update(session):
     session.commit()
 
     # update the name and resave
-    name_schema.load(name_json, instance=name, partial=False)
+    loaded_data = name_schema.load(name_json)
+    for key, value in loaded_data.items():
+        setattr(name, key, value)
     session.add(name)
     session.commit()
 
     assert name.id is not None
     assert name.name == test_name
-    assert name_json == name_schema.dump(name).data
+    dumped = name_schema.dump(name)
+    for key, val in name_json.items():
+        assert dumped[key] == val
 
 
 def test_name_schema_db_query_update(session):
@@ -127,17 +131,20 @@ def test_name_schema_db_query_update(session):
     name_id = name.id
 
     # update it from the json data vi the schema loader
-    name_schema.load(name_json, instance=name, partial=False)
+    loaded_data = name_schema.load(name_json)
+    for key, value in loaded_data.items():
+        setattr(name, key, value)
     session.add(name)
     session.commit()
 
     # get the name from the data base & assert it was updated
-    name = None
-    name = Name.query.filter_by(name=test_name).one_or_none()
-    assert name.id is not None
+    name = Name.query.filter_by(id=name_id).one_or_none()
+    assert name is not None
     assert name.id == name_id
     assert name.name == test_name
-    assert name_json == name_schema.dump(name).data
+    dumped = name_schema.dump(name)
+    for key, val in name_json.items():
+        assert dumped[key] == val
 
 
 def test_name_update_via_save_to_db_method(session):
@@ -169,13 +176,15 @@ def test_name_update_via_save_to_db_method(session):
     name_id = name.id
 
     # update it from the json data vi the schema loader
-    name_schema.load(name_json, instance=name, partial=False)
+    loaded_data = name_schema.load(name_json)
+    for key, value in loaded_data.items():
+        setattr(name, key, value)
     name.save_to_db()
 
     # get the name from the data base & assert it was updated with data changes
     name = None
     name = Name.query.filter_by(id=name_id).one_or_none()
-    assert name.id is not None
+    assert name is not None
     assert name.id == name_id
     assert name.name == test_name.upper()  # name should be uppercase
     assert name.conflict1_num == 'NR 0000001'  # NR number conflicts should be unchanged

--- a/api/tests/python/models/test_request.py
+++ b/api/tests/python/models/test_request.py
@@ -23,7 +23,7 @@ def test_get_queued_oldest(client, app):
     )
     user.save_to_db()
 
-    nr_oldest = RequestDAO.get_queued_oldest(user)
+    nr_oldest = RequestDAO.get_queued_oldest(user, priority_queue=False)
 
     # Tests ####
     assert nr.nrNum == nr_oldest.nrNum
@@ -56,7 +56,7 @@ def test_get_queued_oldest_multirow(client, app):
     )
     user.save_to_db()
 
-    nr_oldest = RequestDAO.get_queued_oldest(user)
+    nr_oldest = RequestDAO.get_queued_oldest(user, priority_queue=False)
 
     # Tests ####
     assert nr_first.nrNum == nr_oldest.nrNum
@@ -82,7 +82,7 @@ def test_get_queued_empty_queue(client, app):
     user.save_to_db()
 
     with pytest.raises(BusinessException) as e_info:
-        nr_oldest = RequestDAO.get_queued_oldest(user)
+        nr_oldest = RequestDAO.get_queued_oldest(user, priority_queue=False)
 
 
 def test_name_search_populated_by_name():

--- a/api/tests/python/namex_services/name_processing/test_name_processing.py
+++ b/api/tests/python/namex_services/name_processing/test_name_processing.py
@@ -2,10 +2,13 @@ import pytest
 
 from namex.services.name_request.auto_analyse.protected_name_analysis import ProtectedNameAnalysisService
 
+from ... import integration_synonym_api
+
 service = ProtectedNameAnalysisService()
 np_svc = service.name_processing_service
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -27,6 +30,7 @@ def test_set_name_remove_french(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -44,6 +48,7 @@ def test_set_name_regex_remove_designations(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -64,6 +69,7 @@ def test_set_name_regex_prefixes(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -87,6 +93,7 @@ def test_set_name_regex_numbers_lot(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -125,6 +132,7 @@ def test_set_name_regex_repeated_strings(name, expected):
 #     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -142,6 +150,7 @@ def test_set_name_regex_keep_together_abv(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -166,6 +175,7 @@ def test_set_name_regex_punctuation(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -183,6 +193,7 @@ def test_set_name_regex_together_one_letter(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [
@@ -198,6 +209,7 @@ def test_set_name_regex_strip_out_numbers_middle_end(name, expected):
     assert cleaned_name == expected
 
 
+@integration_synonym_api
 @pytest.mark.parametrize(
     'name, expected',
     [

--- a/api/tests/python/services/name_request/test_abstract_name_request.py
+++ b/api/tests/python/services/name_request/test_abstract_name_request.py
@@ -190,6 +190,6 @@ def test_get_expiry_days(client, test_name, days, action_cd, request_type):
     mock_nr.request_action_cd = action_cd
     mock_nr.requestTypeCd = request_type
     mock_nr.expirationDate = None
-    mock_expiry_days = int(nr_svc.get_expiry_days(mock_nr.request_action_cd, mock_nr.activeUser.requestTypeCd))
+    mock_expiry_days = int(nr_svc.get_expiry_days(mock_nr.request_action_cd, mock_nr.requestTypeCd))
 
     assert mock_expiry_days == days

--- a/api/tests/python/unit/no-test_name_request_service_mappers.py
+++ b/api/tests/python/unit/no-test_name_request_service_mappers.py
@@ -142,7 +142,7 @@ def test_add_request_names(client, jwt, app):
     nr_svc = NameRequestService()
 
     """
-    Test adding two new names 
+    Test adding two new names
     """
     # We will need a base NR
     nr = build_nr(State.DRAFT, {}, [test_names_no_id[0]])
@@ -197,7 +197,7 @@ def test_update_request_names(client, jwt, app):
     nr_svc = NameRequestService()
 
     """
-    Test updating three names 
+    Test updating three names
     """
     # We will need a base NR
     nr = build_nr(State.DRAFT, {}, [test_names_no_id[0], test_names_no_id[1]])


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/entity/issues/25832

*Description of changes:*
- Update unit tests to work on CI runs
![image](https://github.com/user-attachments/assets/f73f6a0f-89fd-450f-95a1-ec79e56519fb)
![image](https://github.com/user-attachments/assets/6af19e3e-51e0-44d3-a8e8-cc3765e5aab3)
- A bunch of tests are skipped in CI (no access to Solr or Solr Syns API) but can be run locally
- Also fixed a few linting errors (linting needs to pass for tests to run)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
