### PR TITLE
Add Redeploy Option to All NameX Jobs #30329

### DIFF
--- a/.github/workflows/bad-designation-notifier-cd.yml
+++ b/.github/workflows/bad-designation-notifier-cd.yml
@@ -17,6 +17,13 @@ on:
           - test
           - sandbox
           - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   namex-bad-desi-notifier-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "bad-desn-notify"
       working_directory: "./jobs/bad-designation-notifier"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/bad-name-notifier-cd.yml
+++ b/.github/workflows/bad-name-notifier-cd.yml
@@ -17,6 +17,13 @@ on:
           - test
           - sandbox
           - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   namex-bad-name-notifier-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "bad-name-notify"
       working_directory: "./jobs/bad-name-notifier"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/inprogress-update-cd.yml
+++ b/.github/workflows/inprogress-update-cd.yml
@@ -17,6 +17,13 @@ on:
           - test
           - sandbox
           - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   namex-inprogress-updater-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "namex-inprog-updater"
       working_directory: "./jobs/inprogress_update"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/notebook-report-cd.yml
+++ b/.github/workflows/notebook-report-cd.yml
@@ -17,6 +17,13 @@ on:
           - test
           - sandbox
           - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   notebook-report-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "notebook-report"
       working_directory: "./jobs/notebook-report"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/nr-day-job-cd.yml
+++ b/.github/workflows/nr-day-job-cd.yml
@@ -17,6 +17,13 @@ on:
         - test
         - sandbox
         - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   nr-day-job-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "nr-day-job"
       working_directory: "./jobs/nr-day-job"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/nr-duplicates-report-cd.yml
+++ b/.github/workflows/nr-duplicates-report-cd.yml
@@ -17,6 +17,13 @@ on:
           - test
           - sandbox
           - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   duplicates-report-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "duplicates-report"
       working_directory: "./jobs/nr-duplicates-report"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/sftp-nuans-report-cd.yml
+++ b/.github/workflows/sftp-nuans-report-cd.yml
@@ -17,6 +17,13 @@ on:
           - test
           - sandbox
           - prod
+      redeploy:
+        description: "Redeploy Application"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 jobs:
   namex-sftp-nuans-report-cd:
@@ -25,6 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "nuans-report"
       working_directory: "./jobs/sftp-nuans-report"
+      redeploy: ${{ inputs.redeploy }}
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
*Issue #, if available: 30329*

*Description of changes:*
Adds redeploy CD option to the following jobs:

- bad-designation-notifier-cd.yml
- bad-name-notifier-cd.yml
- inprogress-update-cd.yml
- notebook-report-cd.yml
- nr-day-job-cd.yml
- nr-duplicates-report-cd.yml
- sftp-nuans-report-cd.yml


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
