### PR TITLE
21835 make deep copy of cloud event to ensure idempotency

### DIFF
--- a/services/emailer/src/namex_emailer/services/email_scheduler.py
+++ b/services/emailer/src/namex_emailer/services/email_scheduler.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone, timedelta
 import uuid
+import copy
 
 from flask import current_app, request
 from gcp_queue.logging import structured_log
@@ -28,10 +29,11 @@ def schedule_or_reschedule_email(ce: SimpleCloudEvent):
     Cancel any in-flight email task for this nr number and schedule a new one 5 minutes out.
     This is only used for approved, conditional, and rejected emails that are not resends.
     """
-    ce.id = str(uuid.uuid4())  # Assign a new ID so the event won't be treated as a duplicate when it returns
-    cloud_event_payload = to_structured(ce)
-    nr_num = ce.data["request"]["nrNum"].replace(" ", "_")
-    option = ce.data["request"]["option"]
+    ce_copy = copy.deepcopy(ce)
+    ce_copy.id = str(uuid.uuid4())  # Assign a new ID so the event won't be treated as a duplicate when it returns
+    cloud_event_payload = to_structured(ce_copy)
+    nr_num = ce_copy.data["request"]["nrNum"].replace(" ", "_")
+    option = ce_copy.data["request"]["option"]
 
     # Identify the queue
     remote_queue_path = cloud_tasks_client.queue_path(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/entity/issues/21835

*Description of changes:*
When a schedulable cloud event comes in and gets scheduled the cloud event's ID is stored to prevent duplicates. The new cloud event sent to cloud tasks was getting a new cloud event ID but since it was passed in by reference the logic was breaking and coming back as a duplicate cloud event. 

This PR creates a deep copy of the cloud event and then updates the cloud event's id, ensuring that the new cloud event created for cloud tasks is unique and passes the idempotency test. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
