### PR TITLE
29493 rm nr attachment from magic-link consent-accepted emails

### DIFF
--- a/services/emailer/src/namex_emailer/email_templates/MVE/consent/consent-magic-link.md
+++ b/services/emailer/src/namex_emailer/email_templates/MVE/consent/consent-magic-link.md
@@ -50,14 +50,6 @@ Use [BC Corporate Online]({{CORP_ONLINE_URL}}) to complete your application if y
 
 ---
 
-# Attached to this Email
-
-The following documents are attached to this email:
-
-* Results of Name Request
-
----
-
 **Business Registry**
 BC Registries and Online Services
 

--- a/services/emailer/src/namex_emailer/email_templates/NEW/consent/consent-magic-link.md
+++ b/services/emailer/src/namex_emailer/email_templates/NEW/consent/consent-magic-link.md
@@ -58,14 +58,6 @@ Use [BC Corporate Online]({{CORP_ONLINE_URL}}) to complete your application if y
 
 ---
 
-# Attached to this Email
-
-The following documents are attached to this email:
-
-* Results of Name Request
-
----
-
 **Business Registry**
 BC Registries and Online Services
 Toll Free: 1-877-370-1033


### PR DESCRIPTION
*Issue #, if available:* https://github.com/bcgov/entity/issues/29493

*Description of changes:*
Remove NR result attachment from `magic-link`, `consent-accepted` emails. 

The NR result should only be sent when an NR is approved, conditionally approved, or rejected. It does not make sense to send a an email stating that the nr has had their consent accepted and also send them an attachment that their nr needs consent (conditionally approved). This was likely added in as mistake when the magic link emails for consent accepted were made for NEW and MVE NRs.

This is an example of a different consent accepted email that has been in place for a lot longer that does not send the NR result attachment: https://github.com/bcgov/namex/blob/main/services/emailer/src/namex_emailer/email_templates/NEW/consent/consent-modernized.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
