### PR TITLE
27245 fix syntax bug in solr-admin-app

### DIFF
--- a/solr-admin-app/solr_admin/views/decision_reason_view.py
+++ b/solr-admin-app/solr_admin/views/decision_reason_view.py
@@ -61,7 +61,7 @@ class DecisionReasonView(SecuredView):
 # Do the audit logging - we will write the complete record, not the delta (although the latter is possible).
 def _create_audit_log(model, action) -> None:
     audit = decision_reason_audit.DecisionReasonAudit(
-        keycloak.Keycloak(None).get_username(), action, model.id, model.name, model.reason)
+        keycloak.Keycloak().get_username(), action, model.id, model.name, model.reason)
 
     session = models.db.session
     session.add(audit)

--- a/solr-admin-app/solr_admin/views/virtual_word_condition_view.py
+++ b/solr-admin-app/solr_admin/views/virtual_word_condition_view.py
@@ -52,7 +52,7 @@ class VirtualWordConditionView(SecuredView):
 # Do the audit logging - we will write the complete record, not the delta (although the latter is possible).
 def _create_audit_log(model, action) -> None:
     audit = restricted_condition_audit.RestrictedConditionAudit(
-    keycloak.Keycloak(None).get_username(), action,
+    keycloak.Keycloak().get_username(), action,
     model.id, model.rc_condition_text, model.rc_words, model.rc_consent_required, model.rc_consenting_body, model.rc_instructions, model.rc_allow_use)
 
     session = models.db.session


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/entity/issues/27245

*Description of changes:*
After upgrading to Flask 3 and Authlib, the Keycloak class was refactored and no longer accepts any parameters during initialization: 
https://github.com/bcgov/namex/blob/main/solr-admin-app/solr_admin/keycloak.py

Previously, Keycloak(None) was used in several places. This is now invalid and was causing a TypeError. This PR updates all instantiations of Keycloak to be parameterless, resolving the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
