### PR TITLE
fix: add pg8000 graceful shutdown on Cloud Run scale-down

### DIFF
--- a/api/namex/__init__.py
+++ b/api/namex/__init__.py
@@ -18,7 +18,7 @@ from .VERSION import __version__
 
 jwt = JwtManager()
 
-from cloud_sql_connector import DBConfig, setup_search_path_event_listener
+from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener, setup_search_path_event_listener
 from flask_cors import CORS
 from flask_migrate import Migrate, upgrade
 
@@ -78,6 +78,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):  # noqa: B008
         with app.app_context():
             engine = db.engine
             setup_search_path_event_listener(engine, schema)
+            setup_pg8000_close_event_listener(engine)
 
     if run_mode == 'migration':
         Migrate(app, db)

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -367,7 +367,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -350,7 +350,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.0"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -367,7 +367,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "87012397b3ca62e15ffa542214d80f2d2ae7e72d"
+resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/services/namex-pay/src/namex_pay/__init__.py
+++ b/services/namex-pay/src/namex_pay/__init__.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api
-from namex import DBConfig, setup_search_path_event_listener
+from namex import DBConfig, setup_pg8000_close_event_listener, setup_search_path_event_listener
 from namex.models import db
 from namex.resources.ops import api as nr_ops
 from namex.services import queue
@@ -75,6 +75,7 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
         with app.app_context():
             engine = db.engine
             setup_search_path_event_listener(engine, schema)
+            setup_pg8000_close_event_listener(engine)
 
     queue.init_app(app)
     register_endpoints(app)

--- a/services/solr-names-updater/src/solr_names_updater/__init__.py
+++ b/services/solr-names-updater/src/solr_names_updater/__init__.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api
-from namex import DBConfig, setup_search_path_event_listener
+from namex import DBConfig, setup_pg8000_close_event_listener, setup_search_path_event_listener
 from namex.models import db
 from namex.resources.ops import api as nr_ops
 from namex.services import queue
@@ -73,6 +73,7 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
         with app.app_context():
             engine = db.engine
             setup_search_path_event_listener(engine, schema)
+            setup_pg8000_close_event_listener(engine)
 
     queue.init_app(app)
     register_endpoints(app)

--- a/solr-admin-app/solr_admin/__init__.py
+++ b/solr-admin-app/solr_admin/__init__.py
@@ -2,7 +2,7 @@ import os
 
 import flask
 import flask_admin
-from cloud_sql_connector import DBConfig, setup_search_path_event_listener
+from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener, setup_search_path_event_listener
 from sqlalchemy.orm import scoped_session, sessionmaker
 from structured_logging import StructuredLogging
 
@@ -60,6 +60,7 @@ def create_application(run_mode=os.getenv('FLASK_ENV', 'production')):
     with application.app_context():
         engine = models.db.engine
         setup_search_path_event_listener(engine, schema)
+        setup_pg8000_close_event_listener(engine)
 
     # The root page - point the users to the admin interface.
     @application.route('/')

--- a/solr-synonyms-api/synonyms/__init__.py
+++ b/solr-synonyms-api/synonyms/__init__.py
@@ -7,7 +7,7 @@ import os
 import flask
 from flask import Flask
 from flask_jwt_oidc import JwtManager
-from namex import DBConfig, setup_search_path_event_listener
+from namex import DBConfig, setup_pg8000_close_event_listener, setup_search_path_event_listener
 from structured_logging import StructuredLogging
 
 from config import CONFIGURATION
@@ -56,6 +56,7 @@ def create_app(run_mode=None):
         with app.app_context():
             engine = db.engine
             setup_search_path_event_listener(engine, schema)
+            setup_pg8000_close_event_listener(engine)
 
     # Initialize Marshmallow with handling for SQLAlchemy auto-detection issues
     try:


### PR DESCRIPTION
## Summary

- Registers a SQLAlchemy `connect` event listener on app startup that wraps each pg8000 connection's `close()` to suppress `pg8000.exceptions.InterfaceError` during Cloud Run scale-down
- Fixes intermittent `pg8000.exceptions.InterfaceError: network error` logged when Cloud Run terminates idle instances and SQLAlchemy's connection pool teardown tries to close already-severed sockets
- Calls `setup_pg8000_close_event_listener(engine)` (from `sbc-connect-common/cloud-sql-connector`) in all affected long-running services
- GCP Cloud Run Jobs (inprogress_update, nr-day-job, bad-name-notifier) were confirmed to have zero InterfaceError occurrences in logs and are excluded

## Services fixed

- `api/namex/__init__.py`
- `solr-admin-app/solr_admin/__init__.py`
- `services/namex-pay/src/namex_pay/__init__.py`
- `services/solr-names-updater/src/solr_names_updater/__init__.py`
- `solr-synonyms-api/synonyms/__init__.py`

## Test plan

- [ ] Confirm no new `pg8000.exceptions.InterfaceError` entries in GCP Log Explorer for `a083gt-prod` project after deployment
- [ ] Existing unit and integration test suites pass