### PR TITLE
28408 - revert thread pool

### DIFF
--- a/services/emailer/src/namex_emailer/email_processors/resend.py
+++ b/services/emailer/src/namex_emailer/email_processors/resend.py
@@ -4,7 +4,7 @@ from flask import json, request
 from gcp_queue.logging import structured_log
 from namex.resources.name_requests import ReportResource
 from namex_emailer.constants.notification_options import Option, DECISION_OPTIONS
-from namex_emailer.services.helpers import query_notification_event, get_bearer_token, send_email, update_resend_timestamp_async
+from namex_emailer.services.helpers import query_notification_event, get_bearer_token, send_email, update_resend_timestamp
 
 
 def process_resend_email(event_id: str):
@@ -57,7 +57,7 @@ def _resend_email(event_id: str):
 
     # Send the email
     if _send_email(email):
-        update_resend_timestamp_async(event_id)
+        update_resend_timestamp(event_id)
         structured_log(request, 'DEBUG', f'Successfully resent email for the event {event_id}')
 
 

--- a/services/emailer/src/namex_emailer/resources/scheduled_email_handler.py
+++ b/services/emailer/src/namex_emailer/resources/scheduled_email_handler.py
@@ -3,7 +3,7 @@ from flask import Blueprint, request
 from gcp_queue.logging import structured_log
 from simple_cloudevent import from_queue_message
 
-from namex_emailer.services.helpers import get_bearer_token, send_email, write_to_events_async
+from namex_emailer.services.helpers import get_bearer_token, send_email, write_to_events
 from namex_emailer.resources.worker import process_email
 from namex_emailer.services import ce_cache
 
@@ -32,6 +32,6 @@ def deliver_scheduled_email():
 
     # Success
     ce_cache[ce.id] = ce  # mark as done so any further retries get skipped
-    write_to_events_async(ce, email)
+    write_to_events(ce, email)
     structured_log(request, "INFO", f"Scheduled email send completed for {nr_num} (CloudEvent ID: {ce.id})")
     return {}, HTTPStatus.OK

--- a/services/emailer/src/namex_emailer/resources/worker.py
+++ b/services/emailer/src/namex_emailer/resources/worker.py
@@ -116,7 +116,7 @@ def worker():
         return {}, HTTPStatus.NOT_FOUND
     ce_cache[ce.id] = ce
 
-    namex_emailer.services.helpers.write_to_events_async(ce, email)
+    namex_emailer.services.helpers.write_to_events(ce, email)
 
     structured_log(request, "INFO", f"completed ce: {str(ce)}")
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/bcgov/entity/issues/28408

*Description of changes:*
Using a thread pool to record events cannot guarantee that the events will be logged in the correct sequence. Although this issue is unlikely to occur, it's safer and simpler to call the event update service directly

I revert back my previous changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
