### PR TITLE
reapply endpoint registration in solr feeder

### DIFF
--- a/solr-feeder/solr_feeder/__init__.py
+++ b/solr-feeder/solr_feeder/__init__.py
@@ -30,5 +30,6 @@ def create_application(config_name: str = os.getenv('APP_ENV') or 'production'):
     app = flask.Flask(__name__)
     app.logger = StructuredLogging().get_logger()
     app.config.from_object(config[config_name])
+    endpoint.init_app(app)
 
     return app


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/entity/issues/28436

*Description of changes:*
I accidentally removed registering the endpoints in the solr feeder:
https://github.com/bcgov/namex/commit/f1b4f7ed5a3fd69dde6afe695d9d44ccd75bbfef#diff-9f2335eea16c66d5898e5de3228bde6a974b2bb21d8e8b82bbe43d1a90e86227L35-L44

This puts that line back in. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
