### PR TITLE
27245 solr-admin-app: preserve original redirect path after login

### DIFF
--- a/solr-admin-app/solr_admin/keycloak.py
+++ b/solr-admin-app/solr_admin/keycloak.py
@@ -1,6 +1,7 @@
 import requests
 from flask import current_app, session
 from authlib.jose import jwt, JsonWebKey
+from urllib.parse import urlparse
 
 
 # Manages Keycloak auth via OIDC using well-known config and JWKS for token validation.
@@ -22,12 +23,13 @@ class Keycloak:
     '''
     def get_redirect_url(self, request_url: str) -> str:
         config = self._fetch_well_known_config()
+        parsed_path = urlparse(request_url).path  # Extract only the relative path to avoid open redirect vulnerabilities
         return (
             f"{config['authorization_endpoint']}?response_type=code"
             f"&client_id={current_app.config['JWT_OIDC_AUDIENCE']}"
             f"&redirect_uri={current_app.config['OIDC_REDIRECT_URI']}"
             f"&scope=openid"
-            f"&state={request_url}"
+            f"&state={parsed_path}"
         )
 
     '''


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/entity/issues/27245

*Description of changes:*
This PR fixes an issue where users were always redirected to the home page after logging in, instead of being sent back to the page they originally tried to access. The issue was caused by the state parameter being overwritten during the OIDC callback due to overly strict sanitization. The fix ensures that only the relative path is passed in state, and adds a lightweight safety check to prevent open redirect vulnerabilities. As a result, users are now redirected back to their intended destination securely after login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
